### PR TITLE
cli: delete out-of-date comment

### DIFF
--- a/cli/oci.go
+++ b/cli/oci.go
@@ -50,7 +50,6 @@ var cgroupsDirPath string
 var procMountInfo = "/proc/self/mountinfo"
 
 // getContainerInfo returns the container status and its pod ID.
-// It internally expands the container ID from the prefix provided.
 func getContainerInfo(containerID string) (vc.ContainerStatus, string, error) {
 	// container ID MUST be provided.
 	if containerID == "" {


### PR DESCRIPTION
Function getContainerInfo dosen't expand container id from prefix now

Fixes #139

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>