### PR TITLE
Simplify toplevel makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,10 @@
 all: runtime
 
 runtime:
-	cd cli; \
-	make
+	make -C cli
 
 install:
-	cd cli; \
-	make install
+	make -C cli install
 
 help:
 	@printf "To build a Kata Containers runtime:\n"

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
 all: runtime
 
 runtime:
 	cd cli; \
 	make
-install :
+
+install:
 	cd cli; \
 	make install
-
 
 help:
 	@printf "To build a Kata Containers runtime:\n"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ runtime:
 install:
 	make -C cli install
 
+clean:
+	make -C cli clean
+
 help:
 	@printf "To build a Kata Containers runtime:\n"
 	@printf "\n"


### PR DESCRIPTION
Use `make -C $dir` for simplicity. Cleanup whitespace and add a `clean` rule.

Fixes #78.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
