### PR TITLE
utils: Use go env to discover the GOPATH

### DIFF
--- a/virtcontainers/utils/virtcontainers-setup.sh
+++ b/virtcontainers/utils/virtcontainers-setup.sh
@@ -19,10 +19,12 @@ set -e
 
 SCRIPT_PATH=$(dirname $(readlink -f $0))
 
-if [[ -z "$GOPATH" ]]; then
-	echo "This script requires GOPATH to be set. You may need to invoke via 'sudo -E PATH=$PATH ./virtcontainers-setup.sh'"
+if [ ! $(command -v go) ]; then
+	echo "This script requires go to be installed and executable"
 	exit 1
 fi
+
+GOPATH=$(go env "GOPATH")
 
 if [ ! $(command -v docker) ]; then
 	echo "This script requires docker to be installed and executable"


### PR DESCRIPTION
Since Go 1.8 users no longer need to have GOPATH set in their environment
for the Go tool chain to work.  If GOPATH is set, Go will use it.  Otherwise
it defaults to ~/go on linux.  As most users store their code in ~/go, they
don't bother setting GOPATH any more.  virtcontainers-setup.sh, in its
current form, fails for those users, as it requires GOPATH to be set.
This commit fixes the issue by calling go env "GOPATH" to determine the
correct location of the user's go code.  go env "GOPATH" will always
return the correct location, whether GOPATH is set, or not.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>