### PR TITLE
Update data collection script based on review feedback

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -261,8 +261,11 @@ show_package_versions()
 	local pattern="("
 	local project
 
-	# CC 2.x runtime. This shouldn't be installed but let's check anyway
+	# CC 2.x, 3.0 and runv runtimes. They shouldn't be installed but let's
+	# check anyway.
 	pattern+="cc-oci-runtime"
+	pattern+="cc-runtime"
+	pattern+="runv"
 
 	# core components
 	for project in @PROJECT_TYPE@

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -273,10 +273,10 @@ show_package_versions()
 		pattern+="|${project}-proxy"
 		pattern+="|${project}-runtime"
 		pattern+="|${project}-shim"
+		pattern+="|${project}-containers-image"
 	done
 
 	# assets
-	pattern+="|clear-containers-image"
 	pattern+="|linux-container"
 
 	# optimised hypervisor

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -279,11 +279,8 @@ show_package_versions()
 	# assets
 	pattern+="|linux-container"
 
-	# optimised hypervisor
-	pattern+="|qemu-lite"
-
-	# default distro hypervisor
-	pattern+="|qemu-system-x86"
+	# hypervisor name prefix
+	pattern+="|qemu-"
 
 	pattern+=")"
 


### PR DESCRIPTION
Implement review feedback from @devimc on #93.

- Look for other runtime packages (Clear Containers and `runv`-based) in data collection script.
- Fix bug where collect script was looking for Clear Containers images rather than Kata Containers ones.
- Don't hard-code the architecture when looking for hypervisor packages.

Fixes #101.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>