### PR TITLE
virtcontainers: agent: use onlineCPUMem to online vCPUs

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -172,4 +172,8 @@ type agent interface {
 
 	// processListContainer will list the processes running inside the container
 	processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error)
+
+	// onlineCPUMem will online CPUs and Memory inside the Pod.
+	// This function should be called after hot adding vCPUs or Memory.
+	onlineCPUMem() error
 }

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -791,6 +791,8 @@ func (c *Container) addResources() error {
 		if err := c.pod.hypervisor.hotplugAddDevice(uint32(vCPUs), cpuDev); err != nil {
 			return err
 		}
+
+		return c.pod.agent.onlineCPUMem()
 	}
 
 	return nil

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -798,3 +798,8 @@ func (h *hyper) sendCmd(proxyCmd hyperstartProxyCmd) (interface{}, error) {
 
 	return h.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message)
 }
+
+func (h *hyper) onlineCPUMem() error {
+	// cc-agent uses udev to online CPUs automatically
+	return nil
+}

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -792,6 +792,13 @@ func (k *kataAgent) processListContainer(pod Pod, c Container, options ProcessLi
 	return nil, nil
 }
 
+func (k *kataAgent) onlineCPUMem() error {
+	req := &grpc.OnlineCPUMemRequest{}
+
+	_, err := k.sendReq(req)
+	return err
+}
+
 func (k *kataAgent) connect() error {
 	if k.client != nil {
 		return nil
@@ -855,6 +862,8 @@ func (k *kataAgent) sendReq(request interface{}) (interface{}, error) {
 	case *grpc.UpdateInterfaceRequest:
 		ifc, err := k.client.UpdateInterface(context.Background(), req)
 		return ifc, err
+	case *grpc.OnlineCPUMemRequest:
+		return k.client.OnlineCPUMem(context.Background(), req)
 	default:
 		return nil, fmt.Errorf("Unknown gRPC type %T", req)
 	}

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -79,3 +79,8 @@ func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, a
 func (n *noopAgent) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
 	return nil, nil
 }
+
+// onlineCPUMem is the Noop agent Container online CPU and Memory implementation. It does nothing.
+func (n *noopAgent) onlineCPUMem() error {
+	return nil
+}


### PR DESCRIPTION
After hot adding vCPUs in the POD, agent's funtion `onlineCPUMem`
must be called to request the agent to online the vCPUs

fixes #67

Signed-off-by: Julio Montes <julio.montes@intel.com>