### PR TITLE
ci: Add run.sh and setup.sh in order to run the tests.

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+pushd "${tests_repo_dir}"
+.ci/run.sh
+popd

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+clone_tests_repo
+
+pushd "${tests_repo_dir}"
+.ci/setup.sh
+popd


### PR DESCRIPTION
The setup script will be in charge of clone the test repository, meanwhile,
the run script will be in charge of execute for example the docker
integration tests.

Fixes #36

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>