### PR TITLE
virtcontainers: Don't ignore container mounts based on their path

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -300,7 +300,7 @@ func (c *Container) createContainersDirs() error {
 func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) ([]Mount, error) {
 	var sharedDirMounts []Mount
 	for idx, m := range c.mounts {
-		if isSystemMount(m.Destination) || m.Type != "bind" {
+		if m.Type != "bind" {
 			continue
 		}
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -570,8 +570,6 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 			grpcSpec.Mounts[idx].Type = "tmpfs"
 			grpcSpec.Mounts[idx].Source = "shm"
 			grpcSpec.Mounts[idx].Options = []string{"noexec", "nosuid", "nodev", "mode=1777", "size=65536k"}
-
-			break
 		}
 	}
 }

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -29,18 +29,6 @@ import (
 
 var rootfsDir = "rootfs"
 
-var systemMountPrefixes = []string{"/proc", "/dev", "/sys"}
-
-func isSystemMount(m string) bool {
-	for _, p := range systemMountPrefixes {
-		if m == p || strings.HasPrefix(m, p+"/") {
-			return true
-		}
-	}
-
-	return false
-}
-
 func major(dev uint64) int {
 	return int((dev >> 8) & 0xfff)
 }

--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -29,30 +29,6 @@ import (
 	"testing"
 )
 
-func TestIsSystemMount(t *testing.T) {
-	tests := []struct {
-		mnt      string
-		expected bool
-	}{
-		{"/sys", true},
-		{"/sys/", true},
-		{"/sys//", true},
-		{"/sys/fs", true},
-		{"/sys/fs/", true},
-		{"/sys/fs/cgroup", true},
-		{"/sysfoo", false},
-		{"/home", false},
-		{"/dev/block/", true},
-	}
-
-	for _, test := range tests {
-		result := isSystemMount(test.mnt)
-		if result != test.expected {
-			t.Fatalf("Expected result for path %s : %v, got %v", test.mnt, test.expected, result)
-		}
-	}
-}
-
 func TestMajorMinorNumber(t *testing.T) {
 	devices := []string{"/dev/zero", "/dev/net/tun"}
 


### PR DESCRIPTION
Instead of ignoring containers based on their path, this commit
relies on the type of mount being "bind" to choose if this mount
should be ignored or not.

For instance, we have some use cases where k8s expects the path
"/dev/container-log" to be bind mounted inside the container, but
the code ignores it because it has the prefix "/dev" which is a
system prefix mount.

Fixes #116 #122

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>