### PR TITLE
virtcontainers: fix unit tests

### DIFF
--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -1726,7 +1726,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 	cmd := newBasicTestCmd()
 
 	_, c, _, err = EnterContainer(p.ID(), contID, cmd)
-	if c != nil || err == nil {
+	if c == nil || err != nil {
 		t.Fatal()
 	}
 }

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -210,6 +210,12 @@ func TestContainerAddDriveDir(t *testing.T) {
 		id:         testPodID,
 		storage:    fs,
 		hypervisor: &mockHypervisor{},
+		agent:      &noopAgent{},
+		config: &PodConfig{
+			HypervisorConfig: HypervisorConfig{
+				DisableBlockDeviceUse: false,
+			},
+		},
 	}
 
 	contID := "100"
@@ -258,7 +264,6 @@ func TestContainerAddDriveDir(t *testing.T) {
 	if container.state.Fstype == "" || !container.state.HotpluggedDrive {
 		t.Fatal()
 	}
-
 }
 
 func TestCheckPodRunningEmptyCmdFailure(t *testing.T) {
@@ -307,7 +312,10 @@ func TestContainerAddResources(t *testing.T) {
 		CPUQuota:  5000,
 		CPUPeriod: 1000,
 	}
-	c.pod = &Pod{hypervisor: &mockHypervisor{}}
+	c.pod = &Pod{
+		hypervisor: &mockHypervisor{},
+		agent:      &noopAgent{},
+	}
 	err = c.addResources()
 	assert.Nil(err)
 }

--- a/virtcontainers/pkg/vcmock/container.go
+++ b/virtcontainers/pkg/vcmock/container.go
@@ -30,6 +30,10 @@ func (c *Container) Pod() vc.VCPod {
 
 // Process implements the VCContainer function of the same name.
 func (c *Container) Process() vc.Process {
+	// always return a mockprocess with a non-zero Pid
+	if c.MockProcess.Pid == 0 {
+		c.MockProcess.Pid = 1000
+	}
 	return c.MockProcess
 }
 


### PR DESCRIPTION
Fix unit tests according with new changes introduced recently.
Use noopAgent in unit tests to add online fake resources.
Factorize configuration and hardware support for hotplugging block
devices into a single function and use that.

fixes #192

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
Signed-off-by: Julio Montes <julio.montes@intel.com>