### PR TITLE
qemu: Move to qemu 2.11

### DIFF
--- a/arch/amd64-options.mk
+++ b/arch/amd64-options.mk
@@ -18,10 +18,4 @@ MACHINETYPE := pc
 KERNELPARAMS :=
 MACHINEACCELERATORS :=
 
-# The CentOS/RHEL hypervisor binary is not called qemu-lite
-ifeq (,$(filter-out centos rhel,$(distro)))
-    QEMUCMD := qemu-system-x86_64
-else
-    QEMUCMD := qemu-lite-system-x86_64
-endif
-
+QEMUCMD := qemu-system-x86_64

--- a/versions.yaml
+++ b/versions.yaml
@@ -60,9 +60,8 @@ assets:
 
     qemu:
       description: "VMM that uses KVM"
-      url: "https://github.com/kata-containers/qemu"
-      version: "741f430a960b5b67745670e8270db91aeb083c5f-29"
-      release: "19360"
+      url: "https://github.com/qemu/qemu"
+      version: "stable-2.11"
 
   image:
     description: |

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -1990,9 +1990,9 @@ func TestProcessListContainer(t *testing.T) {
 
 func createNewPodConfig(hType HypervisorType, aType AgentType, aConfig interface{}, netModel NetworkModel) PodConfig {
 	hypervisorConfig := HypervisorConfig{
-		KernelPath:     "/usr/share/clear-containers/vmlinux.container",
-		ImagePath:      "/usr/share/clear-containers/clear-containers.img",
-		HypervisorPath: "/usr/bin/qemu-lite-system-x86_64",
+		KernelPath:     "/usr/share/kata-containers/vmlinux.container",
+		ImagePath:      "/usr/share/kata-containers/kata-containers.img",
+		HypervisorPath: "/usr/bin/qemu-system-x86_64",
 	}
 
 	netConfig := NetworkConfig{

--- a/virtcontainers/documentation/api/1.0/api.md
+++ b/virtcontainers/documentation/api/1.0/api.md
@@ -894,7 +894,7 @@ func Example_createAndStartPod() {
 	hypervisorConfig := vc.HypervisorConfig{
 		KernelPath:     "/usr/share/clear-containers/vmlinux.container",
 		ImagePath:      "/usr/share/clear-containers/clear-containers.img",
-		HypervisorPath: "/usr/bin/qemu-lite-system-x86_64",
+		HypervisorPath: "/usr/bin/qemu-system-x86_64",
 	}
 
 	// Use hyperstart default values for the agent.

--- a/virtcontainers/example_pod_run_test.go
+++ b/virtcontainers/example_pod_run_test.go
@@ -50,9 +50,9 @@ func Example_createAndStartPod() {
 
 	// Sets the hypervisor configuration.
 	hypervisorConfig := vc.HypervisorConfig{
-		KernelPath:     "/usr/share/clear-containers/vmlinux.container",
-		ImagePath:      "/usr/share/clear-containers/clear-containers.img",
-		HypervisorPath: "/usr/bin/qemu-lite-system-x86_64",
+		KernelPath:     "/usr/share/kata-containers/vmlinux.container",
+		ImagePath:      "/usr/share/kata-containers/kata-containers.img",
+		HypervisorPath: "/usr/bin/qemu-system-x86_64",
 	}
 
 	// Use hyperstart default values for the agent.

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	qemuArchBaseMachineType = "pc"
-	qemuArchBaseQemuPath    = "/usr/bin/qemu-lite-system-x86_64"
+	qemuArchBaseQemuPath    = "/usr/bin/qemu-system-x86_64"
 )
 
 var qemuArchBaseQemuPaths = map[string]string{


### PR DESCRIPTION
This commit modifies version.yaml to now point to the qemu
2.11 stable version.
It modifies the default QEMU_CMD to be qemu-system-x86_64
instead of qemu-lite-system-x86_64.
And modifies virtcontainers unit tests to now point to the
correct QEMU_CMD.

Fixes: #118.

Depends-on: github.com/kata-containers/tests#182

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>