### PR TITLE
volumes: Attach volumes that are block device files as block devices

### DIFF
--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -281,6 +281,11 @@ type Mount struct {
 
 	// ReadOnly specifies if the mount should be read only or not
 	ReadOnly bool
+
+	// BlockDevice represents block device that is attached to the
+	// VM in case this mount is a block device file or a directory
+	// backed by a block device.
+	BlockDevice *BlockDevice
 }
 
 func bindUnmountContainerRootfs(sharedDir, podID, cID string) error {


### PR DESCRIPTION
Check if a volume passed to the container with -v is a block device
file, and if so pass the block device by hotplugging it to the VM
instead of passing this as a 9pfs volume. This would give us
better performance.

Fixes #137

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>