### PR TITLE
virtcontainers: Do not pass /dev/shm as 9p mount

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -304,6 +304,13 @@ func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (
 			continue
 		}
 
+		// We need to treat /dev/shm as a special case. This is passed as a bind mount in the spec,
+		// but it does not make sense to pass this as a 9p mount from the host side.
+		// This needs to be handled purely in the guest, by allocating memory for this inside the VM.
+		if m.Destination == "/dev/shm" {
+			continue
+		}
+
 		randBytes, err := generateRandomBytes(8)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
All bind mounts are now passed to the guest with 9p.
We need to exclude /dev/shm, as this is passed as a bind mount
in the spec. We handle /dev/shm in the guest by allocating
memory for it on the guest side. Passing /dev/shm as a 9p mount
was causing it to be mounted twice.

Fixes #190

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>