### PR TITLE
docs: Add missing standard docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Kata Containers Runtime Code of Conduct
+
+Kata Containers follows the [OpenStack Foundation Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## This repo is part of [Kata Containers](https://katacontainers.io)
+
+For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+[![Build Status](https://travis-ci.org/kata-containers/runtime.svg?branch=master)](https://travis-ci.org/kata-containers/runtime)
+
+# Runtime
+
+This project contains the runtime for the Kata Containers project.


### PR DESCRIPTION
Add a README, along with the standard code of conduct and contributing
docs.

Fixes #29.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>