### PR TITLE
exec: Allow to exec a process on a ready container

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -210,9 +210,11 @@ func execute(context *cli.Context) error {
 
 	params.cID = status.ID
 
-	// container MUST be running
-	if status.State.State != vc.StateRunning {
-		return fmt.Errorf("Container %s is not running", params.cID)
+	// container MUST be ready or running.
+	if status.State.State != vc.StateReady &&
+		status.State.State != vc.StateRunning {
+		return fmt.Errorf("Container %s is not ready or running",
+			params.cID)
 	}
 
 	envVars, err := oci.EnvVars(params.ociProcess.Env)

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -627,8 +627,10 @@ func (c *Container) enter(cmd Cmd) (*Process, error) {
 		return nil, err
 	}
 
-	if c.state.State != StateRunning {
-		return nil, fmt.Errorf("Container not running, impossible to enter")
+	if c.state.State != StateReady &&
+		c.state.State != StateRunning {
+		return nil, fmt.Errorf("Container not ready or running, " +
+			"impossible to enter")
 	}
 
 	process, err := c.pod.agent.exec(c.pod, *c, cmd)

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -336,3 +336,29 @@ func TestContainerRemoveResources(t *testing.T) {
 	err = c.removeResources()
 	assert.Nil(err)
 }
+
+func TestContainerEnterErrorsOnContainerStates(t *testing.T) {
+	assert := assert.New(t)
+	c := &Container{
+		pod: &Pod{
+			state: State{
+				State: StateRunning,
+			},
+		},
+	}
+	cmd := Cmd{}
+
+	// Container state undefined
+	_, err := c.enter(cmd)
+	assert.Error(err)
+
+	// Container paused
+	c.state.State = StatePaused
+	_, err = c.enter(cmd)
+	assert.Error(err)
+
+	// Container stopped
+	c.state.State = StateStopped
+	_, err = c.enter(cmd)
+	assert.Error(err)
+}


### PR DESCRIPTION
If a container is not running, but created/ready instead, this means
a container process exists and that we can actually exec another
process inside this container. The container does not have to be
in running state.

Fixes #120

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>