### PR TITLE
virtcontainers: Do not rollback by deleting container or pod

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -164,7 +164,6 @@ func StopPod(podID string) (VCPod, error) {
 	// Stop it.
 	err = p.stop()
 	if err != nil {
-		p.delete()
 		return nil, err
 	}
 
@@ -406,7 +405,6 @@ func StartContainer(podID, containerID string) (VCContainer, error) {
 	// Start it.
 	err = c.start()
 	if err != nil {
-		c.delete()
 		return nil, err
 	}
 
@@ -444,7 +442,6 @@ func StopContainer(podID, containerID string) (VCContainer, error) {
 	// Stop it.
 	err = c.stop()
 	if err != nil {
-		c.delete()
 		return nil, err
 	}
 


### PR DESCRIPTION
In case a consumer of virtcontainers tries to start/stop a container,
or stop a pod, and for some reasons, this fails, virtcontainers always
tries to delete everything related to the container or the pod before
it returns the error.

The caller of the runtime is the one responsible for cleaning things
up if something goes wrong, that's why this cleanup call is never
needed.

A real example of that is the case of cc-runtime and CRI-O, where this
cleanup prevented CRI-O from retrieving proper state of the container
after the failure, leading to the inability to stop and remove the
container and the VM afterwards.

Fixes #87

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>