### PR TITLE
versions: Update CRI-O version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -95,7 +95,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/kubernetes-incubator/cri-o"
-    version: "v1.9.10"
+    version: "v1.9.11"
 
   docker:
     description: "Moby project container manager"


### PR DESCRIPTION
This change uses latest commit from CRI-O
1.9 branch instead of using latest 1.9 release.
This will allow us to unskip a test from the
CRI-O ctr.bats test file, since it contains a race
condition fix.

Fixes: #182.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>