### PR TITLE
CI: Add doc team to pullapprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -30,3 +30,14 @@ groups:
     required: 2
     teams:
       - runtime
+
+  documentation:
+    required: 1
+    teams:
+      - documentation
+    conditions:
+      files:
+        include:
+          - "*.md"
+        exclude:
+          - "vendor/*"


### PR DESCRIPTION
Add the standard doc team config to the pullapprove config file.

Fixes #99.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>