### PR TITLE
virtcontainers: vfio: add support for hot plugging VFIO devices

### DIFF
--- a/virtcontainers/device.go
+++ b/virtcontainers/device.go
@@ -132,7 +132,13 @@ func (device *VFIODevice) attach(h hypervisor, c *Container) error {
 
 		device.BDF = deviceBDF
 
-		if err := h.addDevice(*device, vfioDev); err != nil {
+		randBytes, err := generateRandomBytes(8)
+		if err != nil {
+			return err
+		}
+		device.DeviceInfo.ID = hex.EncodeToString(randBytes)
+
+		if err := h.hotplugAddDevice(*device, vfioDev); err != nil {
 			deviceLogger().WithError(err).Error("Failed to add device")
 			return err
 		}

--- a/virtcontainers/pod.go
+++ b/virtcontainers/pod.go
@@ -596,11 +596,6 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
-	// Passthrough devices
-	if err := p.attachDevices(); err != nil {
-		return nil, err
-	}
-
 	// Set pod state
 	if err := p.setPodState(StateReady); err != nil {
 		return nil, err
@@ -1069,24 +1064,4 @@ func togglePausePod(podID string, pause bool) (*Pod, error) {
 	}
 
 	return p, nil
-}
-
-func (p *Pod) attachDevices() error {
-	for _, container := range p.containers {
-		if err := container.attachDevices(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (p *Pod) detachDevices() error {
-	for _, container := range p.containers {
-		if err := container.detachDevices(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/virtcontainers/pod_test.go
+++ b/virtcontainers/pod_test.go
@@ -1171,10 +1171,10 @@ func TestPodAttachDevicesVFIO(t *testing.T) {
 
 	containers[0].pod = &pod
 
-	err = pod.attachDevices()
+	err = containers[0].attachDevices()
 	assert.Nil(t, err, "Error while attaching devices %s", err)
 
-	err = pod.detachDevices()
+	err = containers[0].detachDevices()
 	assert.Nil(t, err, "Error while detaching devices %s", err)
 }
 


### PR DESCRIPTION
With this patch VFIO devices are hot plugged in the VM, that means
no more cold plug in kata containers.

fixes #85

Signed-off-by: Julio Montes <julio.montes@intel.com>