### PR TITLE
support to boot guest with an initrd image

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -86,7 +86,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "e87160f8ea39dfe558bf6761f74717d191d82493"
+  revision = "82c67ab9b21e8cd0042b6c2d3be2d3705a511603"
 
 [[projects]]
   name = "github.com/kata-containers/agent"
@@ -250,6 +250,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a50c12d36c3881a8fdc1c46a9a2ef78edc27ae1a1ec0c448799f37c589209108"
+  inputs-digest = "bb2ac1696f8e90526e492a6d54362549094fa844c17fbd06c727198bff6667ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "e87160f8ea39dfe558bf6761f74717d191d82493"
+  revision = "82c67ab9b21e8cd0042b6c2d3be2d3705a511603"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ PROJECT_BUG_URL = $(PROJECT_URL)/kata-containers/issues/new
 BIN_PREFIX = $(PROJECT_TYPE)
 PROJECT_DIR = $(PROJECT_TAG)
 IMAGENAME = $(PROJECT_TAG).img
+INITRDNAME = $(PROJECT_TAG)-initrd.img
 
 TARGET = $(BIN_PREFIX)-runtime
 TARGET_OUTPUT = $(CURDIR)/$(TARGET)
@@ -77,6 +78,7 @@ PKGRUNDIR := $(LOCALSTATEDIR)/run/$(PROJECT_DIR)
 PKGLIBEXECDIR := $(LIBEXECDIR)/$(PROJECT_DIR)
 
 KERNELPATH := $(PKGDATADIR)/vmlinuz.container
+INITRDPATH := $(PKGDATADIR)/$(INITRDNAME)
 IMAGEPATH := $(PKGDATADIR)/$(IMAGENAME)
 FIRMWAREPATH :=
 
@@ -140,6 +142,8 @@ USER_VARS += DESTSYSCONFIG
 USER_VARS += DESTTARGET
 USER_VARS += IMAGENAME
 USER_VARS += IMAGEPATH
+USER_VARS += INITRDNAME
+USER_VARS += INITRDPATH
 USER_VARS += MACHINETYPE
 USER_VARS += KERNELPATH
 USER_VARS += FIRMWAREPATH
@@ -244,6 +248,7 @@ var showConfigPathsOption = fmt.Sprintf("%s-show-default-config-paths", projectP
 var defaultHypervisorPath = "$(QEMUPATH)"
 var defaultImagePath = "$(IMAGEPATH)"
 var defaultKernelPath = "$(KERNELPATH)"
+var defaultInitrdPath = "$(INITRDPATH)"
 var defaultFirmwarePath = "$(FIRMWAREPATH)"
 var defaultMachineAccelerators = "$(MACHINEACCELERATORS)"
 var defaultShimPath = "$(SHIMPATH)"
@@ -319,6 +324,7 @@ $(GENERATED_FILES): %: %.in Makefile VERSION
 		-e "s|@DESTSYSCONFIG@|$(DESTSYSCONFIG)|g" \
 		-e "s|@IMAGEPATH@|$(IMAGEPATH)|g" \
 		-e "s|@KERNELPATH@|$(KERNELPATH)|g" \
+		-e "s|@INITRDPATH@|$(INITRDPATH)|g" \
 		-e "s|@FIRMWAREPATH@|$(FIRMWAREPATH)|g" \
 		-e "s|@MACHINEACCELERATORS@|$(MACHINEACCELERATORS)|g" \
 		-e "s|@KERNELPARAMS@|$(KERNELPARAMS)|g" \

--- a/cli/config.go
+++ b/cli/config.go
@@ -76,6 +76,7 @@ type tomlConfig struct {
 type hypervisor struct {
 	Path                  string `toml:"path"`
 	Kernel                string `toml:"kernel"`
+	Initrd                string `toml:"initrd"`
 	Image                 string `toml:"image"`
 	Firmware              string `toml:"firmware"`
 	MachineAccelerators   string `toml:"machine_accelerators"`
@@ -131,11 +132,21 @@ func (h hypervisor) kernel() (string, error) {
 	return resolvePath(p)
 }
 
+func (h hypervisor) initrd() (string, error) {
+	p := h.Initrd
+
+	if p == "" {
+		return "", nil
+	}
+
+	return resolvePath(p)
+}
+
 func (h hypervisor) image() (string, error) {
 	p := h.Image
 
 	if p == "" {
-		p = defaultImagePath
+		return "", nil
 	}
 
 	return resolvePath(p)
@@ -267,6 +278,11 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		return vc.HypervisorConfig{}, err
 	}
 
+	initrd, err := h.initrd()
+	if err != nil {
+		return vc.HypervisorConfig{}, err
+	}
+
 	image, err := h.image()
 	if err != nil {
 		return vc.HypervisorConfig{}, err
@@ -289,6 +305,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 	return vc.HypervisorConfig{
 		HypervisorPath:        hypervisor,
 		KernelPath:            kernel,
+		InitrdPath:            initrd,
 		ImagePath:             image,
 		FirmwarePath:          firmware,
 		MachineAccelerators:   machineAccelerators,
@@ -393,6 +410,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		HypervisorPath:        defaultHypervisorPath,
 		KernelPath:            defaultKernelPath,
 		ImagePath:             defaultImagePath,
+		InitrdPath:            defaultInitrdPath,
 		FirmwarePath:          defaultFirmwarePath,
 		MachineAccelerators:   defaultMachineAccelerators,
 		HypervisorMachineType: defaultMachineType,

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -8,6 +8,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH@"
+initrd = "@INITRDPATH@"
 image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
 

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -514,6 +514,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		HypervisorPath:        defaultHypervisorPath,
 		KernelPath:            defaultKernelPath,
 		ImagePath:             defaultImagePath,
+		InitrdPath:            defaultInitrdPath,
 		HypervisorMachineType: defaultMachineType,
 		DefaultVCPUs:          defaultVCPUCount,
 		DefaultMemSz:          defaultMemSize,
@@ -757,6 +758,44 @@ func TestHypervisorDefaultsKernel(t *testing.T) {
 	assert.Equal(h.kernelParams(), kernelParams, "custom hypervisor kernel parameterms wrong")
 }
 
+// The default initrd path is not returned by h.initrd()
+func TestHypervisorDefaultsInitrd(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir(testDir, "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	testInitrdPath := filepath.Join(tmpdir, "initrd")
+	testInitrdLinkPath := filepath.Join(tmpdir, "initrd-link")
+
+	err = createEmptyFile(testInitrdPath)
+	assert.NoError(err)
+
+	err = syscall.Symlink(testInitrdPath, testInitrdLinkPath)
+	assert.NoError(err)
+
+	savedInitrdPath := defaultInitrdPath
+
+	defer func() {
+		defaultInitrdPath = savedInitrdPath
+	}()
+
+	defaultInitrdPath = testInitrdPath
+	h := hypervisor{}
+	p, err := h.initrd()
+	assert.NoError(err)
+	assert.Equal(p, "", "default Image path wrong")
+
+	// test path resolution
+	defaultInitrdPath = testInitrdLinkPath
+	h = hypervisor{}
+	p, err = h.initrd()
+	assert.NoError(err)
+	assert.Equal(p, "")
+}
+
+// The default image path is not returned by h.image()
 func TestHypervisorDefaultsImage(t *testing.T) {
 	assert := assert.New(t)
 
@@ -783,14 +822,14 @@ func TestHypervisorDefaultsImage(t *testing.T) {
 	h := hypervisor{}
 	p, err := h.image()
 	assert.NoError(err)
-	assert.Equal(p, defaultImagePath, "default Image path wrong")
+	assert.Equal(p, "", "default Image path wrong")
 
 	// test path resolution
 	defaultImagePath = testImageLinkPath
 	h = hypervisor{}
 	p, err = h.image()
 	assert.NoError(err)
-	assert.Equal(p, testImagePath)
+	assert.Equal(p, "")
 }
 
 func TestProxyDefaults(t *testing.T) {

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -861,7 +861,7 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 		getKernelParamsFunc = savedFunc
 	}()
 
-	getKernelParamsFunc = func(containerID string) []vc.Param {
+	getKernelParamsFunc = func(containerID string, needSystemd bool) []vc.Param {
 		return []vc.Param{
 			{
 				Key:   "",

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -30,7 +30,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.9"
+const formatVersion = "1.0.10"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -42,6 +42,11 @@ type MetaInfo struct {
 type KernelInfo struct {
 	Path       string
 	Parameters string
+}
+
+// InitrdInfo stores initrd image details
+type InitrdInfo struct {
+	Path string
 }
 
 // ImageInfo stores root filesystem image details
@@ -130,6 +135,7 @@ type EnvInfo struct {
 	Hypervisor HypervisorInfo
 	Image      ImageInfo
 	Kernel     KernelInfo
+	Initrd     InitrdInfo
 	Proxy      ProxyInfo
 	Shim       ShimInfo
 	Agent      AgentInfo
@@ -307,12 +313,17 @@ func getEnvInfo(configFile string, config oci.RuntimeConfig) (env EnvInfo, err e
 		Parameters: strings.Join(vc.SerializeParams(config.HypervisorConfig.KernelParams, "="), " "),
 	}
 
+	initrd := InitrdInfo{
+		Path: config.HypervisorConfig.InitrdPath,
+	}
+
 	env = EnvInfo{
 		Meta:       meta,
 		Runtime:    runtime,
 		Hypervisor: hypervisor,
 		Image:      image,
 		Kernel:     kernel,
+		Initrd:     initrd,
 		Proxy:      proxy,
 		Shim:       shim,
 		Agent:      agent,

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -1117,6 +1117,9 @@ type Kernel struct {
 	// Path is the guest kernel path on the host filesystem.
 	Path string
 
+	// InitrdPath is the guest initrd path on the host filesystem.
+	InitrdPath string
+
 	// Params is the kernel parameters string.
 	Params string
 }
@@ -1394,6 +1397,11 @@ func (config *Config) appendKernel() {
 	if config.Kernel.Path != "" {
 		config.qemuParams = append(config.qemuParams, "-kernel")
 		config.qemuParams = append(config.qemuParams, config.Kernel.Path)
+
+		if config.Kernel.InitrdPath != "" {
+			config.qemuParams = append(config.qemuParams, "-initrd")
+			config.qemuParams = append(config.qemuParams, config.Kernel.InitrdPath)
+		}
 
 		if config.Kernel.Params != "" {
 			config.qemuParams = append(config.qemuParams, "-append")

--- a/virtcontainers/asset.go
+++ b/virtcontainers/asset.go
@@ -34,6 +34,8 @@ func (t assetType) annotations() (string, string, error) {
 		return annotations.KernelPath, annotations.KernelHash, nil
 	case imageAsset:
 		return annotations.ImagePath, annotations.ImageHash, nil
+	case initrdAsset:
+		return annotations.InitrdPath, annotations.InitrdHash, nil
 	case hypervisorAsset:
 		return annotations.HypervisorPath, annotations.HypervisorHash, nil
 	case firmwareAsset:
@@ -46,6 +48,7 @@ func (t assetType) annotations() (string, string, error) {
 const (
 	kernelAsset     assetType = "kernel"
 	imageAsset      assetType = "image"
+	initrdAsset     assetType = "initrd"
 	hypervisorAsset assetType = "hypervisor"
 	firmwareAsset   assetType = "firmware"
 )
@@ -65,6 +68,8 @@ func (a *asset) valid() bool {
 	case kernelAsset:
 		return true
 	case imageAsset:
+		return true
+	case initrdAsset:
 		return true
 	case hypervisorAsset:
 		return true

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -157,6 +157,10 @@ type HypervisorConfig struct {
 	// ImagePath is the guest image host path.
 	ImagePath string
 
+	// InitrdPath is the guest initrd image host path.
+	// ImagePath and InitrdPath cannot be set at the same time.
+	InitrdPath string
+
 	// FirmwarePath is the bios host path
 	FirmwarePath string
 
@@ -225,8 +229,8 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 		return false, fmt.Errorf("Missing kernel path")
 	}
 
-	if conf.ImagePath == "" {
-		return false, fmt.Errorf("Missing image path")
+	if conf.ImagePath == "" && conf.InitrdPath == "" {
+		return false, fmt.Errorf("Missing image and initrd path")
 	}
 
 	if conf.DefaultVCPUs == 0 {
@@ -299,6 +303,8 @@ func (conf *HypervisorConfig) assetPath(t assetType) (string, error) {
 		return conf.KernelPath, nil
 	case imageAsset:
 		return conf.ImagePath, nil
+	case initrdAsset:
+		return conf.InitrdPath, nil
 	case hypervisorAsset:
 		return conf.HypervisorPath, nil
 	case firmwareAsset:
@@ -335,6 +341,16 @@ func (conf *HypervisorConfig) ImageAssetPath() (string, error) {
 // CustomImageAsset returns true if the image asset is a custom one, false otherwise.
 func (conf *HypervisorConfig) CustomImageAsset() bool {
 	return conf.isCustomAsset(imageAsset)
+}
+
+// InitrdAssetPath returns the guest initrd path
+func (conf *HypervisorConfig) InitrdAssetPath() (string, error) {
+	return conf.assetPath(initrdAsset)
+}
+
+// CustomInitrdAsset returns true if the initrd asset is a custom one, false otherwise.
+func (conf *HypervisorConfig) CustomInitrdAsset() bool {
+	return conf.isCustomAsset(initrdAsset)
 }
 
 // HypervisorAssetPath returns the VM hypervisor path

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -25,6 +25,9 @@ const (
 	// ImagePath is a pod annotation for passing a per container path pointing at the guest image that will run in the container VM.
 	ImagePath = vcAnnotationsPrefix + "ImagePath"
 
+	// InitrdPath is a pod annotation for passing a per container path pointing at the guest initrd image that will run in the container VM.
+	InitrdPath = vcAnnotationsPrefix + "InitrdPath"
+
 	// HypervisorPath is a pod annotation for passing a per container path pointing at the hypervisor that will run the container VM.
 	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
 
@@ -36,6 +39,9 @@ const (
 
 	// ImageHash is an pod annotation for passing a container guest image SHA-512 hash value.
 	ImageHash = vcAnnotationsPrefix + "ImageHash"
+
+	// InitrdHash is an pod annotation for passing a container guest initrd SHA-512 hash value.
+	InitrdHash = vcAnnotationsPrefix + "InitrdHash"
 
 	// HypervisorHash is an pod annotation for passing a container hypervisor binary SHA-512 hash value.
 	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -447,6 +447,7 @@ func addAssetAnnotations(ocispec CompatOCISpec, config *vc.PodConfig) {
 	assetAnnotations := []string{
 		vcAnnotations.KernelPath,
 		vcAnnotations.ImagePath,
+		vcAnnotations.InitrdPath,
 		vcAnnotations.KernelHash,
 		vcAnnotations.ImageHash,
 		vcAnnotations.AssetHashType,

--- a/virtcontainers/pod.go
+++ b/virtcontainers/pod.go
@@ -551,7 +551,16 @@ func createAssets(podConfig *PodConfig) error {
 		return err
 	}
 
-	for _, a := range []*asset{kernel, image} {
+	initrd, err := newAsset(podConfig, initrdAsset)
+	if err != nil {
+		return err
+	}
+
+	if image != nil && initrd != nil {
+		return fmt.Errorf("%s and %s cannot be both set", imageAsset, initrdAsset)
+	}
+
+	for _, a := range []*asset{kernel, image, initrd} {
 		if err := podConfig.HypervisorConfig.addCustomAsset(a); err != nil {
 			return err
 		}

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -175,7 +175,7 @@ func (q *qemu) init(pod *Pod) error {
 
 	q.config = pod.config.HypervisorConfig
 	q.pod = pod
-	q.arch = newQemuArch(q.config.HypervisorMachineType)
+	q.arch = newQemuArch(q.config)
 
 	if err = pod.storage.fetchHypervisorState(pod.id, &q.state); err != nil {
 		q.Logger().Debug("Creating bridges")

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -42,10 +42,13 @@ var qemuPaths = map[string]string{
 	QemuQ35:    defaultQemuPath,
 }
 
-var kernelParams = []Param{
+var kernelRootParams = []Param{
 	{"root", "/dev/pmem0p1"},
 	{"rootflags", "dax,data=ordered,errors=remount-ro rw"},
 	{"rootfstype", "ext4"},
+}
+
+var kernelParams = []Param{
 	{"tsc", "reliable"},
 	{"no_timer_check", ""},
 	{"rcupdate.rcu_expedited", "1"},
@@ -83,12 +86,13 @@ func maxQemuVCPUs() uint32 {
 	return uint32(240)
 }
 
-func newQemuArch(machineType string) qemuArch {
+func newQemuArch(config HypervisorConfig) qemuArch {
+	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
 	}
 
-	return &qemuAmd64{
+	q := &qemuAmd64{
 		qemuArchBase{
 			machineType:           machineType,
 			qemuPaths:             qemuPaths,
@@ -98,6 +102,12 @@ func newQemuArch(machineType string) qemuArch {
 			kernelParams:          kernelParams,
 		},
 	}
+
+	if config.ImagePath != "" {
+		q.kernelParams = append(q.kernelParams, kernelRootParams...)
+	}
+
+	return q
 }
 
 func (q *qemuAmd64) capabilities() capabilities {

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -105,6 +105,8 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 
 	if config.ImagePath != "" {
 		q.kernelParams = append(q.kernelParams, kernelRootParams...)
+		q.kernelParamsNonDebug = append(q.kernelParamsNonDebug, kernelParamsSystemdNonDebug...)
+		q.kernelParamsDebug = append(q.kernelParamsDebug, kernelParamsSystemdDebug...)
 	}
 
 	return q

--- a/virtcontainers/qemu_amd64_test.go
+++ b/virtcontainers/qemu_amd64_test.go
@@ -26,21 +26,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newTestQemu(machineType string) qemuArch {
+	config := HypervisorConfig{
+		HypervisorMachineType: machineType,
+	}
+	return newQemuArch(config)
+}
+
 func TestQemuAmd64Capabilities(t *testing.T) {
 	assert := assert.New(t)
 
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 	caps := amd64.capabilities()
 	assert.True(caps.isBlockDeviceHotplugSupported())
 
-	amd64 = newQemuArch(QemuQ35)
+	amd64 = newTestQemu(QemuQ35)
 	caps = amd64.capabilities()
 	assert.False(caps.isBlockDeviceHotplugSupported())
 }
 
 func TestQemuAmd64Bridges(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 	len := 5
 
 	bridges := amd64.bridges(uint32(len))
@@ -53,7 +60,7 @@ func TestQemuAmd64Bridges(t *testing.T) {
 		assert.NotNil(b.Address)
 	}
 
-	amd64 = newQemuArch(QemuQ35)
+	amd64 = newTestQemu(QemuQ35)
 	bridges = amd64.bridges(uint32(len))
 	assert.Len(bridges, len)
 
@@ -64,14 +71,14 @@ func TestQemuAmd64Bridges(t *testing.T) {
 		assert.NotNil(b.Address)
 	}
 
-	amd64 = newQemuArch(QemuQ35 + QemuPC)
+	amd64 = newTestQemu(QemuQ35 + QemuPC)
 	bridges = amd64.bridges(uint32(len))
 	assert.Nil(bridges)
 }
 
 func TestQemuAmd64CPUModel(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 
 	expectedOut := defaultCPUModel
 	model := amd64.cpuModel()
@@ -85,7 +92,7 @@ func TestQemuAmd64CPUModel(t *testing.T) {
 
 func TestQemuAmd64MemoryTopology(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 	memoryOffset := 1024
 
 	hostMem := uint64(100)
@@ -103,7 +110,7 @@ func TestQemuAmd64MemoryTopology(t *testing.T) {
 func TestQemuAmd64AppendImage(t *testing.T) {
 	var devices []govmmQemu.Device
 	assert := assert.New(t)
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 
 	f, err := ioutil.TempFile("", "img")
 	assert.NoError(err)
@@ -135,7 +142,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 	assert := assert.New(t)
 
 	// check PC
-	amd64 := newQemuArch(QemuPC)
+	amd64 := newTestQemu(QemuPC)
 
 	bridges := amd64.bridges(1)
 	assert.Len(bridges, 1)
@@ -156,7 +163,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 	assert.Equal(expectedOut, devices)
 
 	// Check Q35
-	amd64 = newQemuArch(QemuQ35)
+	amd64 = newTestQemu(QemuQ35)
 
 	bridges = amd64.bridges(1)
 	assert.Len(bridges, 1)

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -136,6 +136,11 @@ const (
 // parameters that will be used in standard (non-debug) mode.
 var kernelParamsNonDebug = []Param{
 	{"quiet", ""},
+}
+
+// kernelParamsSystemdNonDebug is a list of the default systemd related
+// kernel parameters that will be used in standard (non-debug) mode.
+var kernelParamsSystemdNonDebug = []Param{
 	{"systemd.show_status", "false"},
 }
 
@@ -144,6 +149,12 @@ var kernelParamsNonDebug = []Param{
 // possible).
 var kernelParamsDebug = []Param{
 	{"debug", ""},
+}
+
+// kernelParamsSystemdDebug is a list of the default systemd related kernel
+// parameters that will be used in debug mode (as much boot output as
+// possible).
+var kernelParamsSystemdDebug = []Param{
 	{"systemd.show_status", "true"},
 	{"systemd.log_level", "debug"},
 }

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -77,6 +77,8 @@ func newQemuArch(config HypervisrConfig) qemuArch {
 
 	if config.ImagePath != "" {
 		q.kernelParams = append(q.kernelParams, kernelRootParams...)
+		q.kernelParamsNonDebug = append(q.kernelParamsNonDebug, kernelParamsSystemdNonDebug...)
+		q.kernelParamsDebug = append(q.kernelParamsDebug, kernelParamsSystemdDebug...)
 	}
 
 	return q

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -38,9 +38,12 @@ var qemuPaths = map[string]string{
 }
 
 var kernelParams = []Param{
-	{"root", "/dev/vda1"},
 	{"console", "ttyAMA0"},
 	{"iommu.passthrough", "0"},
+}
+
+var kernelRootParams = []Param{
+	{"root", "/dev/vda1"},
 }
 
 var supportedQemuMachines = []govmmQemu.Machine{
@@ -55,12 +58,13 @@ func maxQemuVCPUs() uint32 {
 	return uint32(runtime.NumCPU())
 }
 
-func newQemuArch(machineType string) qemuArch {
+func newQemuArch(config HypervisrConfig) qemuArch {
+	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
 	}
 
-	return &qemuArm64{
+	q := &qemuArm64{
 		qemuArchBase{
 			machineType:           machineType,
 			qemuPaths:             qemuPaths,
@@ -70,4 +74,10 @@ func newQemuArch(machineType string) qemuArch {
 			kernelParams:          kernelParams,
 		},
 	}
+
+	if config.ImagePath != "" {
+		q.kernelParams = append(q.kernelParams, kernelRootParams...)
+	}
+
+	return q
 }

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -32,6 +32,7 @@ func newQemuConfig() HypervisorConfig {
 	return HypervisorConfig{
 		KernelPath:        testQemuKernelPath,
 		ImagePath:         testQemuImagePath,
+		InitrdPath:        testQemuInitrdPath,
 		HypervisorPath:    testQemuPath,
 		DefaultVCPUs:      defaultVCPUs,
 		DefaultMemSz:      defaultMemSzMiB,

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -30,6 +30,7 @@ import (
 const testPodID = "7f49d00d-1995-4156-8c79-5f5ab24ce138"
 const testContainerID = "containerID"
 const testKernel = "kernel"
+const testInitrd = "initrd"
 const testImage = "image"
 const testHypervisor = "hypervisor"
 const testBundle = "bundle"
@@ -45,6 +46,7 @@ var podDirLock = ""
 var podFileState = ""
 var podFileLock = ""
 var testQemuKernelPath = ""
+var testQemuInitrdPath = ""
 var testQemuImagePath = ""
 var testQemuPath = ""
 var testHyperstartCtlSocket = ""
@@ -135,6 +137,7 @@ func TestMain(m *testing.M) {
 	podFileLock = filepath.Join(runStoragePath, testPodID, lockFileName)
 
 	testQemuKernelPath = filepath.Join(testDir, testKernel)
+	testQemuInitrdPath = filepath.Join(testDir, testInitrd)
 	testQemuImagePath = filepath.Join(testDir, testImage)
 	testQemuPath = filepath.Join(testDir, testHypervisor)
 


### PR DESCRIPTION
If an initrd image is configured in HypervisorConfig or passed in by annotations, append it to qemu command line arguments so that we boot the guest OS with the specified initrd image rather than a rootfs disk image.

A sample qemu command line:

> -name pod-test9 -uuid 9fc4a0e0-52a3-4e1c-b562-14b5c197dd2b -machine pc,accel=kvm,kernel_irqchip,nvdimm -cpu host,pmu=off -qmp unix:/run/virtcontainers/pods/test9/mon-9fc4a0e0-52a3-4e1c-b562-14b5c197dd2b,server,nowait -qmp unix:/run/virtcontainers/pods/test9/ctl-9fc4a0e0-52a3-4e1c-b562-14b5c197dd2b,server,nowait -m 2048M,slots=2,maxmem=4720M -device virtio-serial-pci,disable-modern=true,id=serial0 -device virtconsole,chardev=charconsole0,id=console0 -chardev socket,id=charconsole0,path=/run/virtcontainers/pods/test9/console.sock,server,nowait -device virtio-scsi-pci,id=scsi0,disable-modern=true -device virtserialport,chardev=charch0,id=channel0,name=agent.channel.0 -chardev socket,id=charch0,path=/run/virtcontainers/pods/test9/kata.sock,server,nowait -device virtio-9p-pci,disable-modern=true,fsdev=extra-9p-kataShared,mount_tag=kataShared -fsdev local,id=extra-9p-kataShared,path=/run/kata-containers/shared/pods/test9,security_model=none -rtc base=utc,driftfix=slew -global kvm-pit.lost_tick_policy=discard -vga none -no-user-config -nodefaults -nographic -daemonize -kernel /golang/src/github.com/hyperhq/hyperstart/build/arch/x86_64/kernel -initrd /golang/src/github.com/kata-containers/osbuilder/kata-initrd.img -append tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k console=hvc0 console=hvc1 iommu=off cryptomgr.notests net.ifnames=0 pci=lastbus=0 debug panic=1 initcall_debug ip=::::::test9::off:: agent.log=debug -smp 1,cores=1,threads=1,sockets=1,maxcpus=240
