### PR TITLE
make: Add make target for virtcontainers in top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,12 +198,18 @@ define SHOW_ARCH
   $(shell printf "\\t%s%s\\\n" "$(1)" $(if $(filter $(ARCH),$(1))," (default)",""))
 endef
 
-all: runtime
+all: vc runtime
 
 runtime: $(TARGET_OUTPUT) $(CONFIG)
 .DEFAULT: default
 
 build: default
+
+vc:
+	make -C virtcontainers
+
+install-vc:
+	make -C virtcontainers install
 
 define GENERATED_CODE
 // WARNING: This file is auto-generated - DO NOT EDIT!
@@ -306,6 +312,7 @@ $(TARGET_OUTPUT): $(EXTRA_DEPS) $(SOURCES) $(GENERATED_GO_FILES) $(GENERATED_FIL
 	coverage \
 	default \
 	install \
+	install-vc \
 	show-header \
 	show-summary \
 	show-variables


### PR DESCRIPTION
Running make from top source directory should build virtcontainers
library and the cli.
Add new `install-all` target that will install virtcontainers test
binaries.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>