### PR TITLE
ci: allow path to tests repo to be over-wridden

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-export tests_repo="github.com/kata-containers/tests"
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
 
 clone_tests_repo()


### PR DESCRIPTION
The github path to the tests repo is hard wired in lib.sh.
This makes it difficult to test any test repo WIP, as it ends
up calling back to the main repo.
Fix by using any value already set, and only setting to the main
repo if unset.

Fixes: #95

Signed-off-by: Graham whaley <graham.whaley@intel.com>