### PR TITLE
virtcontainers: kata_agent: Add virtio-scsi support

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -49,6 +49,7 @@ var (
 	type9pFs                    = "9p"
 	devPath                     = "/dev"
 	vsockSocketScheme           = "vsock"
+	kata9pDevType               = "9p"
 	kataBlkDevType              = "blk"
 )
 
@@ -471,6 +472,7 @@ func (k *kataAgent) startPod(pod Pod) error {
 	// (resolv.conf, etc...) and potentially all container
 	// rootfs will reside.
 	sharedVolume := &grpc.Storage{
+		Driver:     kata9pDevType,
 		Source:     mountGuest9pTag,
 		MountPoint: kataGuestSharedDir,
 		Fstype:     type9pFs,
@@ -611,14 +613,7 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		// without trying to match and update it into the OCI spec list
 		// of actual devices. The device corresponding to the rootfs is
 		// a very specific case.
-		rootfsDevice := &grpc.Device{
-			Type:          kataBlkDevType,
-			VmPath:        virtPath,
-			ContainerPath: "",
-		}
-
-		ctrDevices = append(ctrDevices, rootfsDevice)
-
+		rootfs.Driver = kataBlkDevType
 		rootfs.Source = virtPath
 		rootfs.MountPoint = rootPathParent
 		rootfs.Fstype = c.state.Fstype

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -51,6 +51,7 @@ var (
 	vsockSocketScheme           = "vsock"
 	kata9pDevType               = "9p"
 	kataBlkDevType              = "blk"
+	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L", "nodev"}
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -476,7 +477,7 @@ func (k *kataAgent) startPod(pod Pod) error {
 		Source:     mountGuest9pTag,
 		MountPoint: kataGuestSharedDir,
 		Fstype:     type9pFs,
-		Options:    []string{"trans=virtio", "nodev"},
+		Options:    sharedDir9pOptions,
 	}
 
 	req := &grpc.CreateSandboxRequest{


### PR DESCRIPTION
This pull request relies on the latest agent changes to enable the support of virtio-scsi for block devices.

Fixes #56 