### PR TITLE
runtime: Add Clear Containers runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "runv"]
 	path = runv
 	url = https://github.com/hyperhq/runv.git
+[submodule "cc-runtime"]
+	path = cc-runtime
+	url = https://github.com/clearcontainers/runtime


### PR DESCRIPTION
This adds Clear Containers as a Kata Containers runtime, under
runtime/cc-runtime

The Docker `create`, `start`, `run`, `exec` and `ps` commands
work when using the cc-runtime code together with the vanilla
Kata shim, proxy and agent components. Shortly we will also
document how to build and install all of those together.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>