### PR TITLE
Skip routes with ipv6 gateway

### DIFF
--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -143,6 +143,12 @@ func (h *hyper) processHyperRoute(route netlink.Route, deviceName string) *hyper
 	gateway := route.Gw.String()
 	if gateway == "<nil>" {
 		gateway = ""
+	} else if route.Gw.To4() == nil { // Skip IPv6 as it is not supported by hyperstart agent
+		h.Logger().WithFields(logrus.Fields{
+			"unsupported-route-type": "ipv6",
+			"gateway":                gateway,
+		}).Warn("unsupported route")
+		return nil
 	}
 
 	var destination string


### PR DESCRIPTION
Since ipv6 is not yet supported, we should skip all ipv6 routes including those that have an ipv6 gatway. 