### PR TITLE
runtime: rename pod to sandbox

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -33,7 +33,7 @@ firmware = "@FIRMWAREPATH@"
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`
 machine_accelerators="@MACHINEACCELERATORS@"
 
-# Default number of vCPUs per POD/VM:
+# Default number of vCPUs per SB/VM:
 # unspecified or 0                --> will be set to @DEFVCPUS@
 # < 0                             --> will be set to the actual number of physical cores
 # > 0 <= number of physical cores --> will be set to the specified number
@@ -47,13 +47,13 @@ default_vcpus = 1
 # * Until 30 devices per bridge can be hot plugged.
 # * Until 5 PCI bridges can be cold plugged per VM.
 #   This limitation could be a bug in qemu or in the kernel
-# Default number of bridges per POD/VM:
+# Default number of bridges per SB/VM:
 # unspecified or 0   --> will be set to @DEFBRIDGES@
 # > 1 <= 5           --> will be set to the specified number
 # > 5                --> will be set to 5
 default_bridges = @DEFBRIDGES@
 
-# Default memory size in MiB for POD/VM.
+# Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 #default_memory = @DEFMEMSZ@
 

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -37,7 +37,7 @@ const (
 	testConsole                 = "/dev/pts/999"
 	testContainerTypeAnnotation = "io.kubernetes.cri-o.ContainerType"
 	testSandboxIDAnnotation     = "io.kubernetes.cri-o.SandboxID"
-	testContainerTypePod        = "sandbox"
+	testContainerTypeSandbox    = "sandbox"
 	testContainerTypeContainer  = "container"
 )
 
@@ -301,8 +301,8 @@ func TestCreateCLIFunctionCreateFail(t *testing.T) {
 func TestCreateInvalidArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 		MockContainers: []*vcmock.Container{
 			{MockID: testContainerID},
 			{MockID: testContainerID},
@@ -310,18 +310,18 @@ func TestCreateInvalidArgs(t *testing.T) {
 		},
 	}
 
-	testingImpl.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.CreatePodFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.CreateSandboxFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -364,13 +364,13 @@ func TestCreateInvalidArgs(t *testing.T) {
 func TestCreateInvalidConfigJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -408,13 +408,13 @@ func TestCreateInvalidConfigJSON(t *testing.T) {
 func TestCreateInvalidContainerType(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -455,13 +455,13 @@ func TestCreateInvalidContainerType(t *testing.T) {
 func TestCreateContainerInvalid(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -503,25 +503,25 @@ func TestCreateContainerInvalid(t *testing.T) {
 func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 		MockContainers: []*vcmock.Container{
 			{MockID: testContainerID},
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
-	testingImpl.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
-		testingImpl.CreatePodFunc = nil
+		testingImpl.ListSandboxFunc = nil
+		testingImpl.CreateSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -544,9 +544,9 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// Force pod-type container
+	// Force sandbox-type container
 	spec.Annotations = make(map[string]string)
-	spec.Annotations[testContainerTypeAnnotation] = testContainerTypePod
+	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeSandbox
 
 	// Set a limit to ensure processCgroupsPath() considers the
 	// cgroup part of the spec
@@ -598,25 +598,25 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 		MockContainers: []*vcmock.Container{
 			{MockID: testContainerID},
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
-	testingImpl.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
-		testingImpl.CreatePodFunc = nil
+		testingImpl.ListSandboxFunc = nil
+		testingImpl.CreateSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -639,9 +639,9 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// Force pod-type container
+	// Force sandbox-type container
 	spec.Annotations = make(map[string]string)
-	spec.Annotations[testContainerTypeAnnotation] = testContainerTypePod
+	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeSandbox
 
 	// Set a limit to ensure processCgroupsPath() considers the
 	// cgroup part of the spec
@@ -683,25 +683,25 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 		MockContainers: []*vcmock.Container{
 			{MockID: testContainerID},
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
-	testingImpl.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
-		testingImpl.CreatePodFunc = nil
+		testingImpl.ListSandboxFunc = nil
+		testingImpl.CreateSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -725,9 +725,9 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// Force pod-type container
+	// Force sandbox-type container
 	spec.Annotations = make(map[string]string)
-	spec.Annotations[testContainerTypeAnnotation] = testContainerTypePod
+	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeSandbox
 
 	// Set a limit to ensure processCgroupsPath() considers the
 	// cgroup part of the spec
@@ -754,25 +754,25 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 func TestCreate(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 		MockContainers: []*vcmock.Container{
 			{MockID: testContainerID},
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
-	testingImpl.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
-		testingImpl.CreatePodFunc = nil
+		testingImpl.ListSandboxFunc = nil
+		testingImpl.CreateSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -795,9 +795,9 @@ func TestCreate(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// Force pod-type container
+	// Force sandbox-type container
 	spec.Annotations = make(map[string]string)
-	spec.Annotations[testContainerTypeAnnotation] = testContainerTypePod
+	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeSandbox
 
 	// Set a limit to ensure processCgroupsPath() considers the
 	// cgroup part of the spec
@@ -819,13 +819,13 @@ func TestCreate(t *testing.T) {
 func TestCreateInvalidKernelParams(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -848,9 +848,9 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// Force createPod() to be called.
+	// Force createSandbox() to be called.
 	spec.Annotations = make(map[string]string)
-	spec.Annotations[testContainerTypeAnnotation] = testContainerTypePod
+	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeSandbox
 
 	// rewrite the file
 	err = writeOCIConfigFile(spec, ociConfigFile)
@@ -877,16 +877,16 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 	}
 }
 
-func TestCreateCreatePodPodConfigFail(t *testing.T) {
+func TestCreateSandboxConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -919,21 +919,21 @@ func TestCreateCreatePodPodConfigFail(t *testing.T) {
 		Quota: &quota,
 	}
 
-	_, err = createPod(spec, runtimeConfig, testContainerID, bundlePath, testConsole, true)
+	_, err = createSandbox(spec, runtimeConfig, testContainerID, bundlePath, testConsole, true)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
 
-func TestCreateCreatePodFail(t *testing.T) {
+func TestCreateCreateSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -954,7 +954,7 @@ func TestCreateCreatePodFail(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	_, err = createPod(spec, runtimeConfig, testContainerID, bundlePath, testConsole, true)
+	_, err = createSandbox(spec, runtimeConfig, testContainerID, bundlePath, testConsole, true)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 }
@@ -962,13 +962,13 @@ func TestCreateCreatePodFail(t *testing.T) {
 func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -1006,13 +1006,13 @@ func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 func TestCreateCreateContainerFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -1030,10 +1030,10 @@ func TestCreateCreateContainerFail(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// set expected container type and podID
+	// set expected container type and sandboxID
 	spec.Annotations = make(map[string]string)
 	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeContainer
-	spec.Annotations[testSandboxIDAnnotation] = testPodID
+	spec.Annotations[testSandboxIDAnnotation] = testSandboxID
 
 	// rewrite file
 	err = writeOCIConfigFile(spec, ociConfigFile)
@@ -1049,17 +1049,17 @@ func TestCreateCreateContainerFail(t *testing.T) {
 func TestCreateCreateContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
-	testingImpl.CreateContainerFunc = func(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error) {
-		return &vcmock.Pod{}, &vcmock.Container{}, nil
+	testingImpl.CreateContainerFunc = func(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error) {
+		return &vcmock.Sandbox{}, &vcmock.Container{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateContainerFunc = nil
 	}()
 
@@ -1078,10 +1078,10 @@ func TestCreateCreateContainer(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	// set expected container type and podID
+	// set expected container type and sandboxID
 	spec.Annotations = make(map[string]string)
 	spec.Annotations[testContainerTypeAnnotation] = testContainerTypeContainer
-	spec.Annotations[testSandboxIDAnnotation] = testPodID
+	spec.Annotations[testSandboxIDAnnotation] = testSandboxID
 
 	// rewrite file
 	err = writeOCIConfigFile(spec, ociConfigFile)

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -63,20 +63,20 @@ func TestDeleteInvalidContainer(t *testing.T) {
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
-	// Mock Listpod error
+	// Mock Listsandbox error
 	err = delete(testContainerID, false)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	// Container missing in ListPod
+	// Container missing in ListSandbox
 	err = delete(testContainerID, false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
@@ -85,17 +85,17 @@ func TestDeleteInvalidContainer(t *testing.T) {
 func TestDeleteMissingContainerTypeAnnotation(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID:          pod.ID(),
+						ID:          sandbox.ID(),
 						Annotations: map[string]string{},
 					},
 				},
@@ -104,10 +104,10 @@ func TestDeleteMissingContainerTypeAnnotation(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	err := delete(pod.ID(), false)
+	err := delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
@@ -115,17 +115,17 @@ func TestDeleteMissingContainerTypeAnnotation(t *testing.T) {
 func TestDeleteInvalidConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 						},
@@ -136,10 +136,10 @@ func TestDeleteInvalidConfig(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	err := delete(pod.ID(), false)
+	err := delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
@@ -162,24 +162,24 @@ func testConfigSetup(t *testing.T) string {
 	return configPath
 }
 
-func TestDeletePod(t *testing.T) {
+func TestDeleteSandbox(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	configPath := testConfigSetup(t)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -194,55 +194,55 @@ func TestDeletePod(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	err = delete(pod.ID(), false)
+	err = delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.StopPodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.StopPodFunc = nil
+		testingImpl.StopSandboxFunc = nil
 	}()
 
-	err = delete(pod.ID(), false)
+	err = delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.DeletePodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.DeleteSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.DeletePodFunc = nil
+		testingImpl.DeleteSandboxFunc = nil
 	}()
 
-	err = delete(pod.ID(), false)
+	err = delete(sandbox.ID(), false)
 	assert.Nil(err)
 }
 
 func TestDeleteInvalidContainerType(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	configPath := testConfigSetup(t)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: "InvalidType",
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -257,33 +257,33 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// Delete an invalid container type
-	err = delete(pod.ID(), false)
+	err = delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
 
-func TestDeletePodRunning(t *testing.T) {
+func TestDeleteSandboxRunning(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	configPath := testConfigSetup(t)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -298,50 +298,50 @@ func TestDeletePodRunning(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	// Delete on a running pod should fail
-	err = delete(pod.ID(), false)
+	// Delete on a running sandbox should fail
+	err = delete(sandbox.ID(), false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
-	testingImpl.StopPodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.StopPodFunc = nil
+		testingImpl.StopSandboxFunc = nil
 	}()
 
-	// Force delete a running pod
-	err = delete(pod.ID(), true)
+	// Force delete a running sandbox
+	err = delete(sandbox.ID(), true)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.DeletePodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.DeleteSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.DeletePodFunc = nil
+		testingImpl.DeleteSandboxFunc = nil
 	}()
 
-	err = delete(pod.ID(), true)
+	err = delete(sandbox.ID(), true)
 	assert.Nil(err)
 }
 
 func TestDeleteRunningContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  testContainerID,
-			MockPod: pod,
+			MockID:      testContainerID,
+			MockSandbox: sandbox,
 		},
 	}
 
@@ -349,13 +349,13 @@ func TestDeleteRunningContainer(t *testing.T) {
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.MockContainers[0].ID(),
+						ID: sandbox.MockContainers[0].ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -370,16 +370,16 @@ func TestDeleteRunningContainer(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// Delete on a running container should fail.
-	err = delete(pod.MockContainers[0].ID(), false)
+	err = delete(sandbox.MockContainers[0].ID(), false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
 	// force delete
-	err = delete(pod.MockContainers[0].ID(), true)
+	err = delete(sandbox.MockContainers[0].ID(), true)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
@@ -388,11 +388,11 @@ func TestDeleteRunningContainer(t *testing.T) {
 		testingImpl.StopContainerFunc = nil
 	}()
 
-	err = delete(pod.MockContainers[0].ID(), true)
+	err = delete(sandbox.MockContainers[0].ID(), true)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.DeleteContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
+	testingImpl.DeleteContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &vcmock.Container{}, nil
 	}
 
@@ -400,21 +400,21 @@ func TestDeleteRunningContainer(t *testing.T) {
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err = delete(pod.MockContainers[0].ID(), true)
+	err = delete(sandbox.MockContainers[0].ID(), true)
 	assert.Nil(err)
 }
 
 func TestDeleteContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  testContainerID,
-			MockPod: pod,
+			MockID:      testContainerID,
+			MockSandbox: sandbox,
 		},
 	}
 
@@ -422,13 +422,13 @@ func TestDeleteContainer(t *testing.T) {
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.MockContainers[0].ID(),
+						ID: sandbox.MockContainers[0].ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -443,10 +443,10 @@ func TestDeleteContainer(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	err = delete(pod.MockContainers[0].ID(), false)
+	err = delete(sandbox.MockContainers[0].ID(), false)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
@@ -455,11 +455,11 @@ func TestDeleteContainer(t *testing.T) {
 		testingImpl.StopContainerFunc = nil
 	}()
 
-	err = delete(pod.MockContainers[0].ID(), false)
+	err = delete(sandbox.MockContainers[0].ID(), false)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.DeleteContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
+	testingImpl.DeleteContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &vcmock.Container{}, nil
 	}
 
@@ -467,7 +467,7 @@ func TestDeleteContainer(t *testing.T) {
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err = delete(pod.MockContainers[0].ID(), false)
+	err = delete(sandbox.MockContainers[0].ID(), false)
 	assert.Nil(err)
 }
 
@@ -499,14 +499,14 @@ func TestDeleteCLIFunction(t *testing.T) {
 func TestDeleteCLIFunctionSuccess(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  testContainerID,
-			MockPod: pod,
+			MockID:      testContainerID,
+			MockSandbox: sandbox,
 		},
 	}
 
@@ -514,13 +514,13 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 							vcAnnotations.ConfigJSONKey:    configJSON,
@@ -534,18 +534,18 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 		}, nil
 	}
 
-	testingImpl.StopPodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
-	testingImpl.DeletePodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.DeleteSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
-		testingImpl.StopPodFunc = nil
-		testingImpl.DeletePodFunc = nil
+		testingImpl.ListSandboxFunc = nil
+		testingImpl.StopSandboxFunc = nil
+		testingImpl.DeleteSandboxFunc = nil
 	}()
 
 	flagSet := &flag.FlagSet{}
@@ -561,7 +561,7 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 
 	flagSet = flag.NewFlagSet("container-id", flag.ContinueOnError)
-	flagSet.Parse([]string{pod.ID()})
+	flagSet.Parse([]string{sandbox.ID()})
 	ctx = cli.NewContext(app, flagSet, nil)
 	assert.NotNil(ctx)
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -192,7 +192,7 @@ func generateExecParams(context *cli.Context, specProcess *oci.CompatOCIProcess)
 
 func execute(context *cli.Context) error {
 	containerID := context.Args().First()
-	status, podID, err := getExistingContainerInfo(containerID)
+	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func execute(context *cli.Context) error {
 		Detach:      noNeedForOutput(params.detach, params.ociProcess.Terminal),
 	}
 
-	_, _, process, err := vci.EnterContainer(podID, params.cID, cmd)
+	_, _, process, err := vci.EnterContainer(sandboxID, params.cID, cmd)
 	if err != nil {
 		return err
 	}

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -66,7 +66,7 @@ func TestExecuteErrors(t *testing.T) {
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
-	// ListPod error
+	// ListSandbox error
 	flagSet.Parse([]string{testContainerID})
 	err = execute(ctx)
 	assert.Error(err)
@@ -77,12 +77,12 @@ func TestExecuteErrors(t *testing.T) {
 		vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, vc.State{}, vc.State{}, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, vc.State{}, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	err = execute(ctx)
@@ -100,8 +100,8 @@ func TestExecuteErrors(t *testing.T) {
 	}
 
 	containerState := vc.State{}
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -112,8 +112,8 @@ func TestExecuteErrors(t *testing.T) {
 	containerState = vc.State{
 		State: vc.StatePaused,
 	}
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -124,8 +124,8 @@ func TestExecuteErrors(t *testing.T) {
 	containerState = vc.State{
 		State: vc.StateStopped,
 	}
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -161,12 +161,12 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// Note: flags can only be tested with the CLI command function
@@ -205,12 +205,12 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// Note: flags can only be tested with the CLI command function
@@ -267,12 +267,12 @@ func TestExecuteWithFlags(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	fn, ok := execCLICommand.Action.(func(context *cli.Context) error)
@@ -283,8 +283,8 @@ func TestExecuteWithFlags(t *testing.T) {
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.EnterContainerFunc = func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
-		return &vcmock.Pod{}, &vcmock.Container{}, &vc.Process{}, nil
+	testingImpl.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+		return &vcmock.Sandbox{}, &vcmock.Container{}, &vc.Process{}, nil
 	}
 
 	defer func() {
@@ -300,7 +300,7 @@ func TestExecuteWithFlags(t *testing.T) {
 	os.Remove(pidFilePath)
 
 	// Process ran and exited successfully
-	testingImpl.EnterContainerFunc = func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		workload := []string{"cat", "/dev/null"}
 		command := exec.Command(workload[0], workload[1:]...)
@@ -309,7 +309,7 @@ func TestExecuteWithFlags(t *testing.T) {
 
 		vcProcess := vc.Process{}
 		vcProcess.Pid = command.Process.Pid
-		return &vcmock.Pod{}, &vcmock.Container{}, &vcProcess, nil
+		return &vcmock.Sandbox{}, &vcmock.Container{}, &vcProcess, nil
 	}
 
 	defer func() {
@@ -351,15 +351,15 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	testingImpl.EnterContainerFunc = func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		workload := []string{"cat", "/dev/null"}
 		command := exec.Command(workload[0], workload[1:]...)
@@ -368,7 +368,7 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 
 		vcProcess := vc.Process{}
 		vcProcess.Pid = command.Process.Pid
-		return &vcmock.Pod{}, &vcmock.Container{}, &vcProcess, nil
+		return &vcmock.Sandbox{}, &vcmock.Container{}, &vcProcess, nil
 	}
 
 	defer func() {
@@ -425,12 +425,12 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	fn, ok := execCLICommand.Action.(func(context *cli.Context) error)
@@ -472,12 +472,12 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	processJSON := `{
@@ -511,7 +511,7 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 
 	workload := []string{"cat", "/dev/null"}
 
-	testingImpl.EnterContainerFunc = func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		command := exec.Command(workload[0], workload[1:]...)
 		err := command.Start()
@@ -520,7 +520,7 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 		vcProcess := vc.Process{}
 		vcProcess.Pid = command.Process.Pid
 
-		return &vcmock.Pod{}, &vcmock.Container{}, &vcProcess, nil
+		return &vcmock.Sandbox{}, &vcmock.Container{}, &vcProcess, nil
 	}
 
 	defer func() {
@@ -564,12 +564,12 @@ func TestExecuteWithInvalidEnvironment(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, annotations), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	processJSON := `{

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -99,7 +99,7 @@ var signals = map[string]syscall.Signal{
 
 func kill(containerID, signal string, all bool) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	status, podID, err := getExistingContainerInfo(containerID)
+	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func kill(containerID, signal string, all bool) error {
 		return fmt.Errorf("Container %s not ready or running, cannot send a signal", containerID)
 	}
 
-	if err := vci.KillContainer(podID, containerID, signum, all); err != nil {
+	if err := vci.KillContainer(sandboxID, containerID, signum, all); err != nil {
 		return err
 	}
 
@@ -124,7 +124,7 @@ func kill(containerID, signal string, all bool) error {
 		return nil
 	}
 
-	_, err = vci.StopContainer(podID, containerID)
+	_, err = vci.StopContainer(sandboxID, containerID)
 	return err
 }
 

--- a/cli/kill_test.go
+++ b/cli/kill_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 var (
-	testKillContainerFuncReturnNil = func(podID, containerID string, signal syscall.Signal, all bool) error {
+	testKillContainerFuncReturnNil = func(sandboxID, containerID string, signal syscall.Signal, all bool) error {
 		return nil
 	}
 
-	testStopContainerFuncReturnNil = func(podID, containerID string) (vc.VCContainer, error) {
+	testStopContainerFuncReturnNil = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &vcmock.Container{}, nil
 	}
 )
@@ -72,12 +72,12 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
 	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -102,12 +102,12 @@ func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -124,12 +124,12 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -145,19 +145,19 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.KillContainerFunc = func(podID, containerID string, signal syscall.Signal, all bool) error {
+	testingImpl.KillContainerFunc = func(sandboxID, containerID string, signal syscall.Signal, all bool) error {
 		if !all {
 			return fmt.Errorf("Expecting -all flag = true, Got false")
 		}
 
 		return nil
 	}
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -179,12 +179,12 @@ func TestKillCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -201,12 +201,12 @@ func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -223,12 +223,12 @@ func TestKillCLIFunctionInvalidStatePausedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -245,12 +245,12 @@ func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -266,11 +266,11 @@ func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/list.go
+++ b/cli/list.go
@@ -309,22 +309,22 @@ func getContainers(context *cli.Context) ([]fullContainerState, error) {
 
 	latestHypervisorDetails := getHypervisorDetails(&runtimeConfig.HypervisorConfig)
 
-	podList, err := vci.ListPod()
+	sandboxList, err := vci.ListSandbox()
 	if err != nil {
 		return nil, err
 	}
 
 	var s []fullContainerState
 
-	for _, pod := range podList {
-		if len(pod.ContainersStatus) == 0 {
-			// ignore empty pods
+	for _, sandbox := range sandboxList {
+		if len(sandbox.ContainersStatus) == 0 {
+			// ignore empty sandboxes
 			continue
 		}
 
-		currentHypervisorDetails := getHypervisorDetails(&pod.HypervisorConfig)
+		currentHypervisorDetails := getHypervisorDetails(&sandbox.HypervisorConfig)
 
-		for _, container := range pod.ContainersStatus {
+		for _, container := range sandbox.ContainersStatus {
 			ociState := oci.StatusToOCIState(container)
 			staleAssets := getStaleAssets(currentHypervisorDetails, latestHypervisorDetails)
 

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -375,7 +375,7 @@ func TestListCLIFunctionNoContainers(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestListGetContainersListPodFail(t *testing.T) {
+func TestListGetContainersListSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir(testDir, "")
@@ -401,13 +401,13 @@ func TestListGetContainersListPodFail(t *testing.T) {
 func TestListGetContainers(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// No pre-existing pods
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// No pre-existing sandboxes
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir(testDir, "")
@@ -430,24 +430,24 @@ func TestListGetContainers(t *testing.T) {
 	assert.Equal(state, []fullContainerState(nil))
 }
 
-func TestListGetContainersPodWithoutContainers(t *testing.T) {
+func TestListGetContainersSandboxWithoutContainers(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID:               pod.ID(),
+				ID:               sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus(nil),
 			},
 		}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir(testDir, "")
@@ -470,28 +470,28 @@ func TestListGetContainersPodWithoutContainers(t *testing.T) {
 	assert.Equal(state, []fullContainerState(nil))
 }
 
-func TestListGetContainersPodWithContainer(t *testing.T) {
+func TestListGetContainersSandboxWithContainer(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	rootfs := filepath.Join(tmpdir, "rootfs")
 	err = os.MkdirAll(rootfs, testDirMode)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID:          pod.ID(),
+						ID:          sandbox.ID(),
 						Annotations: map[string]string{},
 						RootFs:      rootfs,
 					},
@@ -501,7 +501,7 @@ func TestListGetContainersPodWithContainer(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	app := cli.NewApp()
@@ -550,19 +550,19 @@ func TestListCLIFunctionFormatFail(t *testing.T) {
 		{"invalid", invalidFlags},
 	}
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	rootfs := filepath.Join(tmpdir, "rootfs")
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 						},
@@ -574,7 +574,7 @@ func TestListCLIFunctionFormatFail(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	savedOutputFile := defaultOutputFile
@@ -651,21 +651,21 @@ func TestListCLIFunctionQuiet(t *testing.T) {
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
 	rootfs := filepath.Join(tmpdir, "rootfs")
 	err = os.MkdirAll(rootfs, testDirMode)
 	assert.NoError(err)
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 						},
@@ -677,7 +677,7 @@ func TestListCLIFunctionQuiet(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("test", 0)
@@ -713,7 +713,7 @@ func TestListCLIFunctionQuiet(t *testing.T) {
 	assert.NoError(err)
 
 	trimmed := strings.TrimSpace(text)
-	assert.Equal(testPodID, trimmed)
+	assert.Equal(testSandboxID, trimmed)
 }
 
 func TestListGetDirOwner(t *testing.T) {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -50,7 +50,7 @@ const (
 	// small docker image used to create root filesystems from
 	testDockerImage = "busybox"
 
-	testPodID       = "99999999-9999-9999-99999999999999999"
+	testSandboxID   = "99999999-9999-9999-99999999999999999"
 	testContainerID = "1"
 	testBundle      = "bundle"
 )
@@ -449,11 +449,11 @@ func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
 }
 
-func newSingleContainerPodStatusList(podID, containerID string, podState, containerState vc.State, annotations map[string]string) []vc.PodStatus {
-	return []vc.PodStatus{
+func newSingleContainerSandboxStatusList(sandboxID, containerID string, sandboxState, containerState vc.State, annotations map[string]string) []vc.SandboxStatus {
+	return []vc.SandboxStatus{
 		{
-			ID:    podID,
-			State: podState,
+			ID:    sandboxID,
+			State: sandboxState,
 			ContainersStatus: []vc.ContainerStatus{
 				{
 					ID:          containerID,

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -51,15 +51,15 @@ Where "<container-id>" is the container name to be resumed.`,
 
 func toggleContainerPause(containerID string, pause bool) (err error) {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	_, podID, err := getExistingContainerInfo(containerID)
+	_, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
 
 	if pause {
-		_, err = vci.PausePod(podID)
+		_, err = vci.PauseSandbox(sandboxID)
 	} else {
-		_, err = vci.ResumePod(podID)
+		_, err = vci.ResumeSandbox(sandboxID)
 	}
 
 	return err

--- a/cli/pause_test.go
+++ b/cli/pause_test.go
@@ -24,12 +24,12 @@ import (
 )
 
 var (
-	testPausePodFuncReturnNil = func(podID string) (vc.VCPod, error) {
-		return &vcmock.Pod{}, nil
+	testPauseSandboxFuncReturnNil = func(sandboxID string) (vc.VCSandbox, error) {
+		return &vcmock.Sandbox{}, nil
 	}
 
-	testResumePodFuncReturnNil = func(podID string) (vc.VCPod, error) {
-		return &vcmock.Pod{}, nil
+	testResumeSandboxFuncReturnNil = func(sandboxID string) (vc.VCSandbox, error) {
+		return &vcmock.Sandbox{}, nil
 	}
 )
 
@@ -40,13 +40,13 @@ func TestPauseCLIFunctionSuccessful(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.PausePodFunc = testPausePodFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
-		testingImpl.PausePodFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.PauseSandboxFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -58,13 +58,13 @@ func TestPauseCLIFunctionSuccessful(t *testing.T) {
 func TestPauseCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.PausePodFunc = testPausePodFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 	defer func() {
-		testingImpl.PausePodFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.PauseSandboxFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -73,18 +73,18 @@ func TestPauseCLIFunctionContainerNotExistFailure(t *testing.T) {
 	execCLICommandFunc(assert, pauseCLICommand, set, true)
 }
 
-func TestPauseCLIFunctionPausePodFailure(t *testing.T) {
+func TestPauseCLIFunctionPauseSandboxFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	state := vc.State{
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -100,13 +100,13 @@ func TestResumeCLIFunctionSuccessful(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ResumePodFunc = testResumePodFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
-		testingImpl.ResumePodFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ResumeSandboxFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -118,13 +118,13 @@ func TestResumeCLIFunctionSuccessful(t *testing.T) {
 func TestResumeCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ResumePodFunc = testResumePodFuncReturnNil
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 	defer func() {
-		testingImpl.ResumePodFunc = nil
-		testingImpl.ListPodFunc = nil
+		testingImpl.ResumeSandboxFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -133,18 +133,18 @@ func TestResumeCLIFunctionContainerNotExistFailure(t *testing.T) {
 	execCLICommandFunc(assert, resumeCLICommand, set, true)
 }
 
-func TestResumeCLIFunctionPausePodFailure(t *testing.T) {
+func TestResumeCLIFunctionPauseSandboxFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	state := vc.State{
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return newSingleContainerPodStatusList(testPodID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
 	}
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -57,7 +57,7 @@ func ps(containerID, format string, args []string) error {
 	}
 
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	status, podID, err := getExistingContainerInfo(containerID)
+	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func ps(containerID, format string, args []string) error {
 
 	options.Format = format
 
-	msg, err := vci.ProcessListContainer(containerID, podID, options)
+	msg, err := vci.ProcessListContainer(containerID, sandboxID, options)
 	if err != nil {
 		return err
 	}

--- a/cli/ps_test.go
+++ b/cli/ps_test.go
@@ -45,25 +45,25 @@ func TestPSCLIAction(t *testing.T) {
 func TestPSFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
+	sandbox := &vcmock.Sandbox{
 		MockID: testContainerID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  pod.ID(),
-			MockPod: pod,
+			MockID:      sandbox.ID(),
+			MockSandbox: sandbox,
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// return a podStatus with the container status
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// return a sandboxStatus with the container status
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 						},
@@ -74,7 +74,7 @@ func TestPSFailure(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// inexistent container
@@ -82,35 +82,35 @@ func TestPSFailure(t *testing.T) {
 	assert.Error(err)
 
 	// container is not running
-	err = ps(pod.ID(), "json", []string{"-ef"})
+	err = ps(sandbox.ID(), "json", []string{"-ef"})
 	assert.Error(err)
 }
 
 func TestPSSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
+	sandbox := &vcmock.Sandbox{
 		MockID: testContainerID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  pod.ID(),
-			MockPod: pod,
+			MockID:      sandbox.ID(),
+			MockSandbox: sandbox,
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// return a podStatus with the container status
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// return a sandboxStatus with the container status
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
 						State: vc.State{
 							State: vc.StateRunning,
 						},
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 						},
@@ -120,15 +120,15 @@ func TestPSSuccessful(t *testing.T) {
 		}, nil
 	}
 
-	testingImpl.ProcessListContainerFunc = func(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+	testingImpl.ProcessListContainerFunc = func(sandboxID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
 		return []byte("echo,sleep,grep"), nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 		testingImpl.ProcessListContainerFunc = nil
 	}()
 
-	err := ps(pod.ID(), "json", []string{})
+	err := ps(sandbox.ID(), "json", []string{})
 	assert.NoError(err)
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -90,7 +90,7 @@ func run(containerID, bundle, console, consoleSocket, pidFile string, detach boo
 		return err
 	}
 
-	pod, err := start(containerID)
+	sandbox, err := start(containerID)
 	if err != nil {
 		return err
 	}
@@ -99,9 +99,9 @@ func run(containerID, bundle, console, consoleSocket, pidFile string, detach boo
 		return nil
 	}
 
-	containers := pod.GetAllContainers()
+	containers := sandbox.GetAllContainers()
 	if len(containers) == 0 {
-		return fmt.Errorf("There are no containers running in the pod: %s", pod.ID())
+		return fmt.Errorf("There are no containers running in the sandbox: %s", sandbox.ID())
 	}
 
 	p, err := os.FindProcess(containers[0].GetPid())
@@ -115,7 +115,7 @@ func run(containerID, bundle, console, consoleSocket, pidFile string, detach boo
 	}
 
 	// delete container's resources
-	if err := delete(pod.ID(), true); err != nil {
+	if err := delete(sandbox.ID(), true); err != nil {
 		return err
 	}
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -48,9 +48,9 @@ var startCLICommand = cli.Command{
 	},
 }
 
-func start(containerID string) (vc.VCPod, error) {
+func start(containerID string) (vc.VCSandbox, error) {
 	// Checks the MUST and MUST NOT from OCI runtime specification
-	status, podID, err := getExistingContainerInfo(containerID)
+	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -62,14 +62,14 @@ func start(containerID string) (vc.VCPod, error) {
 		return nil, err
 	}
 
-	if containerType.IsPod() {
-		return vci.StartPod(podID)
+	if containerType.IsSandbox() {
+		return vci.StartSandbox(sandboxID)
 	}
 
-	c, err := vci.StartContainer(podID, containerID)
+	c, err := vci.StartContainer(sandboxID, containerID)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.Pod(), nil
+	return c.Sandbox(), nil
 }

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -33,39 +33,39 @@ func TestStartInvalidArgs(t *testing.T) {
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
-	// Mock Listpod error
+	// Mock Listsandbox error
 	_, err = start(testContainerID)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	// Container missing in ListPod
+	// Container missing in ListSandbox
 	_, err = start(testContainerID)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
 
-func TestStartPod(t *testing.T) {
+func TestStartSandbox(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 						},
@@ -76,39 +76,39 @@ func TestStartPod(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	_, err := start(pod.ID())
+	_, err := start(sandbox.ID())
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.StartPodFunc = func(podID string) (vc.VCPod, error) {
-		return pod, nil
+	testingImpl.StartSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.StartPodFunc = nil
+		testingImpl.StartSandboxFunc = nil
 	}()
 
-	_, err = start(pod.ID())
+	_, err = start(sandbox.ID())
 	assert.Nil(err)
 }
 
 func TestStartMissingAnnotation(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID:          pod.ID(),
+						ID:          sandbox.ID(),
 						Annotations: map[string]string{},
 					},
 				},
@@ -117,10 +117,10 @@ func TestStartMissingAnnotation(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
-	_, err := start(pod.ID())
+	_, err := start(sandbox.ID())
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
@@ -128,21 +128,21 @@ func TestStartMissingAnnotation(t *testing.T) {
 func TestStartContainerSucessFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  testContainerID,
-			MockPod: pod,
+			MockID:      testContainerID,
+			MockSandbox: sandbox,
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
 						ID: testContainerID,
@@ -156,15 +156,15 @@ func TestStartContainerSucessFailure(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	_, err := start(testContainerID)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.StartContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
-		return pod.MockContainers[0], nil
+	testingImpl.StartContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
+		return sandbox.MockContainers[0], nil
 	}
 
 	defer func() {
@@ -203,21 +203,21 @@ func TestStartCLIFunction(t *testing.T) {
 func TestStartCLIFunctionSuccess(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
-		MockID: testPodID,
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  testContainerID,
-			MockPod: pod,
+			MockID:      testContainerID,
+			MockSandbox: sandbox,
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
 						ID: testContainerID,
@@ -230,12 +230,12 @@ func TestStartCLIFunctionSuccess(t *testing.T) {
 		}, nil
 	}
 
-	testingImpl.StartContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
-		return pod.MockContainers[0], nil
+	testingImpl.StartContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
+		return sandbox.MockContainers[0], nil
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 		testingImpl.StartContainerFunc = nil
 	}()
 

--- a/cli/state_test.go
+++ b/cli/state_test.go
@@ -49,25 +49,25 @@ func TestStateCliAction(t *testing.T) {
 func TestStateSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	pod := &vcmock.Pod{
+	sandbox := &vcmock.Sandbox{
 		MockID: testContainerID,
 	}
 
-	pod.MockContainers = []*vcmock.Container{
+	sandbox.MockContainers = []*vcmock.Container{
 		{
-			MockID:  pod.ID(),
-			MockPod: pod,
+			MockID:      sandbox.ID(),
+			MockSandbox: sandbox,
 		},
 	}
 
-	testingImpl.ListPodFunc = func() ([]vc.PodStatus, error) {
-		// return a podStatus with the container status
-		return []vc.PodStatus{
+	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		// return a sandboxStatus with the container status
+		return []vc.SandboxStatus{
 			{
-				ID: pod.ID(),
+				ID: sandbox.ID(),
 				ContainersStatus: []vc.ContainerStatus{
 					{
-						ID: pod.ID(),
+						ID: sandbox.ID(),
 						Annotations: map[string]string{
 							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 						},
@@ -78,13 +78,13 @@ func TestStateSuccessful(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListPodFunc = nil
+		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// trying with an inexistent id
 	err := state("123456789")
 	assert.Error(err)
 
-	err = state(pod.ID())
+	err = state(sandbox.ID())
 	assert.NoError(err)
 }

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// AgentType describes the type of guest agent a Pod should run.
+// AgentType describes the type of guest agent a Sandbox should run.
 type AgentType string
 
 // ProcessListOptions contains the options used to list running
@@ -105,8 +105,8 @@ func newAgent(agentType AgentType) agent {
 	}
 }
 
-// newAgentConfig returns an agent config from a generic PodConfig interface.
-func newAgentConfig(config PodConfig) interface{} {
+// newAgentConfig returns an agent config from a generic SandboxConfig interface.
+func newAgentConfig(config SandboxConfig) interface{} {
 	switch config.AgentType {
 	case NoopAgentType:
 		return nil
@@ -138,42 +138,42 @@ type agent interface {
 	// init().
 	// After init() is called, agent implementations should be initialized and ready
 	// to handle all other Agent interface methods.
-	init(pod *Pod, config interface{}) error
+	init(sandbox *Sandbox, config interface{}) error
 
 	// capabilities should return a structure that specifies the capabilities
 	// supported by the agent.
 	capabilities() capabilities
 
-	// createPod will tell the agent to perform necessary setup for a Pod.
-	createPod(pod *Pod) error
+	// createSandbox will tell the agent to perform necessary setup for a Sandbox.
+	createSandbox(sandbox *Sandbox) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(pod *Pod, c Container, cmd Cmd) (*Process, error)
+	exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error)
 
-	// startPod will tell the agent to start all containers related to the Pod.
-	startPod(pod Pod) error
+	// startSandbox will tell the agent to start all containers related to the Sandbox.
+	startSandbox(sandbox Sandbox) error
 
-	// stopPod will tell the agent to stop all containers related to the Pod.
-	stopPod(pod Pod) error
+	// stopSandbox will tell the agent to stop all containers related to the Sandbox.
+	stopSandbox(sandbox Sandbox) error
 
-	// createContainer will tell the agent to create a container related to a Pod.
-	createContainer(pod *Pod, c *Container) (*Process, error)
+	// createContainer will tell the agent to create a container related to a Sandbox.
+	createContainer(sandbox *Sandbox, c *Container) (*Process, error)
 
-	// startContainer will tell the agent to start a container related to a Pod.
-	startContainer(pod Pod, c *Container) error
+	// startContainer will tell the agent to start a container related to a Sandbox.
+	startContainer(sandbox Sandbox, c *Container) error
 
-	// stopContainer will tell the agent to stop a container related to a Pod.
-	stopContainer(pod Pod, c Container) error
+	// stopContainer will tell the agent to stop a container related to a Sandbox.
+	stopContainer(sandbox Sandbox, c Container) error
 
 	// killContainer will tell the agent to send a signal to a
-	// container related to a Pod. If all is true, all processes in
+	// container related to a Sandbox. If all is true, all processes in
 	// the container will be sent the signal.
-	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
+	killContainer(sandbox Sandbox, c Container, signal syscall.Signal, all bool) error
 
 	// processListContainer will list the processes running inside the container
-	processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error)
+	processListContainer(sandbox Sandbox, c Container, options ProcessListOptions) (ProcessList, error)
 
-	// onlineCPUMem will online CPUs and Memory inside the Pod.
+	// onlineCPUMem will online CPUs and Memory inside the Sandbox.
 	// This function should be called after hot adding vCPUs or Memory.
 	onlineCPUMem() error
 }

--- a/virtcontainers/agent_test.go
+++ b/virtcontainers/agent_test.go
@@ -109,7 +109,7 @@ func TestNewAgentFromUnknownAgentType(t *testing.T) {
 	testNewAgentFromAgentType(t, agentType, &noopAgent{})
 }
 
-func testNewAgentConfig(t *testing.T, config PodConfig, expected interface{}) {
+func testNewAgentConfig(t *testing.T, config SandboxConfig, expected interface{}) {
 	agentConfig := newAgentConfig(config)
 	if reflect.DeepEqual(agentConfig, expected) == false {
 		t.Fatal()
@@ -119,38 +119,38 @@ func testNewAgentConfig(t *testing.T, config PodConfig, expected interface{}) {
 func TestNewAgentConfigFromNoopAgentType(t *testing.T) {
 	var agentConfig interface{}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		AgentType:   NoopAgentType,
 		AgentConfig: agentConfig,
 	}
 
-	testNewAgentConfig(t, podConfig, agentConfig)
+	testNewAgentConfig(t, sandboxConfig, agentConfig)
 }
 
 func TestNewAgentConfigFromHyperstartAgentType(t *testing.T) {
 	agentConfig := HyperConfig{}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		AgentType:   HyperstartAgent,
 		AgentConfig: agentConfig,
 	}
 
-	testNewAgentConfig(t, podConfig, agentConfig)
+	testNewAgentConfig(t, sandboxConfig, agentConfig)
 }
 
 func TestNewAgentConfigFromKataAgentType(t *testing.T) {
 	agentConfig := KataAgentConfig{}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		AgentType:   KataContainersAgent,
 		AgentConfig: agentConfig,
 	}
 
-	testNewAgentConfig(t, podConfig, agentConfig)
+	testNewAgentConfig(t, sandboxConfig, agentConfig)
 }
 
 func TestNewAgentConfigFromUnknownAgentType(t *testing.T) {
 	var agentConfig interface{}
 
-	testNewAgentConfig(t, PodConfig{}, agentConfig)
+	testNewAgentConfig(t, SandboxConfig{}, agentConfig)
 }

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -35,9 +35,9 @@ const (
 	containerID = "1"
 )
 
-var podAnnotations = map[string]string{
-	"pod.foo":   "pod.bar",
-	"pod.hello": "pod.world",
+var sandboxAnnotations = map[string]string{
+	"sandbox.foo":   "sandbox.bar",
+	"sandbox.hello": "sandbox.world",
 }
 
 var containerAnnotations = map[string]string{
@@ -62,7 +62,7 @@ func newBasicTestCmd() Cmd {
 	return cmd
 }
 
-func newTestPodConfigNoop() PodConfig {
+func newTestSandboxConfigNoop() SandboxConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          containerID,
@@ -78,8 +78,8 @@ func newTestPodConfigNoop() PodConfig {
 		HypervisorPath: filepath.Join(testDir, testHypervisor),
 	}
 
-	podConfig := PodConfig{
-		ID:               testPodID,
+	sandboxConfig := SandboxConfig{
+		ID:               testSandboxID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -87,13 +87,13 @@ func newTestPodConfigNoop() PodConfig {
 
 		Containers: []ContainerConfig{container},
 
-		Annotations: podAnnotations,
+		Annotations: sandboxAnnotations,
 	}
 
-	return podConfig
+	return sandboxConfig
 }
 
-func newTestPodConfigHyperstartAgent() PodConfig {
+func newTestSandboxConfigHyperstartAgent() SandboxConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          containerID,
@@ -114,8 +114,8 @@ func newTestPodConfigHyperstartAgent() PodConfig {
 		SockTtyName: testHyperstartTtySocket,
 	}
 
-	podConfig := PodConfig{
-		ID:               testPodID,
+	sandboxConfig := SandboxConfig{
+		ID:               testSandboxID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -123,13 +123,13 @@ func newTestPodConfigHyperstartAgent() PodConfig {
 		AgentConfig: agentConfig,
 
 		Containers:  []ContainerConfig{container},
-		Annotations: podAnnotations,
+		Annotations: sandboxAnnotations,
 	}
 
-	return podConfig
+	return sandboxConfig
 }
 
-func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
+func newTestSandboxConfigHyperstartAgentCNINetwork() SandboxConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          containerID,
@@ -154,8 +154,8 @@ func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 		NumInterfaces: 1,
 	}
 
-	podConfig := PodConfig{
-		ID:               testPodID,
+	sandboxConfig := SandboxConfig{
+		ID:               testSandboxID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
@@ -166,13 +166,13 @@ func newTestPodConfigHyperstartAgentCNINetwork() PodConfig {
 		NetworkConfig: netConfig,
 
 		Containers:  []ContainerConfig{container},
-		Annotations: podAnnotations,
+		Annotations: sandboxAnnotations,
 	}
 
-	return podConfig
+	return sandboxConfig
 }
 
-func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
+func newTestSandboxConfigHyperstartAgentCNMNetwork() SandboxConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          containerID,
@@ -208,8 +208,8 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 		NumInterfaces: len(hooks.PreStartHooks),
 	}
 
-	podConfig := PodConfig{
-		ID:    testPodID,
+	sandboxConfig := SandboxConfig{
+		ID:    testSandboxID,
 		Hooks: hooks,
 
 		HypervisorType:   MockHypervisor,
@@ -222,13 +222,13 @@ func newTestPodConfigHyperstartAgentCNMNetwork() PodConfig {
 		NetworkConfig: netConfig,
 
 		Containers:  []ContainerConfig{container},
-		Annotations: podAnnotations,
+		Annotations: sandboxAnnotations,
 	}
 
-	return podConfig
+	return sandboxConfig
 }
 
-func newTestPodConfigKataAgent() PodConfig {
+func newTestSandboxConfigKataAgent() SandboxConfig {
 	// Sets the hypervisor configuration.
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:     filepath.Join(testDir, testKernel),
@@ -236,31 +236,31 @@ func newTestPodConfigKataAgent() PodConfig {
 		HypervisorPath: filepath.Join(testDir, testHypervisor),
 	}
 
-	podConfig := PodConfig{
-		ID:               testPodID,
+	sandboxConfig := SandboxConfig{
+		ID:               testSandboxID,
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
 		AgentType: KataContainersAgent,
 
-		Annotations: podAnnotations,
+		Annotations: sandboxAnnotations,
 	}
 
-	return podConfig
+	return sandboxConfig
 }
 
-func TestCreatePodNoopAgentSuccessful(t *testing.T) {
+func TestCreateSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,14 +278,14 @@ func testGenerateCCProxySockDir() (string, error) {
 	return dir, nil
 }
 
-func TestCreatePodHyperstartAgentSuccessful(t *testing.T) {
+func TestCreateSandboxHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -299,26 +299,26 @@ func TestCreatePodHyperstartAgentSuccessful(t *testing.T) {
 	proxy.Start()
 	defer proxy.Stop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCreatePodKataAgentSuccessful(t *testing.T) {
+func TestCreateSandboxKataAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigKataAgent()
+	config := newTestSandboxConfigKataAgent()
 
 	sockDir, err := testGenerateKataProxySockDir()
 	if err != nil {
@@ -340,64 +340,64 @@ func TestCreatePodKataAgentSuccessful(t *testing.T) {
 	}
 	defer kataProxyMock.Stop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCreatePodFailing(t *testing.T) {
+func TestCreateSandboxFailing(t *testing.T) {
 	cleanUp()
 
-	config := PodConfig{}
+	config := SandboxConfig{}
 
-	p, err := CreatePod(config)
-	if p.(*Pod) != nil || err == nil {
+	p, err := CreateSandbox(config)
+	if p.(*Sandbox) != nil || err == nil {
 		t.Fatal()
 	}
 }
 
-func TestDeletePodNoopAgentSuccessful(t *testing.T) {
+func TestDeleteSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = DeletePod(p.ID())
+	p, err = DeleteSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = os.Stat(podDir)
+	_, err = os.Stat(sandboxDir)
 	if err == nil {
 		t.Fatal()
 	}
 }
 
-func TestDeletePodHyperstartAgentSuccessful(t *testing.T) {
+func TestDeleteSandboxHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -411,36 +411,36 @@ func TestDeletePodHyperstartAgentSuccessful(t *testing.T) {
 	proxy.Start()
 	defer proxy.Stop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = DeletePod(p.ID())
+	p, err = DeleteSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = os.Stat(podDir)
+	_, err = os.Stat(sandboxDir)
 	if err == nil {
 		t.Fatal(err)
 	}
 }
 
-func TestDeletePodKataAgentSuccessful(t *testing.T) {
+func TestDeleteSandboxKataAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigKataAgent()
+	config := newTestSandboxConfigKataAgent()
 
 	sockDir, err := testGenerateKataProxySockDir()
 	if err != nil {
@@ -462,59 +462,59 @@ func TestDeletePodKataAgentSuccessful(t *testing.T) {
 	}
 	defer kataProxyMock.Stop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = DeletePod(p.ID())
+	p, err = DeleteSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = os.Stat(podDir)
+	_, err = os.Stat(sandboxDir)
 	if err == nil {
 		t.Fatal(err)
 	}
 }
 
-func TestDeletePodFailing(t *testing.T) {
+func TestDeleteSandboxFailing(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
-	os.Remove(podDir)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
+	os.Remove(sandboxDir)
 
-	p, err := DeletePod(testPodID)
+	p, err := DeleteSandbox(testSandboxID)
 	if p != nil || err == nil {
 		t.Fatal()
 	}
 }
 
-func TestStartPodNoopAgentSuccessful(t *testing.T) {
+func TestStartSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
+func TestStartSandboxHyperstartAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -531,25 +531,25 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestStartPodKataAgentSuccessful(t *testing.T) {
+func TestStartSandboxKataAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigKataAgent()
+	config := newTestSandboxConfigKataAgent()
 
 	sockDir, err := testGenerateKataProxySockDir()
 	if err != nil {
@@ -571,51 +571,51 @@ func TestStartPodKataAgentSuccessful(t *testing.T) {
 	}
 	defer kataProxyMock.Stop()
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestStartPodFailing(t *testing.T) {
+func TestStartSandboxFailing(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
-	os.Remove(podDir)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
+	os.Remove(sandboxDir)
 
-	p, err := StartPod(testPodID)
+	p, err := StartSandbox(testSandboxID)
 	if p != nil || err == nil {
 		t.Fatal()
 	}
 }
 
-func TestStopPodNoopAgentSuccessful(t *testing.T) {
+func TestStopSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	vp, err := StopPod(p.ID())
+	vp, err := StopSandbox(p.ID())
 	if vp == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestPauseThenResumePodNoopAgentSuccessful(t *testing.T) {
+func TestPauseThenResumeSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -628,17 +628,17 @@ func TestPauseThenResumePodNoopAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err = PausePod(p.ID())
+	p, err = PauseSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	expectedState := StatePaused
 
-	assert.Equal(t, pImpl.state.State, expectedState, "unexpected paused pod state")
+	assert.Equal(t, pImpl.state.State, expectedState, "unexpected paused sandbox state")
 
 	for i, c := range p.GetAllContainers() {
 		cImpl, ok := c.(*Container)
@@ -648,17 +648,17 @@ func TestPauseThenResumePodNoopAgentSuccessful(t *testing.T) {
 			fmt.Sprintf("paused container %d has unexpected state", i))
 	}
 
-	p, err = ResumePod(p.ID())
+	p, err = ResumeSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok = p.(*Pod)
+	pImpl, ok = p.(*Sandbox)
 	assert.True(t, ok)
 
 	expectedState = StateRunning
 
-	assert.Equal(t, pImpl.state.State, expectedState, "unexpected resumed pod state")
+	assert.Equal(t, pImpl.state.State, expectedState, "unexpected resumed sandbox state")
 
 	for i, c := range p.GetAllContainers() {
 		cImpl, ok := c.(*Container)
@@ -669,14 +669,14 @@ func TestPauseThenResumePodNoopAgentSuccessful(t *testing.T) {
 	}
 }
 
-func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
+func TestStopSandboxHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -693,25 +693,25 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = StopPod(p.ID())
+	p, err = StopSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStopPodKataAgentSuccessful(t *testing.T) {
+func TestStopSandboxKataAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigKataAgent()
+	config := newTestSandboxConfigKataAgent()
 
 	sockDir, err := testGenerateKataProxySockDir()
 	if err != nil {
@@ -733,54 +733,54 @@ func TestStopPodKataAgentSuccessful(t *testing.T) {
 	}
 	defer kataProxyMock.Stop()
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = StopPod(p.ID())
+	p, err = StopSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStopPodFailing(t *testing.T) {
+func TestStopSandboxFailing(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
-	os.Remove(podDir)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
+	os.Remove(sandboxDir)
 
-	p, err := StopPod(testPodID)
+	p, err := StopSandbox(testSandboxID)
 	if p != nil || err == nil {
 		t.Fatal()
 	}
 }
 
-func TestRunPodNoopAgentSuccessful(t *testing.T) {
+func TestRunSandboxNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := RunPod(config)
+	p, err := RunSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
+func TestRunSandboxHyperstartAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -797,31 +797,31 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, err := RunPod(config)
+	p, err := RunSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestRunPodKataAgentSuccessful(t *testing.T) {
+func TestRunSandboxKataAgentSuccessful(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigKataAgent()
+	config := newTestSandboxConfigKataAgent()
 
 	sockDir, err := testGenerateKataProxySockDir()
 	if err != nil {
@@ -843,67 +843,67 @@ func TestRunPodKataAgentSuccessful(t *testing.T) {
 	}
 	defer kataProxyMock.Stop()
 
-	p, err := RunPod(config)
+	p, err := RunSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestRunPodFailing(t *testing.T) {
+func TestRunSandboxFailing(t *testing.T) {
 	cleanUp()
 
-	config := PodConfig{}
+	config := SandboxConfig{}
 
-	p, err := RunPod(config)
+	p, err := RunSandbox(config)
 	if p != nil || err == nil {
 		t.Fatal()
 	}
 }
 
-func TestListPodSuccessful(t *testing.T) {
+func TestListSandboxSuccessful(t *testing.T) {
 	cleanUp()
 
 	os.RemoveAll(configStoragePath)
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = ListPod()
+	_, err = ListSandbox()
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestListPodNoPodDirectory(t *testing.T) {
+func TestListSandboxNoSandboxDirectory(t *testing.T) {
 	cleanUp()
 
 	os.RemoveAll(configStoragePath)
 
-	_, err := ListPod()
+	_, err := ListSandbox()
 	if err != nil {
-		t.Fatal(fmt.Sprintf("unexpected ListPod error from non-existent pod directory: %v", err))
+		t.Fatal(fmt.Sprintf("unexpected ListSandbox error from non-existent sandbox directory: %v", err))
 	}
 }
 
-func TestStatusPodSuccessfulStateReady(t *testing.T) {
+func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:        filepath.Join(testDir, testKernel),
 		ImagePath:         filepath.Join(testDir, testImage),
@@ -915,15 +915,15 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
-	expectedStatus := PodStatus{
-		ID: testPodID,
+	expectedStatus := SandboxStatus{
+		ID: testSandboxID,
 		State: State{
 			State: StateReady,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 		Agent:            NoopAgentType,
-		Annotations:      podAnnotations,
+		Annotations:      sandboxAnnotations,
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
@@ -937,12 +937,12 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 		},
 	}
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	status, err := StatusPod(p.ID())
+	status, err := StatusSandbox(p.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -952,14 +952,14 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 	expectedStatus.ContainersStatus[0].StartTime = status.ContainersStatus[0].StartTime
 
 	if reflect.DeepEqual(status, expectedStatus) == false {
-		t.Fatalf("Got pod status %v\n expecting %v", status, expectedStatus)
+		t.Fatalf("Got sandbox status %v\n expecting %v", status, expectedStatus)
 	}
 }
 
-func TestStatusPodSuccessfulStateRunning(t *testing.T) {
+func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:        filepath.Join(testDir, testKernel),
 		ImagePath:         filepath.Join(testDir, testImage),
@@ -971,15 +971,15 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
-	expectedStatus := PodStatus{
-		ID: testPodID,
+	expectedStatus := SandboxStatus{
+		ID: testSandboxID,
 		State: State{
 			State: StateRunning,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 		Agent:            NoopAgentType,
-		Annotations:      podAnnotations,
+		Annotations:      sandboxAnnotations,
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
@@ -993,17 +993,17 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 		},
 	}
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = StartPod(p.ID())
+	p, err = StartSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	status, err := StatusPod(p.ID())
+	status, err := StatusSandbox(p.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1013,47 +1013,47 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 	expectedStatus.ContainersStatus[0].StartTime = status.ContainersStatus[0].StartTime
 
 	if reflect.DeepEqual(status, expectedStatus) == false {
-		t.Fatalf("Got pod status %v\n expecting %v", status, expectedStatus)
+		t.Fatalf("Got sandbox status %v\n expecting %v", status, expectedStatus)
 	}
 }
 
-func TestStatusPodFailingFetchPodConfig(t *testing.T) {
+func TestStatusSandboxFailingFetchSandboxConfig(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
 	path := filepath.Join(configStoragePath, p.ID())
 	os.RemoveAll(path)
-	globalPodList.removePod(p.ID())
+	globalSandboxList.removeSandbox(p.ID())
 
-	_, err = StatusPod(p.ID())
+	_, err = StatusSandbox(p.ID())
 	if err == nil {
 		t.Fatal()
 	}
 }
 
-func TestStatusPodPodFailingFetchPodState(t *testing.T) {
+func TestStatusPodSandboxFailingFetchSandboxState(t *testing.T) {
 	cleanUp()
 
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	os.RemoveAll(pImpl.configPath)
-	globalPodList.removePod(p.ID())
+	globalSandboxList.removeSandbox(p.ID())
 
-	_, err = StatusPod(p.ID())
+	_, err = StatusSandbox(p.ID())
 	if err == nil {
 		t.Fatal()
 	}
@@ -1075,15 +1075,15 @@ func TestCreateContainerSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1095,31 +1095,31 @@ func TestCreateContainerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestCreateContainerFailingNoPod(t *testing.T) {
+func TestCreateContainerFailingNoSandbox(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = DeletePod(p.ID())
+	p, err = DeleteSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err == nil {
 		t.Fatal()
 	}
@@ -1136,15 +1136,15 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1156,7 +1156,7 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1173,14 +1173,14 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 	}
 }
 
-func TestDeleteContainerFailingNoPod(t *testing.T) {
+func TestDeleteContainerFailingNoSandbox(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
 	contID := "100"
-	os.RemoveAll(podDir)
+	os.RemoveAll(sandboxDir)
 
-	c, err := DeleteContainer(testPodID, contID)
+	c, err := DeleteContainer(testSandboxID, contID)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1190,15 +1190,15 @@ func TestDeleteContainerFailingNoContainer(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1213,9 +1213,9 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1226,7 +1226,7 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1238,14 +1238,14 @@ func TestStartContainerNoopAgentSuccessful(t *testing.T) {
 	}
 }
 
-func TestStartContainerFailingNoPod(t *testing.T) {
+func TestStartContainerFailingNoSandbox(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
 	contID := "100"
-	os.RemoveAll(podDir)
+	os.RemoveAll(sandboxDir)
 
-	c, err := StartContainer(testPodID, contID)
+	c, err := StartContainer(testSandboxID, contID)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1255,15 +1255,15 @@ func TestStartContainerFailingNoContainer(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1274,19 +1274,19 @@ func TestStartContainerFailingNoContainer(t *testing.T) {
 	}
 }
 
-func TestStartContainerFailingPodNotStarted(t *testing.T) {
+func TestStartContainerFailingSandboxNotStarted(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1298,7 +1298,7 @@ func TestStartContainerFailingPodNotStarted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1314,9 +1314,9 @@ func TestStopContainerNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1328,7 +1328,7 @@ func TestStopContainerNoopAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1353,7 +1353,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -1370,7 +1370,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1382,7 +1382,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1398,20 +1398,20 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
+func TestStartStopSandboxHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	cleanUp()
 
-	config := newTestPodConfigHyperstartAgentCNINetwork()
+	config := newTestSandboxConfigHyperstartAgentCNINetwork()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -1428,28 +1428,28 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = StopPod(p.ID())
+	p, err = StopSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = DeletePod(p.ID())
+	p, err = DeleteSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
+func TestStartStopSandboxHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
-	config := newTestPodConfigHyperstartAgentCNMNetwork()
+	config := newTestSandboxConfigHyperstartAgentCNMNetwork()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -1466,30 +1466,30 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, _, err := createAndStartPod(config)
+	p, _, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	v, err := StopPod(p.ID())
+	v, err := StopSandbox(p.ID())
 	if v == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	v, err = DeletePod(p.ID())
+	v, err = DeleteSandbox(p.ID())
 	if v == nil || err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStopContainerFailingNoPod(t *testing.T) {
+func TestStopContainerFailingNoSandbox(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
 	contID := "100"
-	os.RemoveAll(podDir)
+	os.RemoveAll(sandboxDir)
 
-	c, err := StopContainer(testPodID, contID)
+	c, err := StopContainer(testSandboxID, contID)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1499,15 +1499,15 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1522,9 +1522,9 @@ func testKillContainerFromContReadySuccessful(t *testing.T, signal syscall.Signa
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1536,7 +1536,7 @@ func testKillContainerFromContReadySuccessful(t *testing.T, signal syscall.Signa
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1562,9 +1562,9 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1576,7 +1576,7 @@ func TestEnterContainerNoopAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1603,7 +1603,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigHyperstartAgent()
+	config := newTestSandboxConfigHyperstartAgent()
 
 	sockDir, err := testGenerateCCProxySockDir()
 	if err != nil {
@@ -1620,7 +1620,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	hyperConfig := config.AgentConfig.(HyperConfig)
 	config.AgentConfig = hyperConfig
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1632,7 +1632,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1655,22 +1655,22 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
 }
 
-func TestEnterContainerFailingNoPod(t *testing.T) {
+func TestEnterContainerFailingNoSandbox(t *testing.T) {
 	cleanUp()
 
-	podDir := filepath.Join(configStoragePath, testPodID)
+	sandboxDir := filepath.Join(configStoragePath, testSandboxID)
 	contID := "100"
-	os.RemoveAll(podDir)
+	os.RemoveAll(sandboxDir)
 
 	cmd := newBasicTestCmd()
 
-	_, c, _, err := EnterContainer(testPodID, contID, cmd)
+	_, c, _, err := EnterContainer(testSandboxID, contID, cmd)
 	if c != nil || err == nil {
 		t.Fatal()
 	}
@@ -1680,15 +1680,15 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1705,9 +1705,9 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, podDir, err := createAndStartPod(config)
+	p, sandboxDir, err := createAndStartSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
@@ -1719,7 +1719,7 @@ func TestEnterContainerFailingContNotStarted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1737,15 +1737,15 @@ func TestStatusContainerSuccessful(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1757,7 +1757,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
@@ -1768,7 +1768,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	cImpl, ok := c.(*Container)
@@ -1788,15 +1788,15 @@ func TestStatusContainerStateReady(t *testing.T) {
 
 	// (homage to a great album! ;)
 	contID := "101"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1808,14 +1808,14 @@ func TestStatusContainerStateReady(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// fresh lookup
-	p2, err := fetchPod(p.ID())
+	p2, err := fetchSandbox(p.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1851,20 +1851,20 @@ func TestStatusContainerStateRunning(t *testing.T) {
 
 	// (homage to a great album! ;)
 	contID := "101"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	p, err = StartPod(p.ID())
+	p, err = StartSandbox(p.ID())
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	podDir := filepath.Join(configStoragePath, p.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir := filepath.Join(configStoragePath, p.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1881,14 +1881,14 @@ func TestStatusContainerStateRunning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contDir := filepath.Join(podDir, contID)
+	contDir := filepath.Join(sandboxDir, contID)
 	_, err = os.Stat(contDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// fresh lookup
-	p2, err := fetchPod(p.ID())
+	p2, err := fetchSandbox(p.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1923,18 +1923,18 @@ func TestStatusContainerFailing(t *testing.T) {
 	cleanUp()
 
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
 	os.RemoveAll(pImpl.configPath)
-	globalPodList.removePod(p.ID())
+	globalSandboxList.removeSandbox(p.ID())
 
 	_, err = StatusContainer(p.ID(), contID)
 	if err == nil {
@@ -1962,12 +1962,12 @@ func TestProcessListContainer(t *testing.T) {
 	_, err = ProcessListContainer("xyz", "xyz", options)
 	assert.Error(err)
 
-	config := newTestPodConfigNoop()
-	p, err := CreatePod(config)
+	config := newTestSandboxConfigNoop()
+	p, err := CreateSandbox(config)
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	pImpl, ok := p.(*Pod)
+	pImpl, ok := p.(*Sandbox)
 	assert.True(ok)
 	defer os.RemoveAll(pImpl.configPath)
 
@@ -1983,7 +1983,7 @@ func TestProcessListContainer(t *testing.T) {
 	assert.Error(err)
 
 	_, err = ProcessListContainer(pImpl.id, contID, options)
-	// Pod not running, impossible to ps the container
+	// Sandbox not running, impossible to ps the container
 	assert.Error(err)
 }
 
@@ -1991,7 +1991,7 @@ func TestProcessListContainer(t *testing.T) {
  * Benchmarks
  */
 
-func createNewPodConfig(hType HypervisorType, aType AgentType, aConfig interface{}, netModel NetworkModel) PodConfig {
+func createNewSandboxConfig(hType HypervisorType, aType AgentType, aConfig interface{}, netModel NetworkModel) SandboxConfig {
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:     "/usr/share/kata-containers/vmlinux.container",
 		ImagePath:      "/usr/share/kata-containers/kata-containers.img",
@@ -2002,8 +2002,8 @@ func createNewPodConfig(hType HypervisorType, aType AgentType, aConfig interface
 		NumInterfaces: 1,
 	}
 
-	return PodConfig{
-		ID:               testPodID,
+	return SandboxConfig{
+		ID:               testSandboxID,
 		HypervisorType:   hType,
 		HypervisorConfig: hypervisorConfig,
 
@@ -2051,62 +2051,62 @@ func createNewContainerConfigs(numOfContainers int) []ContainerConfig {
 	return contConfigs
 }
 
-// createAndStartPod handles the common test operation of creating and
-// starting a pod.
-func createAndStartPod(config PodConfig) (pod VCPod, podDir string,
+// createAndStartSandbox handles the common test operation of creating and
+// starting a sandbox.
+func createAndStartSandbox(config SandboxConfig) (sandbox VCSandbox, sandboxDir string,
 	err error) {
 
-	// Create pod
-	pod, err = CreatePod(config)
-	if pod == nil || err != nil {
+	// Create sandbox
+	sandbox, err = CreateSandbox(config)
+	if sandbox == nil || err != nil {
 		return nil, "", err
 	}
 
-	podDir = filepath.Join(configStoragePath, pod.ID())
-	_, err = os.Stat(podDir)
+	sandboxDir = filepath.Join(configStoragePath, sandbox.ID())
+	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		return nil, "", err
 	}
 
-	// Start pod
-	pod, err = StartPod(pod.ID())
-	if pod == nil || err != nil {
+	// Start sandbox
+	sandbox, err = StartSandbox(sandbox.ID())
+	if sandbox == nil || err != nil {
 		return nil, "", err
 	}
 
-	return pod, podDir, nil
+	return sandbox, sandboxDir, nil
 }
 
-func createStartStopDeletePod(b *testing.B, podConfig PodConfig) {
-	p, _, err := createAndStartPod(podConfig)
+func createStartStopDeleteSandbox(b *testing.B, sandboxConfig SandboxConfig) {
+	p, _, err := createAndStartSandbox(sandboxConfig)
 	if p == nil || err != nil {
-		b.Fatalf("Could not create and start pod: %s", err)
+		b.Fatalf("Could not create and start sandbox: %s", err)
 	}
 
-	// Stop pod
-	_, err = StopPod(p.ID())
+	// Stop sandbox
+	_, err = StopSandbox(p.ID())
 	if err != nil {
-		b.Fatalf("Could not stop pod: %s", err)
+		b.Fatalf("Could not stop sandbox: %s", err)
 	}
 
-	// Delete pod
-	_, err = DeletePod(p.ID())
+	// Delete sandbox
+	_, err = DeleteSandbox(p.ID())
 	if err != nil {
-		b.Fatalf("Could not delete pod: %s", err)
+		b.Fatalf("Could not delete sandbox: %s", err)
 	}
 }
 
-func createStartStopDeleteContainers(b *testing.B, podConfig PodConfig, contConfigs []ContainerConfig) {
-	// Create pod
-	p, err := CreatePod(podConfig)
+func createStartStopDeleteContainers(b *testing.B, sandboxConfig SandboxConfig, contConfigs []ContainerConfig) {
+	// Create sandbox
+	p, err := CreateSandbox(sandboxConfig)
 	if err != nil {
-		b.Fatalf("Could not create pod: %s", err)
+		b.Fatalf("Could not create sandbox: %s", err)
 	}
 
-	// Start pod
-	_, err = StartPod(p.ID())
+	// Start sandbox
+	_, err = StartSandbox(p.ID())
 	if err != nil {
-		b.Fatalf("Could not start pod: %s", err)
+		b.Fatalf("Could not start sandbox: %s", err)
 	}
 
 	// Create containers
@@ -2141,22 +2141,22 @@ func createStartStopDeleteContainers(b *testing.B, podConfig PodConfig, contConf
 		}
 	}
 
-	// Stop pod
-	_, err = StopPod(p.ID())
+	// Stop sandbox
+	_, err = StopSandbox(p.ID())
 	if err != nil {
-		b.Fatalf("Could not stop pod: %s", err)
+		b.Fatalf("Could not stop sandbox: %s", err)
 	}
 
-	// Delete pod
-	_, err = DeletePod(p.ID())
+	// Delete sandbox
+	_, err = DeleteSandbox(p.ID())
 	if err != nil {
-		b.Fatalf("Could not delete pod: %s", err)
+		b.Fatalf("Could not delete sandbox: %s", err)
 	}
 }
 
-func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkCNI(b *testing.B) {
+func BenchmarkCreateStartStopDeleteSandboxQemuHypervisorHyperstartAgentNetworkCNI(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, CNINetworkModel)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, CNINetworkModel)
 
 		sockDir, err := testGenerateCCProxySockDir()
 		if err != nil {
@@ -2171,20 +2171,20 @@ func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkCNI(b 
 		proxy.Start()
 		defer proxy.Stop()
 
-		createStartStopDeletePod(b, podConfig)
+		createStartStopDeleteSandbox(b, sandboxConfig)
 	}
 }
 
-func BenchmarkCreateStartStopDeletePodQemuHypervisorNoopAgentNetworkCNI(b *testing.B) {
+func BenchmarkCreateStartStopDeleteSandboxQemuHypervisorNoopAgentNetworkCNI(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, NoopAgentType, nil, CNINetworkModel)
-		createStartStopDeletePod(b, podConfig)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, NoopAgentType, nil, CNINetworkModel)
+		createStartStopDeleteSandbox(b, sandboxConfig)
 	}
 }
 
-func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
+func BenchmarkCreateStartStopDeleteSandboxQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 
 		sockDir, err := testGenerateCCProxySockDir()
 		if err != nil {
@@ -2199,27 +2199,27 @@ func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkNoop(b
 		proxy.Start()
 		defer proxy.Stop()
 
-		createStartStopDeletePod(b, podConfig)
+		createStartStopDeleteSandbox(b, sandboxConfig)
 	}
 }
 
-func BenchmarkCreateStartStopDeletePodQemuHypervisorNoopAgentNetworkNoop(b *testing.B) {
+func BenchmarkCreateStartStopDeleteSandboxQemuHypervisorNoopAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, NoopAgentType, nil, NoopNetworkModel)
-		createStartStopDeletePod(b, podConfig)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, NoopAgentType, nil, NoopNetworkModel)
+		createStartStopDeleteSandbox(b, sandboxConfig)
 	}
 }
 
-func BenchmarkCreateStartStopDeletePodMockHypervisorNoopAgentNetworkNoop(b *testing.B) {
+func BenchmarkCreateStartStopDeleteSandboxMockHypervisorNoopAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(MockHypervisor, NoopAgentType, nil, NoopNetworkModel)
-		createStartStopDeletePod(b, podConfig)
+		sandboxConfig := createNewSandboxConfig(MockHypervisor, NoopAgentType, nil, NoopNetworkModel)
+		createStartStopDeleteSandbox(b, sandboxConfig)
 	}
 }
 
 func BenchmarkStartStop1ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 		contConfigs := createNewContainerConfigs(1)
 
 		sockDir, err := testGenerateCCProxySockDir()
@@ -2235,13 +2235,13 @@ func BenchmarkStartStop1ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *tes
 		proxy.Start()
 		defer proxy.Stop()
 
-		createStartStopDeleteContainers(b, podConfig, contConfigs)
+		createStartStopDeleteContainers(b, sandboxConfig, contConfigs)
 	}
 }
 
 func BenchmarkStartStop10ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
+		sandboxConfig := createNewSandboxConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 		contConfigs := createNewContainerConfigs(10)
 
 		sockDir, err := testGenerateCCProxySockDir()
@@ -2257,6 +2257,6 @@ func BenchmarkStartStop10ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *te
 		proxy.Start()
 		defer proxy.Stop()
 
-		createStartStopDeleteContainers(b, podConfig, contConfigs)
+		createStartStopDeleteContainers(b, sandboxConfig, contConfigs)
 	}
 }

--- a/virtcontainers/asset.go
+++ b/virtcontainers/asset.go
@@ -115,8 +115,8 @@ func (a *asset) hash(hashType string) (string, error) {
 	return hash, nil
 }
 
-// newAsset returns a new asset from the pod annotations.
-func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
+// newAsset returns a new asset from the sandbox annotations.
+func newAsset(sandboxConfig *SandboxConfig, t assetType) (*asset, error) {
 	pathAnnotation, hashAnnotation, err := t.annotations()
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
 		return nil, fmt.Errorf("Missing annotation paths for %s", t)
 	}
 
-	path, ok := podConfig.Annotations[pathAnnotation]
+	path, ok := sandboxConfig.Annotations[pathAnnotation]
 	if !ok || path == "" {
 		return nil, nil
 	}
@@ -137,13 +137,13 @@ func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
 
 	a := &asset{path: path, kind: t}
 
-	hash, ok := podConfig.Annotations[hashAnnotation]
+	hash, ok := sandboxConfig.Annotations[hashAnnotation]
 	if !ok || hash == "" {
 		return a, nil
 	}
 
 	// We have a hash annotation, we need to verify the asset against it.
-	hashType, ok := podConfig.Annotations[annotations.AssetHashType]
+	hashType, ok := sandboxConfig.Annotations[annotations.AssetHashType]
 	if !ok {
 		virtLog.Warningf("Unrecognized hash type: %s, switching to %s", hashType, annotations.SHA512)
 		hashType = annotations.SHA512

--- a/virtcontainers/asset_test.go
+++ b/virtcontainers/asset_test.go
@@ -90,7 +90,7 @@ func TestAssetNew(t *testing.T) {
 	_, err = tmpfile.Write(assetContent)
 	assert.Nil(err)
 
-	p := &PodConfig{
+	p := &SandboxConfig{
 		Annotations: map[string]string{
 			annotations.KernelPath: tmpfile.Name(),
 			annotations.KernelHash: assetContentHash,
@@ -105,7 +105,7 @@ func TestAssetNew(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(assetContentHash, a.computedHash)
 
-	p = &PodConfig{
+	p = &SandboxConfig{
 		Annotations: map[string]string{
 			annotations.KernelPath: tmpfile.Name(),
 			annotations.KernelHash: assetContentWrongHash,

--- a/virtcontainers/cc_proxy.go
+++ b/virtcontainers/cc_proxy.go
@@ -24,14 +24,14 @@ type ccProxy struct {
 }
 
 // start is the proxy start implementation for ccProxy.
-func (p *ccProxy) start(pod Pod, params proxyParams) (int, string, error) {
-	config, err := newProxyConfig(pod.config)
+func (p *ccProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+	config, err := newProxyConfig(sandbox.config)
 	if err != nil {
 		return -1, "", err
 	}
 
 	// construct the socket path the proxy instance will use
-	proxyURL, err := defaultProxyURL(pod, SocketTypeUNIX)
+	proxyURL, err := defaultProxyURL(sandbox, SocketTypeUNIX)
 	if err != nil {
 		return -1, "", err
 	}
@@ -49,6 +49,6 @@ func (p *ccProxy) start(pod Pod, params proxyParams) (int, string, error) {
 	return cmd.Process.Pid, proxyURL, nil
 }
 
-func (p *ccProxy) stop(pod Pod, pid int) error {
+func (p *ccProxy) stop(sandbox Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -35,27 +35,27 @@ func TestCCProxyStart(t *testing.T) {
 	proxy := &ccProxy{}
 
 	type testData struct {
-		pod         Pod
+		sandbox     Sandbox
 		expectedURI string
 		expectError bool
 	}
 
 	invalidPath := filepath.Join(tmpdir, "enoent")
-	expectedSocketPath := filepath.Join(runStoragePath, testPodID, "proxy.sock")
+	expectedSocketPath := filepath.Join(runStoragePath, testSandboxID, "proxy.sock")
 	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
 
 	data := []testData{
-		{Pod{}, "", true},
+		{Sandbox{}, "", true},
 		{
-			Pod{
-				config: &PodConfig{
+			Sandbox{
+				config: &SandboxConfig{
 					ProxyType: "invalid",
 				},
 			}, "", true,
 		},
 		{
-			Pod{
-				config: &PodConfig{
+			Sandbox{
+				config: &SandboxConfig{
 					ProxyType:   CCProxyType,
 					ProxyConfig: ProxyConfig{
 					// invalid - no path
@@ -64,8 +64,8 @@ func TestCCProxyStart(t *testing.T) {
 			}, "", true,
 		},
 		{
-			Pod{
-				config: &PodConfig{
+			Sandbox{
+				config: &SandboxConfig{
 					ProxyType: CCProxyType,
 					ProxyConfig: ProxyConfig{
 						Path: invalidPath,
@@ -74,9 +74,9 @@ func TestCCProxyStart(t *testing.T) {
 			}, "", true,
 		},
 		{
-			Pod{
-				id: testPodID,
-				config: &PodConfig{
+			Sandbox{
+				id: testSandboxID,
+				config: &SandboxConfig{
 					ProxyType: CCProxyType,
 					ProxyConfig: ProxyConfig{
 						Path: "echo",
@@ -87,7 +87,7 @@ func TestCCProxyStart(t *testing.T) {
 	}
 
 	for _, d := range data {
-		pid, uri, err := proxy.start(d.pod, proxyParams{})
+		pid, uri, err := proxy.start(d.sandbox, proxyParams{})
 		if d.expectError {
 			assert.Error(err)
 			continue

--- a/virtcontainers/cc_shim.go
+++ b/virtcontainers/cc_shim.go
@@ -25,12 +25,12 @@ type ccShim struct{}
 // start is the ccShim start implementation.
 // It starts the cc-shim binary with URL and token flags provided by
 // the proxy.
-func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
-	if pod.config == nil {
-		return -1, fmt.Errorf("Pod config cannot be nil")
+func (s *ccShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+	if sandbox.config == nil {
+		return -1, fmt.Errorf("Sandbox config cannot be nil")
 	}
 
-	config, ok := newShimConfig(*(pod.config)).(ShimConfig)
+	config, ok := newShimConfig(*(sandbox.config)).(ShimConfig)
 	if !ok {
 		return -1, fmt.Errorf("Wrong shim config type, should be CCShimConfig type")
 	}

--- a/virtcontainers/cc_shim_test.go
+++ b/virtcontainers/cc_shim_test.go
@@ -46,65 +46,65 @@ func getMockCCShimBinPath() string {
 	return DefaultMockCCShimBinPath
 }
 
-func testCCShimStart(t *testing.T, pod Pod, params ShimParams, expectFail bool) {
+func testCCShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectFail bool) {
 	s := &ccShim{}
 
-	pid, err := s.start(pod, params)
+	pid, err := s.start(sandbox, params)
 	if expectFail {
 		if err == nil || pid != -1 {
-			t.Fatalf("This test should fail (pod %+v, params %+v, expectFail %t)",
-				pod, params, expectFail)
+			t.Fatalf("This test should fail (sandbox %+v, params %+v, expectFail %t)",
+				sandbox, params, expectFail)
 		}
 	} else {
 		if err != nil {
-			t.Fatalf("This test should pass (pod %+v, params %+v, expectFail %t): %s",
-				pod, params, expectFail, err)
+			t.Fatalf("This test should pass (sandbox %+v, params %+v, expectFail %t): %s",
+				sandbox, params, expectFail, err)
 		}
 
 		if pid == -1 {
-			t.Fatalf("This test should pass (pod %+v, params %+v, expectFail %t)",
-				pod, params, expectFail)
+			t.Fatalf("This test should pass (sandbox %+v, params %+v, expectFail %t)",
+				sandbox, params, expectFail)
 		}
 	}
 }
 
-func TestCCShimStartNilPodConfigFailure(t *testing.T) {
-	testCCShimStart(t, Pod{}, ShimParams{}, true)
+func TestCCShimStartNilSandboxConfigFailure(t *testing.T) {
+	testCCShimStart(t, Sandbox{}, ShimParams{}, true)
 }
 
 func TestCCShimStartNilShimConfigFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{},
+	sandbox := Sandbox{
+		config: &SandboxConfig{},
 	}
 
-	testCCShimStart(t, pod, ShimParams{}, true)
+	testCCShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestCCShimStartShimPathEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType:   CCShimType,
 			ShimConfig: ShimConfig{},
 		},
 	}
 
-	testCCShimStart(t, pod, ShimParams{}, true)
+	testCCShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestCCShimStartShimTypeInvalid(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType:   "foo",
 			ShimConfig: ShimConfig{},
 		},
 	}
 
-	testCCShimStart(t, pod, ShimParams{}, true)
+	testCCShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -112,12 +112,12 @@ func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
 		},
 	}
 
-	testCCShimStart(t, pod, ShimParams{}, true)
+	testCCShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -129,12 +129,12 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 		Token: "testToken",
 	}
 
-	testCCShimStart(t, pod, params, true)
+	testCCShimStart(t, sandbox, params, true)
 }
 
 func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -147,7 +147,7 @@ func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
 		URL:   "unix://is/awesome",
 	}
 
-	testCCShimStart(t, pod, params, true)
+	testCCShimStart(t, sandbox, params, true)
 }
 
 func TestCCShimStartParamsInvalidCommand(t *testing.T) {
@@ -159,8 +159,8 @@ func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 
 	cmd := filepath.Join(dir, "does-not-exist")
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: cmd,
@@ -173,20 +173,20 @@ func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 		URL:   "http://foo",
 	}
 
-	testCCShimStart(t, pod, params, true)
+	testCCShimStart(t, sandbox, params, true)
 }
 
-func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Pod, ShimParams, error) {
+func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Sandbox, ShimParams, error) {
 	saveStdout := os.Stdout
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {
-		return nil, nil, nil, Pod{}, ShimParams{}, err
+		return nil, nil, nil, Sandbox{}, ShimParams{}, err
 	}
 
 	os.Stdout = wStdout
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -201,11 +201,11 @@ func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.Fi
 		Detach:    detach,
 	}
 
-	return rStdout, wStdout, saveStdout, pod, params, nil
+	return rStdout, wStdout, saveStdout, sandbox, params, nil
 }
 
 func TestCCShimStartSuccessful(t *testing.T) {
-	rStdout, wStdout, saveStdout, pod, params, err := startCCShimStartWithoutConsoleSuccessful(t, false)
+	rStdout, wStdout, saveStdout, sandbox, params, err := startCCShimStartWithoutConsoleSuccessful(t, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestCCShimStartSuccessful(t *testing.T) {
 		wStdout.Close()
 	}()
 
-	testCCShimStart(t, pod, params, false)
+	testCCShimStart(t, sandbox, params, false)
 
 	bufStdout := make([]byte, 1024)
 	if _, err := rStdout.Read(bufStdout); err != nil {
@@ -229,7 +229,7 @@ func TestCCShimStartSuccessful(t *testing.T) {
 }
 
 func TestCCShimStartDetachSuccessful(t *testing.T) {
-	rStdout, wStdout, saveStdout, pod, params, err := startCCShimStartWithoutConsoleSuccessful(t, true)
+	rStdout, wStdout, saveStdout, sandbox, params, err := startCCShimStartWithoutConsoleSuccessful(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestCCShimStartDetachSuccessful(t *testing.T) {
 		rStdout.Close()
 	}()
 
-	testCCShimStart(t, pod, params, false)
+	testCCShimStart(t, sandbox, params, false)
 
 	readCh := make(chan error)
 	go func() {
@@ -270,8 +270,8 @@ func TestCCShimStartDetachSuccessful(t *testing.T) {
 }
 
 func TestCCShimStartWithConsoleNonExistingFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -285,7 +285,7 @@ func TestCCShimStartWithConsoleNonExistingFailure(t *testing.T) {
 		Console: testWrongConsolePath,
 	}
 
-	testCCShimStart(t, pod, params, true)
+	testCCShimStart(t, sandbox, params, true)
 }
 
 func ioctl(fd uintptr, flag, data uintptr) error {
@@ -346,8 +346,8 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockCCShimBinPath(),
@@ -362,6 +362,6 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 		Console:   console,
 	}
 
-	testCCShimStart(t, pod, params, false)
+	testCCShimStart(t, sandbox, params, false)
 	master.Close()
 }

--- a/virtcontainers/cnm.go
+++ b/virtcontainers/cnm.go
@@ -39,7 +39,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 }
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
-func (n *cnm) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
+func (n *cnm) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
 	endpoints, err := createEndpointsFromScan(netNsPath, config)
 	if err != nil {
 		return NetworkNamespace{}, err
@@ -51,7 +51,7 @@ func (n *cnm) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated 
 		Endpoints:    endpoints,
 	}
 
-	if err := addNetworkCommon(pod, &networkNS); err != nil {
+	if err := addNetworkCommon(sandbox, &networkNS); err != nil {
 		return NetworkNamespace{}, err
 	}
 
@@ -60,7 +60,7 @@ func (n *cnm) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated 
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNM network.
-func (n *cnm) remove(pod Pod, networkNS NetworkNamespace) error {
+func (n *cnm) remove(sandbox Sandbox, networkNS NetworkNamespace) error {
 	if err := removeNetworkCommon(networkNS); err != nil {
 		return err
 	}

--- a/virtcontainers/device.go
+++ b/virtcontainers/device.go
@@ -362,14 +362,14 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.ID = hex.EncodeToString(randBytes)
 
-	// Increment the block index for the pod. This is used to determine the name
+	// Increment the block index for the sandbox. This is used to determine the name
 	// for the block device in the case where the block device is used as container
 	// rootfs and the predicted block device name needs to be provided to the agent.
-	index, err := c.pod.getAndSetPodBlockIndex()
+	index, err := c.sandbox.getAndSetSandboxBlockIndex()
 
 	defer func() {
 		if err != nil {
-			c.pod.decrementPodBlockIndex()
+			c.sandbox.decrementSandboxBlockIndex()
 		}
 	}()
 
@@ -397,7 +397,7 @@ func (device *BlockDevice) attach(h hypervisor, c *Container) (err error) {
 
 	device.DeviceInfo.Hotplugged = true
 
-	if c.pod.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
+	if c.sandbox.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
 		device.VirtPath = filepath.Join("/dev", driveName)
 	} else {
 		scsiAddr, err := getSCSIAddress(index)

--- a/virtcontainers/device_test.go
+++ b/virtcontainers/device_test.go
@@ -326,12 +326,12 @@ func TestAttachBlockDevice(t *testing.T) {
 		BlockDeviceDriver: VirtioBlock,
 	}
 
-	config := &PodConfig{
+	config := &SandboxConfig{
 		HypervisorConfig: hConfig,
 	}
 
-	pod := &Pod{
-		id:         testPodID,
+	sandbox := &Sandbox{
+		id:         testSandboxID,
 		storage:    fs,
 		hypervisor: hypervisor,
 		config:     config,
@@ -339,12 +339,12 @@ func TestAttachBlockDevice(t *testing.T) {
 
 	contID := "100"
 	container := Container{
-		pod: pod,
-		id:  contID,
+		sandbox: sandbox,
+		id:      contID,
 	}
 
 	// create state file
-	path := filepath.Join(runStoragePath, testPodID, container.ID())
+	path := filepath.Join(runStoragePath, testSandboxID, container.ID())
 	err := os.MkdirAll(path, dirMode)
 	if err != nil {
 		t.Fatal(err)
@@ -386,7 +386,7 @@ func TestAttachBlockDevice(t *testing.T) {
 	err = device.detach(hypervisor)
 	assert.Nil(t, err)
 
-	container.pod.config.HypervisorConfig.BlockDeviceDriver = VirtioSCSI
+	container.sandbox.config.HypervisorConfig.BlockDeviceDriver = VirtioSCSI
 	err = device.attach(hypervisor, &container)
 	assert.Nil(t, err)
 

--- a/virtcontainers/doc.go
+++ b/virtcontainers/doc.go
@@ -17,12 +17,12 @@
 /*
 Package virtcontainers manages hardware virtualized containers.
 Each container belongs to a set of containers sharing the same networking
-namespace and storage, also known as a pod.
+namespace and storage, also known as a sandbox.
 
-Virtcontainers pods are hardware virtualized, i.e. they run on virtual machines.
-Virtcontainers will create one VM per pod, and containers will be created as
-processes within the pod VM.
+Virtcontainers sandboxes are hardware virtualized, i.e. they run on virtual machines.
+Virtcontainers will create one VM per sandbox, and containers will be created as
+processes within the sandbox VM.
 
-The virtcontainers package manages both pods and containers lifecycles.
+The virtcontainers package manages both sandboxes and containers lifecycles.
 */
 package virtcontainers

--- a/virtcontainers/documentation/api/1.0/api.md
+++ b/virtcontainers/documentation/api/1.0/api.md
@@ -1,38 +1,38 @@
 # virtcontainers 1.0 API
 
 The virtcontainers 1.0 API operates on two high level objects:
-[Pods](#pod-api) and [containers](#container-api):
+[Sandboxes](#sandbox-api) and [containers](#container-api):
 
-* [Pod API](#pod-api)
+* [Sandbox API](#sandbox-api)
 * [Container API](#container-api)
 * [Examples](#examples)
 
-## Pod API
+## Sandbox API
 
-The virtcontainers 1.0 pod API manages hardware virtualized
-[pod lifecycles](#pod-functions). The virtcontainers pod
+The virtcontainers 1.0 sandbox API manages hardware virtualized
+[sandbox lifecycles](#sandbox-functions). The virtcontainers sandbox
 semantics strictly follow the
-[Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod/) ones.
+[Kubernetes](https://kubernetes.io/docs/concepts/workloads/sandboxes/sandbox/) ones.
 
-The pod API allows callers to [create](#createpod), [delete](#deletepod),
-[start](#startpod), [stop](#stoppod), [run](#runpod), [pause](#pausepod),
-[resume](resumepod) and [list](#listpod) VM (Virtual Machine) based pods.
+The sandbox API allows callers to [create](#createsandbox), [delete](#deletesandbox),
+[start](#startsandbox), [stop](#stopsandbox), [run](#runsandbox), [pause](#pausesandbox),
+[resume](resumesandbox) and [list](#listsandbox) VM (Virtual Machine) based sandboxes.
 
-To initially create a pod, the API caller must prepare a
-[`PodConfig`](#podconfig) and pass it to either [`CreatePod`](#createpod)
-or [`RunPod`](#runpod). Upon successful pod creation, the virtcontainers
-API will return a [`VCPod`](#vcpod) interface back to the caller.
+To initially create a sandbox, the API caller must prepare a
+[`SandboxConfig`](#sandboxconfig) and pass it to either [`CreateSandbox`](#createsandbox)
+or [`RunSandbox`](#runsandbox). Upon successful sandbox creation, the virtcontainers
+API will return a [`VCSandbox`](#vcsandbox) interface back to the caller.
 
-The `VCPod` interface is a pod abstraction hiding the internal and private
-virtcontainers pod structure. It is a handle for API callers to manage the
-pod lifecycle through the rest of the [pod API](#pod-functions).
+The `VCSandbox` interface is a sandbox abstraction hiding the internal and private
+virtcontainers sandbox structure. It is a handle for API callers to manage the
+sandbox lifecycle through the rest of the [sandbox API](#sandbox-functions).
 
-* [Structures](#pod-structures)
-* [Functions](#pod-functions)
+* [Structures](#sandbox-structures)
+* [Functions](#sandbox-functions)
 
-### Pod Structures
+### Sandbox Structures
 
-* [PodConfig](#podconfig)
+* [SandboxConfig](#sandboxconfig)
   * [Resources](#resources)
   * [HypervisorType](#hypervisortype)
   * [HypervisorConfig](#hypervisorconfig)
@@ -48,12 +48,12 @@ pod lifecycle through the rest of the [pod API](#pod-functions).
     * [Cmd](#cmd)
     * [Mount](#mount)
     * [DeviceInfo](#deviceinfo)
-* [VCPod](#vcpod)
+* [VCSandbox](#vcsandbox)
 
-#### `PodConfig`
+#### `SandboxConfig`
 ```Go
-// PodConfig is a Pod configuration.
-type PodConfig struct {
+// SandboxConfig is a Sandbox configuration.
+type SandboxConfig struct {
 	ID string
 
 	Hostname string
@@ -61,7 +61,7 @@ type PodConfig struct {
 	// Field specific to OCI specs, needed to setup all the hooks
 	Hooks Hooks
 
-	// VMConfig is the VM configuration to set for this pod.
+	// VMConfig is the VM configuration to set for this sandbox.
 	VMConfig Resources
 
 	HypervisorType   HypervisorType
@@ -79,12 +79,12 @@ type PodConfig struct {
 	NetworkModel  NetworkModel
 	NetworkConfig NetworkConfig
 
-	// Volumes is a list of shared volumes between the host and the Pod.
+	// Volumes is a list of shared volumes between the host and the Sandbox.
 	Volumes []Volume
 
-	// Containers describe the list of containers within a Pod.
+	// Containers describe the list of containers within a Sandbox.
 	// This list can be empty and populated by adding containers
-	// to the Pod a posteriori.
+	// to the Sandbox a posteriori.
 	Containers []ContainerConfig
 
 	// Annotations keys must be unique strings and must be name-spaced
@@ -155,11 +155,11 @@ type HypervisorConfig struct {
 	Debug bool
 
 	// DefaultVCPUs specifies default number of vCPUs for the VM.
-	// Pod configuration VMConfig.VCPUs overwrites this.
+	// Sandbox configuration VMConfig.VCPUs overwrites this.
 	DefaultVCPUs uint32
 
 	// DefaultMem specifies default memory size in MiB for the VM.
-	// Pod configuration VMConfig.Memory overwrites this.
+	// Sandbox configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
 
 	// DefaultBridges specifies default number of bridges for the VM.
@@ -188,7 +188,7 @@ type HypervisorConfig struct {
 
 ##### `AgentType`
 ```Go
-// AgentType describes the type of guest agent a Pod should run.
+// AgentType describes the type of guest agent a Sandbox should run.
 type AgentType string
 
 const (
@@ -456,11 +456,11 @@ type DeviceInfo struct {
 }
 ```
 
-#### `VCPod`
+#### `VCSandbox`
 ```Go
-// VCPod is the Pod interface
-// (required since virtcontainers.Pod only contains private fields)
-type VCPod interface {
+// VCSandbox is the Sandbox interface
+// (required since virtcontainers.Sandbox only contains private fields)
+type VCSandbox interface {
 	Annotations(key string) (string, error)
 	GetAllContainers() []VCContainer
 	GetAnnotations() map[string]string
@@ -470,84 +470,84 @@ type VCPod interface {
 }
 ```
 
-### Pod Functions
+### Sandbox Functions
 
-* [CreatePod](#createpod)
-* [DeletePod](#deletepod)
-* [StartPod](#startpod)
-* [StopPod](#stoppod)
-* [RunPod](#runpod)
-* [ListPod](#listpod)
-* [StatusPod](#statuspod)
-* [PausePod](#pausepod)
-* [ResumePod](#resumepod)
+* [CreateSandbox](#createsandbox)
+* [DeleteSandbox](#deletesandbox)
+* [StartSandbox](#startsandbox)
+* [StopSandbox](#stopsandbox)
+* [RunSandbox](#runsandbox)
+* [ListSandbox](#listsandbox)
+* [StatusSandbox](#statussandbox)
+* [PauseSandbox](#pausesandbox)
+* [ResumeSandbox](#resumesandbox)
 
-#### `CreatePod`
+#### `CreateSandbox`
 ```Go
-// CreatePod is the virtcontainers pod creation entry point.
-// CreatePod creates a pod and its containers. It does not start them.
-func CreatePod(podConfig PodConfig) (VCPod, error)
+// CreateSandbox is the virtcontainers sandbox creation entry point.
+// CreateSandbox creates a sandbox and its containers. It does not start them.
+func CreateSandbox(sandboxConfig SandboxConfig) (VCSandbox, error)
 ```
 
-#### `DeletePod`
+#### `DeleteSandbox`
 ```Go
-// DeletePod is the virtcontainers pod deletion entry point.
-// DeletePod will stop an already running container and then delete it.
-func DeletePod(podID string) (VCPod, error)
+// DeleteSandbox is the virtcontainers sandbox deletion entry point.
+// DeleteSandbox will stop an already running container and then delete it.
+func DeleteSandbox(sandboxID string) (VCSandbox, error)
 ```
 
-#### `StartPod`
+#### `StartSandbox`
 ```Go
-// StartPod is the virtcontainers pod starting entry point.
-// StartPod will talk to the given hypervisor to start an existing
-// pod and all its containers.
-func StartPod(podID string) (VCPod, error)
+// StartSandbox is the virtcontainers sandbox starting entry point.
+// StartSandbox will talk to the given hypervisor to start an existing
+// sandbox and all its containers.
+func StartSandbox(sandboxID string) (VCSandbox, error)
 ```
 
-#### `StopPod`
+#### `StopSandbox`
 ```Go
-// StopPod is the virtcontainers pod stopping entry point.
-// StopPod will talk to the given agent to stop an existing pod
-// and destroy all containers within that pod.
-func StopPod(podID string) (VCPod, error)
+// StopSandbox is the virtcontainers sandbox stopping entry point.
+// StopSandbox will talk to the given agent to stop an existing sandbox
+// and destroy all containers within that sandbox.
+func StopSandbox(sandboxID string) (VCSandbox, error)
 ```
 
-#### `RunPod`
+#### `RunSandbox`
 ```Go
-// RunPod is the virtcontainers pod running entry point.
-// RunPod creates a pod and its containers and then it starts them.
-func RunPod(podConfig PodConfig) (VCPod, error)
+// RunSandbox is the virtcontainers sandbox running entry point.
+// RunSandbox creates a sandbox and its containers and then it starts them.
+func RunSandbox(sandboxConfig SandboxConfig) (VCSandbox, error)
 ```
 
-#### `ListPod`
+#### `ListSandbox`
 ```Go
-// ListPod is the virtcontainers pod listing entry point.
-func ListPod() ([]PodStatus, error)
+// ListSandbox is the virtcontainers sandbox listing entry point.
+func ListSandbox() ([]SandboxStatus, error)
 ```
 
-#### `StatusPod`
+#### `StatusSandbox`
 ```Go
-// StatusPod is the virtcontainers pod status entry point.
-func StatusPod(podID string) (PodStatus, error)
+// StatusSandbox is the virtcontainers sandbox status entry point.
+func StatusSandbox(sandboxID string) (SandboxStatus, error)
 ```
 
-#### `PausePod`
+#### `PauseSandbox`
 ```Go
-// PausePod is the virtcontainers pausing entry point which pauses an
-// already running pod.
-func PausePod(podID string) (VCPod, error)
+// PauseSandbox is the virtcontainers pausing entry point which pauses an
+// already running sandbox.
+func PauseSandbox(sandboxID string) (VCSandbox, error)
 ```
 
-#### `ResumePod`
+#### `ResumeSandbox`
 ```Go
-// ResumePod is the virtcontainers resuming entry point which resumes
-// (or unpauses) and already paused pod.
-func ResumePod(podID string) (VCPod, error)
+// ResumeSandbox is the virtcontainers resuming entry point which resumes
+// (or unpauses) and already paused sandbox.
+func ResumeSandbox(sandboxID string) (VCSandbox, error)
 ```
 
 ## Container API
 
-The virtcontainers 1.0 container API manages pod
+The virtcontainers 1.0 container API manages sandbox
 [container lifecycles](#container-functions).
 
 A virtcontainers container is process running inside a containerized
@@ -556,8 +556,8 @@ a virtcontainers container is just a regular container running inside a
 virtual machine's guest OS.
 
 A virtcontainers container always belong to one and only one
-virtcontainers pod, again following the
-[Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
+virtcontainers sandbox, again following the
+[Kubernetes](https://kubernetes.io/docs/concepts/workloads/sandboxes/sandbox-overview/)
 logic and semantics.
 
 The container API allows callers to [create](#createcontainer),
@@ -566,12 +566,12 @@ The container API allows callers to [create](#createcontainer),
 allows for running [additional processes](#entercontainer) inside a
 specific container.
 
-As a virtcontainers container is always linked to a pod, the entire container
-API always takes a pod ID as its first argument.
+As a virtcontainers container is always linked to a sandbox, the entire container
+API always takes a sandbox ID as its first argument.
 
 To create a container, the API caller must prepare a
 [`ContainerConfig`](#containerconfig) and pass it to
-[`CreateContainer`](#createcontainer) together with a pod ID. Upon successful
+[`CreateContainer`](#createcontainer) together with a sandbox ID. Upon successful
 container creation, the virtcontainers API will return a
 [`VCContainer`](#vccontainer) interface back to the caller.
 
@@ -729,10 +729,10 @@ type DeviceInfo struct {
 // Process gathers data related to a container process.
 type Process struct {
 	// Token is the process execution context ID. It must be
-	// unique per pod.
+	// unique per sandbox.
 	// Token is used to manipulate processes for containers
 	// that have not started yet, and later identify them
-	// uniquely within a pod.
+	// uniquely within a sandbox.
 	Token string
 
 	// Pid is the process ID as seen by the host software
@@ -786,7 +786,7 @@ type VCContainer interface {
 	GetPid() int
 	GetToken() string
 	ID() string
-	Pod() VCPod
+	Sandbox() VCSandbox
 	Process() Process
 	SetPid(pid int) error
 }
@@ -806,70 +806,70 @@ type VCContainer interface {
 #### `CreateContainer`
 ```Go
 // CreateContainer is the virtcontainers container creation entry point.
-// CreateContainer creates a container on a given pod.
-func CreateContainer(podID string, containerConfig ContainerConfig) (VCPod, VCContainer, error)
+// CreateContainer creates a container on a given sandbox.
+func CreateContainer(sandboxID string, containerConfig ContainerConfig) (VCSandbox, VCContainer, error)
 ```
 
 #### `DeleteContainer`
 ```Go
 // DeleteContainer is the virtcontainers container deletion entry point.
-// DeleteContainer deletes a Container from a Pod. If the container is running,
+// DeleteContainer deletes a Container from a Sandbox. If the container is running,
 // it needs to be stopped first.
-func DeleteContainer(podID, containerID string) (VCContainer, error)
+func DeleteContainer(sandboxID, containerID string) (VCContainer, error)
 ```
 
 #### `StartContainer`
 ```Go
 // StartContainer is the virtcontainers container starting entry point.
 // StartContainer starts an already created container.
-func StartContainer(podID, containerID string) (VCContainer, error)
+func StartContainer(sandboxID, containerID string) (VCContainer, error)
 ```
 
 #### `StopContainer`
 ```Go
 // StopContainer is the virtcontainers container stopping entry point.
 // StopContainer stops an already running container.
-func StopContainer(podID, containerID string) (VCContainer, error)
+func StopContainer(sandboxID, containerID string) (VCContainer, error)
 ```
 
 #### `EnterContainer`
 ```Go
 // EnterContainer is the virtcontainers container command execution entry point.
 // EnterContainer enters an already running container and runs a given command.
-func EnterContainer(podID, containerID string, cmd Cmd) (VCPod, VCContainer, *Process, error)
+func EnterContainer(sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error)
 ```
 
 #### `StatusContainer`
 ```Go
 // StatusContainer is the virtcontainers container status entry point.
 // StatusContainer returns a detailed container status.
-func StatusContainer(podID, containerID string) (ContainerStatus, error)
+func StatusContainer(sandboxID, containerID string) (ContainerStatus, error)
 ```
 
 #### `KillContainer`
 ```Go
 // KillContainer is the virtcontainers entry point to send a signal
-// to a container running inside a pod. If all is true, all processes in
+// to a container running inside a sandbox. If all is true, all processes in
 // the container will be sent the signal.
-func KillContainer(podID, containerID string, signal syscall.Signal, all bool) error
+func KillContainer(sandboxID, containerID string, signal syscall.Signal, all bool) error
 ```
 
 #### `ProcessListContainer`
 ```Go
 // ProcessListContainer is the virtcontainers entry point to list
 // processes running inside a container
-func ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error)
+func ProcessListContainer(sandboxID, containerID string, options ProcessListOptions) (ProcessList, error)
 ```
 
 ## Examples
 
-### Preparing and running a pod
+### Preparing and running a sandbox
 
 ```Go
 
-// This example creates and starts a single container pod,
+// This example creates and starts a single container sandbox,
 // using qemu as the hypervisor and hyperstart as the VM agent.
-func Example_createAndStartPod() {
+func Example_createAndStartSandbox() {
 	envs := []vc.EnvVar{
 		{
 			Var:   "PATH",
@@ -906,11 +906,11 @@ func Example_createAndStartPod() {
 		Memory: 1024,
 	}
 
-	// The pod configuration:
+	// The sandbox configuration:
 	// - One container
 	// - Hypervisor is QEMU
 	// - Agent is hyperstart
-	podConfig := vc.PodConfig{
+	sandboxConfig := vc.SandboxConfig{
 		VMConfig: vmConfig,
 
 		HypervisorType:   vc.QemuHypervisor,
@@ -922,9 +922,9 @@ func Example_createAndStartPod() {
 		Containers: []vc.ContainerConfig{container},
 	}
 
-	_, err := vc.RunPod(podConfig)
+	_, err := vc.RunSandbox(sandboxConfig)
 	if err != nil {
-		fmt.Printf("Could not run pod: %s", err)
+		fmt.Printf("Could not run sandbox: %s", err)
 	}
 
 	return

--- a/virtcontainers/errors.go
+++ b/virtcontainers/errors.go
@@ -22,10 +22,10 @@ import (
 
 // common error objects used for argument checking
 var (
-	errNeedPod         = errors.New("Pod must be specified")
-	errNeedPodID       = errors.New("Pod ID cannot be empty")
+	errNeedSandbox     = errors.New("Sandbox must be specified")
+	errNeedSandboxID   = errors.New("Sandbox ID cannot be empty")
 	errNeedContainerID = errors.New("Container ID cannot be empty")
 	errNeedFile        = errors.New("File cannot be empty")
 	errNeedState       = errors.New("State cannot be empty")
-	errInvalidResource = errors.New("Invalid pod resource")
+	errInvalidResource = errors.New("Invalid sandbox resource")
 )

--- a/virtcontainers/example_pod_run_test.go
+++ b/virtcontainers/example_pod_run_test.go
@@ -25,9 +25,9 @@ import (
 
 const containerRootfs = "/var/lib/container/bundle/"
 
-// This example creates and starts a single container pod,
+// This example creates and starts a single container sandbox,
 // using qemu as the hypervisor and hyperstart as the VM agent.
-func Example_createAndStartPod() {
+func Example_createAndStartSandbox() {
 	envs := []vc.EnvVar{
 		{
 			Var:   "PATH",
@@ -63,11 +63,11 @@ func Example_createAndStartPod() {
 		Memory: 1024,
 	}
 
-	// The pod configuration:
+	// The sandbox configuration:
 	// - One container
 	// - Hypervisor is QEMU
 	// - Agent is hyperstart
-	podConfig := vc.PodConfig{
+	sandboxConfig := vc.SandboxConfig{
 		VMConfig: vmConfig,
 
 		HypervisorType:   vc.QemuHypervisor,
@@ -79,9 +79,9 @@ func Example_createAndStartPod() {
 		Containers: []vc.ContainerConfig{container},
 	}
 
-	_, err := vc.RunPod(podConfig)
+	_, err := vc.RunSandbox(sandboxConfig)
 	if err != nil {
-		fmt.Printf("Could not run pod: %s", err)
+		fmt.Printf("Could not run sandbox: %s", err)
 	}
 
 	return

--- a/virtcontainers/filesystem.go
+++ b/virtcontainers/filesystem.go
@@ -26,32 +26,32 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// podResource is an int representing a pod resource type.
+// sandboxResource is an int representing a sandbox resource type.
 //
-// Note that some are specific to the pod itself and others can apply to
-// pods and containers.
-type podResource int
+// Note that some are specific to the sandbox itself and others can apply to
+// sandboxes and containers.
+type sandboxResource int
 
 const (
 	// configFileType represents a configuration file type
-	configFileType podResource = iota
+	configFileType sandboxResource = iota
 
 	// stateFileType represents a state file type
 	stateFileType
 
-	// networkFileType represents a network file type (pod only)
+	// networkFileType represents a network file type (sandbox only)
 	networkFileType
 
-	// hypervisorFileType represents a hypervisor file type (pod only)
+	// hypervisorFileType represents a hypervisor file type (sandbox only)
 	hypervisorFileType
 
-	// agentFileType represents an agent file type (pod only)
+	// agentFileType represents an agent file type (sandbox only)
 	agentFileType
 
 	// processFileType represents a process file type
 	processFileType
 
-	// lockFileType represents a lock file type (pod only)
+	// lockFileType represents a lock file type (sandbox only)
 	lockFileType
 
 	// mountsFileType represents a mount file type
@@ -61,13 +61,13 @@ const (
 	devicesFileType
 )
 
-// configFile is the file name used for every JSON pod configuration.
+// configFile is the file name used for every JSON sandbox configuration.
 const configFile = "config.json"
 
-// stateFile is the file name storing a pod state.
+// stateFile is the file name storing a sandbox state.
 const stateFile = "state.json"
 
-// networkFile is the file name storing a pod network.
+// networkFile is the file name storing a sandbox network.
 const networkFile = "network.json"
 
 // hypervisorFile is the file name storing a hypervisor's state.
@@ -79,7 +79,7 @@ const agentFile = "agent.json"
 // processFile is the file name storing a container process.
 const processFile = "process.json"
 
-// lockFile is the file name locking the usage of a pod.
+// lockFile is the file name locking the usage of a sandbox.
 const lockFileName = "lock"
 
 const mountsFile = "mounts.json"
@@ -91,55 +91,55 @@ const devicesFile = "devices.json"
 const dirMode = os.FileMode(0750) | os.ModeDir
 
 // storagePathSuffix is the suffix used for all storage paths
-const storagePathSuffix = "/virtcontainers/pods"
+const storagePathSuffix = "/virtcontainers/sandboxes"
 
-// configStoragePath is the pod configuration directory.
-// It will contain one config.json file for each created pod.
+// configStoragePath is the sandbox configuration directory.
+// It will contain one config.json file for each created sandbox.
 var configStoragePath = filepath.Join("/var/lib", storagePathSuffix)
 
-// runStoragePath is the pod runtime directory.
-// It will contain one state.json and one lock file for each created pod.
+// runStoragePath is the sandbox runtime directory.
+// It will contain one state.json and one lock file for each created sandbox.
 var runStoragePath = filepath.Join("/run", storagePathSuffix)
 
 // resourceStorage is the virtcontainers resources (configuration, state, etc...)
 // storage interface.
 // The default resource storage implementation is filesystem.
 type resourceStorage interface {
-	// Create all resources for a pod
-	createAllResources(pod Pod) error
+	// Create all resources for a sandbox
+	createAllResources(sandbox Sandbox) error
 
 	// Resources URIs functions return both the URI
 	// for the actual resource and the URI base.
-	containerURI(podID, containerID string, resource podResource) (string, string, error)
-	podURI(podID string, resource podResource) (string, string, error)
+	containerURI(sandboxID, containerID string, resource sandboxResource) (string, string, error)
+	sandboxURI(sandboxID string, resource sandboxResource) (string, string, error)
 
-	// Pod resources
-	storePodResource(podID string, resource podResource, data interface{}) error
-	deletePodResources(podID string, resources []podResource) error
-	fetchPodConfig(podID string) (PodConfig, error)
-	fetchPodState(podID string) (State, error)
-	fetchPodNetwork(podID string) (NetworkNamespace, error)
-	storePodNetwork(podID string, networkNS NetworkNamespace) error
+	// Sandbox resources
+	storeSandboxResource(sandboxID string, resource sandboxResource, data interface{}) error
+	deleteSandboxResources(sandboxID string, resources []sandboxResource) error
+	fetchSandboxConfig(sandboxID string) (SandboxConfig, error)
+	fetchSandboxState(sandboxID string) (State, error)
+	fetchSandboxNetwork(sandboxID string) (NetworkNamespace, error)
+	storeSandboxNetwork(sandboxID string, networkNS NetworkNamespace) error
 
 	// Hypervisor resources
-	fetchHypervisorState(podID string, state interface{}) error
-	storeHypervisorState(podID string, state interface{}) error
+	fetchHypervisorState(sandboxID string, state interface{}) error
+	storeHypervisorState(sandboxID string, state interface{}) error
 
 	// Agent resources
-	fetchAgentState(podID string, state interface{}) error
-	storeAgentState(podID string, state interface{}) error
+	fetchAgentState(sandboxID string, state interface{}) error
+	storeAgentState(sandboxID string, state interface{}) error
 
 	// Container resources
-	storeContainerResource(podID, containerID string, resource podResource, data interface{}) error
-	deleteContainerResources(podID, containerID string, resources []podResource) error
-	fetchContainerConfig(podID, containerID string) (ContainerConfig, error)
-	fetchContainerState(podID, containerID string) (State, error)
-	fetchContainerProcess(podID, containerID string) (Process, error)
-	storeContainerProcess(podID, containerID string, process Process) error
-	fetchContainerMounts(podID, containerID string) ([]Mount, error)
-	storeContainerMounts(podID, containerID string, mounts []Mount) error
-	fetchContainerDevices(podID, containerID string) ([]Device, error)
-	storeContainerDevices(podID, containerID string, devices []Device) error
+	storeContainerResource(sandboxID, containerID string, resource sandboxResource, data interface{}) error
+	deleteContainerResources(sandboxID, containerID string, resources []sandboxResource) error
+	fetchContainerConfig(sandboxID, containerID string) (ContainerConfig, error)
+	fetchContainerState(sandboxID, containerID string) (State, error)
+	fetchContainerProcess(sandboxID, containerID string) (Process, error)
+	storeContainerProcess(sandboxID, containerID string, process Process) error
+	fetchContainerMounts(sandboxID, containerID string) ([]Mount, error)
+	storeContainerMounts(sandboxID, containerID string, mounts []Mount) error
+	fetchContainerDevices(sandboxID, containerID string) ([]Device, error)
+	storeContainerDevices(sandboxID, containerID string, devices []Device) error
 }
 
 // filesystem is a resourceStorage interface implementation for a local filesystem.
@@ -151,37 +151,37 @@ func (fs *filesystem) Logger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "filesystem")
 }
 
-func (fs *filesystem) createAllResources(pod Pod) (err error) {
-	for _, resource := range []podResource{stateFileType, configFileType} {
-		_, path, _ := fs.podURI(pod.id, resource)
+func (fs *filesystem) createAllResources(sandbox Sandbox) (err error) {
+	for _, resource := range []sandboxResource{stateFileType, configFileType} {
+		_, path, _ := fs.sandboxURI(sandbox.id, resource)
 		err = os.MkdirAll(path, dirMode)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, container := range pod.containers {
-		for _, resource := range []podResource{stateFileType, configFileType} {
-			_, path, _ := fs.containerURI(pod.id, container.id, resource)
+	for _, container := range sandbox.containers {
+		for _, resource := range []sandboxResource{stateFileType, configFileType} {
+			_, path, _ := fs.containerURI(sandbox.id, container.id, resource)
 			err = os.MkdirAll(path, dirMode)
 			if err != nil {
-				fs.deletePodResources(pod.id, nil)
+				fs.deleteSandboxResources(sandbox.id, nil)
 				return err
 			}
 		}
 	}
 
-	podlockFile, _, err := fs.podURI(pod.id, lockFileType)
+	sandboxlockFile, _, err := fs.sandboxURI(sandbox.id, lockFileType)
 	if err != nil {
-		fs.deletePodResources(pod.id, nil)
+		fs.deleteSandboxResources(sandbox.id, nil)
 		return err
 	}
 
-	_, err = os.Stat(podlockFile)
+	_, err = os.Stat(sandboxlockFile)
 	if err != nil {
-		lockFile, err := os.Create(podlockFile)
+		lockFile, err := os.Create(sandboxlockFile)
 		if err != nil {
-			fs.deletePodResources(pod.id, nil)
+			fs.deleteSandboxResources(sandbox.id, nil)
 			return err
 		}
 		lockFile.Close()
@@ -262,7 +262,7 @@ func (fs *filesystem) storeDeviceFile(file string, data interface{}) error {
 	return nil
 }
 
-func (fs *filesystem) fetchFile(file string, resource podResource, data interface{}) error {
+func (fs *filesystem) fetchFile(file string, resource sandboxResource, data interface{}) error {
 	if file == "" {
 		return errNeedFile
 	}
@@ -332,27 +332,27 @@ func (fs *filesystem) fetchDeviceFile(fileData []byte, devices *[]Device) error 
 }
 
 // resourceNeedsContainerID determines if the specified
-// podResource needs a containerID. Since some podResources can
-// be used for both pods and containers, it is necessary to specify
-// whether the resource is being used in a pod-specific context using
-// the podSpecific parameter.
-func resourceNeedsContainerID(podSpecific bool, resource podResource) bool {
+// sandboxResource needs a containerID. Since some sandboxResources can
+// be used for both sandboxes and containers, it is necessary to specify
+// whether the resource is being used in a sandbox-specific context using
+// the sandboxSpecific parameter.
+func resourceNeedsContainerID(sandboxSpecific bool, resource sandboxResource) bool {
 
 	switch resource {
 	case lockFileType, networkFileType, hypervisorFileType, agentFileType:
-		// pod-specific resources
+		// sandbox-specific resources
 		return false
 	default:
-		return !podSpecific
+		return !sandboxSpecific
 	}
 }
 
-func resourceDir(podSpecific bool, podID, containerID string, resource podResource) (string, error) {
-	if podID == "" {
-		return "", errNeedPodID
+func resourceDir(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource) (string, error) {
+	if sandboxID == "" {
+		return "", errNeedSandboxID
 	}
 
-	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
+	if resourceNeedsContainerID(sandboxSpecific, resource) == true && containerID == "" {
 		return "", errNeedContainerID
 	}
 
@@ -369,23 +369,23 @@ func resourceDir(podSpecific bool, podID, containerID string, resource podResour
 		return "", errInvalidResource
 	}
 
-	dirPath := filepath.Join(path, podID, containerID)
+	dirPath := filepath.Join(path, sandboxID, containerID)
 
 	return dirPath, nil
 }
 
-// If podSpecific is true, the resource is being applied for an empty
-// pod (meaning containerID may be blank).
+// If sandboxSpecific is true, the resource is being applied for an empty
+// sandbox (meaning containerID may be blank).
 // Note that this function defers determining if containerID can be
 // blank to resourceDIR()
-func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, resource podResource) (string, string, error) {
-	if podID == "" {
-		return "", "", errNeedPodID
+func (fs *filesystem) resourceURI(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource) (string, string, error) {
+	if sandboxID == "" {
+		return "", "", errNeedSandboxID
 	}
 
 	var filename string
 
-	dirPath, err := resourceDir(podSpecific, podID, containerID, resource)
+	dirPath, err := resourceDir(sandboxSpecific, sandboxID, containerID, resource)
 	if err != nil {
 		return "", "", err
 	}
@@ -422,30 +422,30 @@ func (fs *filesystem) resourceURI(podSpecific bool, podID, containerID string, r
 	return filePath, dirPath, nil
 }
 
-func (fs *filesystem) containerURI(podID, containerID string, resource podResource) (string, string, error) {
-	if podID == "" {
-		return "", "", errNeedPodID
+func (fs *filesystem) containerURI(sandboxID, containerID string, resource sandboxResource) (string, string, error) {
+	if sandboxID == "" {
+		return "", "", errNeedSandboxID
 	}
 
 	if containerID == "" {
 		return "", "", errNeedContainerID
 	}
 
-	return fs.resourceURI(false, podID, containerID, resource)
+	return fs.resourceURI(false, sandboxID, containerID, resource)
 }
 
-func (fs *filesystem) podURI(podID string, resource podResource) (string, string, error) {
-	return fs.resourceURI(true, podID, "", resource)
+func (fs *filesystem) sandboxURI(sandboxID string, resource sandboxResource) (string, string, error) {
+	return fs.resourceURI(true, sandboxID, "", resource)
 }
 
 // commonResourceChecks performs basic checks common to both setting and
-// getting a podResource.
-func (fs *filesystem) commonResourceChecks(podSpecific bool, podID, containerID string, resource podResource) error {
-	if podID == "" {
-		return errNeedPodID
+// getting a sandboxResource.
+func (fs *filesystem) commonResourceChecks(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource) error {
+	if sandboxID == "" {
+		return errNeedSandboxID
 	}
 
-	if resourceNeedsContainerID(podSpecific, resource) == true && containerID == "" {
+	if resourceNeedsContainerID(sandboxSpecific, resource) == true && containerID == "" {
 		return errNeedContainerID
 	}
 
@@ -465,12 +465,12 @@ func (fs *filesystem) commonResourceChecks(podSpecific bool, podID, containerID 
 	return nil
 }
 
-func (fs *filesystem) storePodAndContainerConfigResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeSandboxAndContainerConfigResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != configFileType {
 		return errInvalidResource
 	}
 
-	configFile, _, err := fs.resourceURI(podSpecific, podID, containerID, configFileType)
+	configFile, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, configFileType)
 	if err != nil {
 		return err
 	}
@@ -478,12 +478,12 @@ func (fs *filesystem) storePodAndContainerConfigResource(podSpecific bool, podID
 	return fs.storeFile(configFile, file)
 }
 
-func (fs *filesystem) storeStateResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeStateResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != stateFileType {
 		return errInvalidResource
 	}
 
-	stateFile, _, err := fs.resourceURI(podSpecific, podID, containerID, stateFileType)
+	stateFile, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, stateFileType)
 	if err != nil {
 		return err
 	}
@@ -491,13 +491,13 @@ func (fs *filesystem) storeStateResource(podSpecific bool, podID, containerID st
 	return fs.storeFile(stateFile, file)
 }
 
-func (fs *filesystem) storeNetworkResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeNetworkResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != networkFileType {
 		return errInvalidResource
 	}
 
-	// pod only resource
-	networkFile, _, err := fs.resourceURI(true, podID, containerID, networkFileType)
+	// sandbox only resource
+	networkFile, _, err := fs.resourceURI(true, sandboxID, containerID, networkFileType)
 	if err != nil {
 		return err
 	}
@@ -505,12 +505,12 @@ func (fs *filesystem) storeNetworkResource(podSpecific bool, podID, containerID 
 	return fs.storeFile(networkFile, file)
 }
 
-func (fs *filesystem) storeProcessResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeProcessResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != processFileType {
 		return errInvalidResource
 	}
 
-	processFile, _, err := fs.resourceURI(podSpecific, podID, containerID, processFileType)
+	processFile, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, processFileType)
 	if err != nil {
 		return err
 	}
@@ -518,12 +518,12 @@ func (fs *filesystem) storeProcessResource(podSpecific bool, podID, containerID 
 	return fs.storeFile(processFile, file)
 }
 
-func (fs *filesystem) storeMountResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeMountResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != mountsFileType {
 		return errInvalidResource
 	}
 
-	mountsFile, _, err := fs.resourceURI(podSpecific, podID, containerID, mountsFileType)
+	mountsFile, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, mountsFileType)
 	if err != nil {
 		return err
 	}
@@ -531,12 +531,12 @@ func (fs *filesystem) storeMountResource(podSpecific bool, podID, containerID st
 	return fs.storeFile(mountsFile, file)
 }
 
-func (fs *filesystem) storeDeviceResource(podSpecific bool, podID, containerID string, resource podResource, file interface{}) error {
+func (fs *filesystem) storeDeviceResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, file interface{}) error {
 	if resource != devicesFileType {
 		return errInvalidResource
 	}
 
-	devicesFile, _, err := fs.resourceURI(podSpecific, podID, containerID, devicesFileType)
+	devicesFile, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, devicesFileType)
 	if err != nil {
 		return err
 	}
@@ -544,41 +544,41 @@ func (fs *filesystem) storeDeviceResource(podSpecific bool, podID, containerID s
 	return fs.storeDeviceFile(devicesFile, file)
 }
 
-func (fs *filesystem) storeResource(podSpecific bool, podID, containerID string, resource podResource, data interface{}) error {
-	if err := fs.commonResourceChecks(podSpecific, podID, containerID, resource); err != nil {
+func (fs *filesystem) storeResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, data interface{}) error {
+	if err := fs.commonResourceChecks(sandboxSpecific, sandboxID, containerID, resource); err != nil {
 		return err
 	}
 
 	switch file := data.(type) {
-	case PodConfig, ContainerConfig:
-		return fs.storePodAndContainerConfigResource(podSpecific, podID, containerID, resource, file)
+	case SandboxConfig, ContainerConfig:
+		return fs.storeSandboxAndContainerConfigResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case State:
-		return fs.storeStateResource(podSpecific, podID, containerID, resource, file)
+		return fs.storeStateResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case NetworkNamespace:
-		return fs.storeNetworkResource(podSpecific, podID, containerID, resource, file)
+		return fs.storeNetworkResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case Process:
-		return fs.storeProcessResource(podSpecific, podID, containerID, resource, file)
+		return fs.storeProcessResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case []Mount:
-		return fs.storeMountResource(podSpecific, podID, containerID, resource, file)
+		return fs.storeMountResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case []Device:
-		return fs.storeDeviceResource(podSpecific, podID, containerID, resource, file)
+		return fs.storeDeviceResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	default:
 		return fmt.Errorf("Invalid resource data type")
 	}
 }
 
-func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string, resource podResource, data interface{}) error {
-	if err := fs.commonResourceChecks(podSpecific, podID, containerID, resource); err != nil {
+func (fs *filesystem) fetchResource(sandboxSpecific bool, sandboxID, containerID string, resource sandboxResource, data interface{}) error {
+	if err := fs.commonResourceChecks(sandboxSpecific, sandboxID, containerID, resource); err != nil {
 		return err
 	}
 
-	path, _, err := fs.resourceURI(podSpecific, podID, containerID, resource)
+	path, _, err := fs.resourceURI(sandboxSpecific, sandboxID, containerID, resource)
 	if err != nil {
 		return err
 	}
@@ -586,54 +586,54 @@ func (fs *filesystem) fetchResource(podSpecific bool, podID, containerID string,
 	return fs.fetchFile(path, resource, data)
 }
 
-func (fs *filesystem) storePodResource(podID string, resource podResource, data interface{}) error {
-	return fs.storeResource(true, podID, "", resource, data)
+func (fs *filesystem) storeSandboxResource(sandboxID string, resource sandboxResource, data interface{}) error {
+	return fs.storeResource(true, sandboxID, "", resource, data)
 }
 
-func (fs *filesystem) fetchPodConfig(podID string) (PodConfig, error) {
-	var podConfig PodConfig
+func (fs *filesystem) fetchSandboxConfig(sandboxID string) (SandboxConfig, error) {
+	var sandboxConfig SandboxConfig
 
-	if err := fs.fetchResource(true, podID, "", configFileType, &podConfig); err != nil {
-		return PodConfig{}, err
+	if err := fs.fetchResource(true, sandboxID, "", configFileType, &sandboxConfig); err != nil {
+		return SandboxConfig{}, err
 	}
 
-	return podConfig, nil
+	return sandboxConfig, nil
 }
 
-func (fs *filesystem) fetchPodState(podID string) (State, error) {
+func (fs *filesystem) fetchSandboxState(sandboxID string) (State, error) {
 	var state State
 
-	if err := fs.fetchResource(true, podID, "", stateFileType, &state); err != nil {
+	if err := fs.fetchResource(true, sandboxID, "", stateFileType, &state); err != nil {
 		return State{}, err
 	}
 
 	return state, nil
 }
 
-func (fs *filesystem) fetchPodNetwork(podID string) (NetworkNamespace, error) {
+func (fs *filesystem) fetchSandboxNetwork(sandboxID string) (NetworkNamespace, error) {
 	var networkNS NetworkNamespace
 
-	if err := fs.fetchResource(true, podID, "", networkFileType, &networkNS); err != nil {
+	if err := fs.fetchResource(true, sandboxID, "", networkFileType, &networkNS); err != nil {
 		return NetworkNamespace{}, err
 	}
 
 	return networkNS, nil
 }
 
-func (fs *filesystem) fetchHypervisorState(podID string, state interface{}) error {
-	return fs.fetchResource(true, podID, "", hypervisorFileType, state)
+func (fs *filesystem) fetchHypervisorState(sandboxID string, state interface{}) error {
+	return fs.fetchResource(true, sandboxID, "", hypervisorFileType, state)
 }
 
-func (fs *filesystem) fetchAgentState(podID string, state interface{}) error {
-	return fs.fetchResource(true, podID, "", agentFileType, state)
+func (fs *filesystem) fetchAgentState(sandboxID string, state interface{}) error {
+	return fs.fetchResource(true, sandboxID, "", agentFileType, state)
 }
 
-func (fs *filesystem) storePodNetwork(podID string, networkNS NetworkNamespace) error {
-	return fs.storePodResource(podID, networkFileType, networkNS)
+func (fs *filesystem) storeSandboxNetwork(sandboxID string, networkNS NetworkNamespace) error {
+	return fs.storeSandboxResource(sandboxID, networkFileType, networkNS)
 }
 
-func (fs *filesystem) storeHypervisorState(podID string, state interface{}) error {
-	hypervisorFile, _, err := fs.resourceURI(true, podID, "", hypervisorFileType)
+func (fs *filesystem) storeHypervisorState(sandboxID string, state interface{}) error {
+	hypervisorFile, _, err := fs.resourceURI(true, sandboxID, "", hypervisorFileType)
 	if err != nil {
 		return err
 	}
@@ -641,8 +641,8 @@ func (fs *filesystem) storeHypervisorState(podID string, state interface{}) erro
 	return fs.storeFile(hypervisorFile, state)
 }
 
-func (fs *filesystem) storeAgentState(podID string, state interface{}) error {
-	agentFile, _, err := fs.resourceURI(true, podID, "", agentFileType)
+func (fs *filesystem) storeAgentState(sandboxID string, state interface{}) error {
+	agentFile, _, err := fs.resourceURI(true, sandboxID, "", agentFileType)
 	if err != nil {
 		return err
 	}
@@ -650,13 +650,13 @@ func (fs *filesystem) storeAgentState(podID string, state interface{}) error {
 	return fs.storeFile(agentFile, state)
 }
 
-func (fs *filesystem) deletePodResources(podID string, resources []podResource) error {
+func (fs *filesystem) deleteSandboxResources(sandboxID string, resources []sandboxResource) error {
 	if resources == nil {
-		resources = []podResource{configFileType, stateFileType}
+		resources = []sandboxResource{configFileType, stateFileType}
 	}
 
 	for _, resource := range resources {
-		_, dir, err := fs.podURI(podID, resource)
+		_, dir, err := fs.sandboxURI(sandboxID, resource)
 		if err != nil {
 			return err
 		}
@@ -670,87 +670,87 @@ func (fs *filesystem) deletePodResources(podID string, resources []podResource) 
 	return nil
 }
 
-func (fs *filesystem) storeContainerResource(podID, containerID string, resource podResource, data interface{}) error {
-	if podID == "" {
-		return errNeedPodID
+func (fs *filesystem) storeContainerResource(sandboxID, containerID string, resource sandboxResource, data interface{}) error {
+	if sandboxID == "" {
+		return errNeedSandboxID
 	}
 
 	if containerID == "" {
 		return errNeedContainerID
 	}
 
-	return fs.storeResource(false, podID, containerID, resource, data)
+	return fs.storeResource(false, sandboxID, containerID, resource, data)
 }
 
-func (fs *filesystem) fetchContainerConfig(podID, containerID string) (ContainerConfig, error) {
+func (fs *filesystem) fetchContainerConfig(sandboxID, containerID string) (ContainerConfig, error) {
 	var config ContainerConfig
 
-	if err := fs.fetchResource(false, podID, containerID, configFileType, &config); err != nil {
+	if err := fs.fetchResource(false, sandboxID, containerID, configFileType, &config); err != nil {
 		return ContainerConfig{}, err
 	}
 
 	return config, nil
 }
 
-func (fs *filesystem) fetchContainerState(podID, containerID string) (State, error) {
+func (fs *filesystem) fetchContainerState(sandboxID, containerID string) (State, error) {
 	var state State
 
-	if err := fs.fetchResource(false, podID, containerID, stateFileType, &state); err != nil {
+	if err := fs.fetchResource(false, sandboxID, containerID, stateFileType, &state); err != nil {
 		return State{}, err
 	}
 
 	return state, nil
 }
 
-func (fs *filesystem) fetchContainerProcess(podID, containerID string) (Process, error) {
+func (fs *filesystem) fetchContainerProcess(sandboxID, containerID string) (Process, error) {
 	var process Process
 
-	if err := fs.fetchResource(false, podID, containerID, processFileType, &process); err != nil {
+	if err := fs.fetchResource(false, sandboxID, containerID, processFileType, &process); err != nil {
 		return Process{}, err
 	}
 
 	return process, nil
 }
 
-func (fs *filesystem) storeContainerProcess(podID, containerID string, process Process) error {
-	return fs.storeContainerResource(podID, containerID, processFileType, process)
+func (fs *filesystem) storeContainerProcess(sandboxID, containerID string, process Process) error {
+	return fs.storeContainerResource(sandboxID, containerID, processFileType, process)
 }
 
-func (fs *filesystem) fetchContainerMounts(podID, containerID string) ([]Mount, error) {
+func (fs *filesystem) fetchContainerMounts(sandboxID, containerID string) ([]Mount, error) {
 	var mounts []Mount
 
-	if err := fs.fetchResource(false, podID, containerID, mountsFileType, &mounts); err != nil {
+	if err := fs.fetchResource(false, sandboxID, containerID, mountsFileType, &mounts); err != nil {
 		return []Mount{}, err
 	}
 
 	return mounts, nil
 }
 
-func (fs *filesystem) fetchContainerDevices(podID, containerID string) ([]Device, error) {
+func (fs *filesystem) fetchContainerDevices(sandboxID, containerID string) ([]Device, error) {
 	var devices []Device
 
-	if err := fs.fetchResource(false, podID, containerID, devicesFileType, &devices); err != nil {
+	if err := fs.fetchResource(false, sandboxID, containerID, devicesFileType, &devices); err != nil {
 		return []Device{}, err
 	}
 
 	return devices, nil
 }
 
-func (fs *filesystem) storeContainerMounts(podID, containerID string, mounts []Mount) error {
-	return fs.storeContainerResource(podID, containerID, mountsFileType, mounts)
+func (fs *filesystem) storeContainerMounts(sandboxID, containerID string, mounts []Mount) error {
+	return fs.storeContainerResource(sandboxID, containerID, mountsFileType, mounts)
 }
 
-func (fs *filesystem) storeContainerDevices(podID, containerID string, devices []Device) error {
-	return fs.storeContainerResource(podID, containerID, devicesFileType, devices)
+func (fs *filesystem) storeContainerDevices(sandboxID, containerID string, devices []Device) error {
+	return fs.storeContainerResource(sandboxID, containerID, devicesFileType, devices)
 }
 
-func (fs *filesystem) deleteContainerResources(podID, containerID string, resources []podResource) error {
+func (fs *filesystem) deleteContainerResources(sandboxID, containerID string, resources []sandboxResource) error {
 	if resources == nil {
-		resources = []podResource{configFileType, stateFileType}
+		resources = []sandboxResource{configFileType, stateFileType}
 	}
 
 	for _, resource := range resources {
-		_, dir, err := fs.podURI(podID, resource)
+		_, dir, err := fs.sandboxURI(sandboxID, resource)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/filesystem_test.go
+++ b/virtcontainers/filesystem_test.go
@@ -34,52 +34,52 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		{ID: "100"},
 	}
 
-	podConfig := &PodConfig{
+	sandboxConfig := &SandboxConfig{
 		Containers: contConfigs,
 	}
 
-	pod := Pod{
-		id:      testPodID,
+	sandbox := Sandbox{
+		id:      testSandboxID,
 		storage: fs,
-		config:  podConfig,
+		config:  sandboxConfig,
 	}
 
-	if err := pod.newContainers(); err != nil {
+	if err := sandbox.newContainers(); err != nil {
 		t.Fatal(err)
 	}
 
-	podConfigPath := filepath.Join(configStoragePath, testPodID)
-	podRunPath := filepath.Join(runStoragePath, testPodID)
+	sandboxConfigPath := filepath.Join(configStoragePath, testSandboxID)
+	sandboxRunPath := filepath.Join(runStoragePath, testSandboxID)
 
-	os.RemoveAll(podConfigPath)
-	os.RemoveAll(podRunPath)
+	os.RemoveAll(sandboxConfigPath)
+	os.RemoveAll(sandboxRunPath)
 
 	for _, container := range contConfigs {
-		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
+		configPath := filepath.Join(configStoragePath, testSandboxID, container.ID)
 		os.RemoveAll(configPath)
 
-		runPath := filepath.Join(runStoragePath, testPodID, container.ID)
+		runPath := filepath.Join(runStoragePath, testSandboxID, container.ID)
 		os.RemoveAll(runPath)
 	}
 
-	err := fs.createAllResources(pod)
+	err := fs.createAllResources(sandbox)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Check resources
-	_, err = os.Stat(podConfigPath)
+	_, err = os.Stat(sandboxConfigPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = os.Stat(podRunPath)
+	_, err = os.Stat(sandboxRunPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, container := range contConfigs {
-		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
+		configPath := filepath.Join(configStoragePath, testSandboxID, container.ID)
 		s, err := os.Stat(configPath)
 		if err != nil {
 			t.Fatal(err)
@@ -90,7 +90,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 			t.Fatal(fmt.Errorf("dirmode [%v] != expected [%v]", s.Mode(), dirMode))
 		}
 
-		runPath := filepath.Join(runStoragePath, testPodID, container.ID)
+		runPath := filepath.Join(runStoragePath, testSandboxID, container.ID)
 		s, err = os.Stat(runPath)
 		if err != nil {
 			t.Fatal(err)
@@ -104,12 +104,12 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 	}
 }
 
-func TestFilesystemCreateAllResourcesFailingPodIDEmpty(t *testing.T) {
+func TestFilesystemCreateAllResourcesFailingSandboxIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
-	pod := Pod{}
+	sandbox := Sandbox{}
 
-	err := fs.createAllResources(pod)
+	err := fs.createAllResources(sandbox)
 	if err == nil {
 		t.Fatal()
 	}
@@ -122,12 +122,12 @@ func TestFilesystemCreateAllResourcesFailingContainerIDEmpty(t *testing.T) {
 		{id: ""},
 	}
 
-	pod := Pod{
-		id:         testPodID,
+	sandbox := Sandbox{
+		id:         testSandboxID,
 		containers: containers,
 	}
 
-	err := fs.createAllResources(pod)
+	err := fs.createAllResources(sandbox)
 	if err == nil {
 		t.Fatal()
 	}
@@ -234,7 +234,7 @@ func TestFilesystemFetchFileSuccessful(t *testing.T) {
 	}
 	f.Close()
 
-	err = fs.fetchFile(path, podResource(-1), &data)
+	err = fs.fetchFile(path, sandboxResource(-1), &data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestFilesystemFetchFileFailingNoFile(t *testing.T) {
 	path := filepath.Join(testDir, "testFilesystem")
 	os.Remove(path)
 
-	err := fs.fetchFile(path, podResource(-1), &data)
+	err := fs.fetchFile(path, sandboxResource(-1), &data)
 	if err == nil {
 		t.Fatal()
 	}
@@ -275,7 +275,7 @@ func TestFilesystemFetchFileFailingUnMarshalling(t *testing.T) {
 	}
 	f.Close()
 
-	err = fs.fetchFile(path, podResource(-1), data)
+	err = fs.fetchFile(path, sandboxResource(-1), data)
 	if err == nil {
 		t.Fatal()
 	}
@@ -286,7 +286,7 @@ func TestFilesystemFetchContainerConfigSuccessful(t *testing.T) {
 	contID := "100"
 	rootFs := "rootfs"
 
-	contConfigDir := filepath.Join(configStoragePath, testPodID, contID)
+	contConfigDir := filepath.Join(configStoragePath, testSandboxID, contID)
 	os.MkdirAll(contConfigDir, dirMode)
 
 	path := filepath.Join(contConfigDir, configFile)
@@ -305,7 +305,7 @@ func TestFilesystemFetchContainerConfigSuccessful(t *testing.T) {
 	}
 	f.Close()
 
-	data, err := fs.fetchContainerConfig(testPodID, contID)
+	data, err := fs.fetchContainerConfig(testSandboxID, contID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,13 +323,13 @@ func TestFilesystemFetchContainerConfigSuccessful(t *testing.T) {
 func TestFilesystemFetchContainerConfigFailingContIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
-	_, err := fs.fetchContainerConfig(testPodID, "")
+	_, err := fs.fetchContainerConfig(testSandboxID, "")
 	if err == nil {
 		t.Fatal()
 	}
 }
 
-func TestFilesystemFetchContainerConfigFailingPodIDEmpty(t *testing.T) {
+func TestFilesystemFetchContainerConfigFailingSandboxIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
 	_, err := fs.fetchContainerConfig("", "100")
@@ -342,7 +342,7 @@ func TestFilesystemFetchContainerMountsSuccessful(t *testing.T) {
 	fs := &filesystem{}
 	contID := "100"
 
-	contMountsDir := filepath.Join(runStoragePath, testPodID, contID)
+	contMountsDir := filepath.Join(runStoragePath, testSandboxID, contID)
 	os.MkdirAll(contMountsDir, dirMode)
 
 	path := filepath.Join(contMountsDir, mountsFile)
@@ -378,7 +378,7 @@ func TestFilesystemFetchContainerMountsSuccessful(t *testing.T) {
 	}
 	f.Close()
 
-	data, err := fs.fetchContainerMounts(testPodID, contID)
+	data, err := fs.fetchContainerMounts(testSandboxID, contID)
 	if err != nil {
 		data, _ := ioutil.ReadFile(path)
 		t.Logf("Data from file : %s", string(data[:]))
@@ -404,7 +404,7 @@ func TestFilesystemFetchContainerMountsInvalidType(t *testing.T) {
 	fs := &filesystem{}
 	contID := "100"
 
-	contMountsDir := filepath.Join(runStoragePath, testPodID, contID)
+	contMountsDir := filepath.Join(runStoragePath, testSandboxID, contID)
 	os.MkdirAll(contMountsDir, dirMode)
 
 	path := filepath.Join(contMountsDir, mountsFile)
@@ -423,7 +423,7 @@ func TestFilesystemFetchContainerMountsInvalidType(t *testing.T) {
 	}
 	f.Close()
 
-	_, err = fs.fetchContainerMounts(testPodID, contID)
+	_, err = fs.fetchContainerMounts(testSandboxID, contID)
 	if err == nil {
 		t.Fatal()
 	}
@@ -432,13 +432,13 @@ func TestFilesystemFetchContainerMountsInvalidType(t *testing.T) {
 func TestFilesystemFetchContainerMountsFailingContIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
-	_, err := fs.fetchContainerMounts(testPodID, "")
+	_, err := fs.fetchContainerMounts(testSandboxID, "")
 	if err == nil {
 		t.Fatal()
 	}
 }
 
-func TestFilesystemFetchContainerMountsFailingPodIDEmpty(t *testing.T) {
+func TestFilesystemFetchContainerMountsFailingSandboxIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
 	_, err := fs.fetchContainerMounts("", "100")
@@ -447,7 +447,7 @@ func TestFilesystemFetchContainerMountsFailingPodIDEmpty(t *testing.T) {
 	}
 }
 
-func TestFilesystemResourceDirFailingPodIDEmpty(t *testing.T) {
+func TestFilesystemResourceDirFailingSandboxIDEmpty(t *testing.T) {
 	for _, b := range []bool{true, false} {
 		_, err := resourceDir(b, "", "", configFileType)
 		if err == nil {
@@ -458,7 +458,7 @@ func TestFilesystemResourceDirFailingPodIDEmpty(t *testing.T) {
 
 func TestFilesystemResourceDirFailingInvalidResource(t *testing.T) {
 	for _, b := range []bool{true, false} {
-		_, err := resourceDir(b, testPodID, "100", podResource(-1))
+		_, err := resourceDir(b, testSandboxID, "100", sandboxResource(-1))
 		if err == nil {
 			t.Fatal()
 		}
@@ -469,19 +469,19 @@ func TestFilesystemResourceURIFailingResourceDir(t *testing.T) {
 	fs := &filesystem{}
 
 	for _, b := range []bool{true, false} {
-		_, _, err := fs.resourceURI(b, testPodID, "100", podResource(-1))
+		_, _, err := fs.resourceURI(b, testSandboxID, "100", sandboxResource(-1))
 		if err == nil {
 			t.Fatal()
 		}
 	}
 }
 
-func TestFilesystemStoreResourceFailingPodConfigStateFileType(t *testing.T) {
+func TestFilesystemStoreResourceFailingSandboxConfigStateFileType(t *testing.T) {
 	fs := &filesystem{}
-	data := PodConfig{}
+	data := SandboxConfig{}
 
 	for _, b := range []bool{true, false} {
-		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		err := fs.storeResource(b, testSandboxID, "100", stateFileType, data)
 		if err == nil {
 			t.Fatal()
 		}
@@ -493,16 +493,16 @@ func TestFilesystemStoreResourceFailingContainerConfigStateFileType(t *testing.T
 	data := ContainerConfig{}
 
 	for _, b := range []bool{true, false} {
-		err := fs.storeResource(b, testPodID, "100", stateFileType, data)
+		err := fs.storeResource(b, testSandboxID, "100", stateFileType, data)
 		if err == nil {
 			t.Fatal()
 		}
 	}
 }
 
-func TestFilesystemStoreResourceFailingPodConfigResourceURI(t *testing.T) {
+func TestFilesystemStoreResourceFailingSandboxConfigResourceURI(t *testing.T) {
 	fs := &filesystem{}
-	data := PodConfig{}
+	data := SandboxConfig{}
 
 	for _, b := range []bool{true, false} {
 		err := fs.storeResource(b, "", "100", configFileType, data)
@@ -529,7 +529,7 @@ func TestFilesystemStoreResourceFailingStateConfigFileType(t *testing.T) {
 	data := State{}
 
 	for _, b := range []bool{true, false} {
-		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		err := fs.storeResource(b, testSandboxID, "100", configFileType, data)
 		if err == nil {
 			t.Fatal()
 		}
@@ -553,7 +553,7 @@ func TestFilesystemStoreResourceFailingWrongDataType(t *testing.T) {
 	data := TestNoopStructure{}
 
 	for _, b := range []bool{true, false} {
-		err := fs.storeResource(b, testPodID, "100", configFileType, data)
+		err := fs.storeResource(b, testSandboxID, "100", configFileType, data)
 		if err == nil {
 			t.Fatal()
 		}
@@ -564,7 +564,7 @@ func TestFilesystemFetchResourceFailingWrongResourceType(t *testing.T) {
 	fs := &filesystem{}
 
 	for _, b := range []bool{true, false} {
-		if err := fs.fetchResource(b, testPodID, "100", lockFileType, nil); err == nil {
+		if err := fs.fetchResource(b, testSandboxID, "100", lockFileType, nil); err == nil {
 			t.Fatal()
 		}
 	}

--- a/virtcontainers/hack/virtc/README.md
+++ b/virtcontainers/hack/virtc/README.md
@@ -5,7 +5,7 @@ This is example software; unlike other projects like runc, runv, or rkt, virtcon
 
 ## Virtc example
 
-Here we explain how to use the pod and container API from `virtc` command line.
+Here we explain how to use the sandbox and container API from `virtc` command line.
 
 ### Prepare your environment
 
@@ -93,81 +93,81 @@ The shim will be installed at the following location: `/usr/libexec/clear-contai
 _Start a new container_
 
 ```
-# ./virtc container start --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container start --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 _Execute a new process on a running container_
 ```
-# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container enter --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
-_Start a pod with container(s) previously created_
+_Start a sandbox with container(s) previously created_
 ```
-# ./virtc pod start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc sandbox start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
-Notice that in both cases, the `--pod-id` and `--id` options have been defined when previously creating a pod and a container. 
+Notice that in both cases, the `--sandbox-id` and `--id` options have been defined when previously creating a sandbox and a container. 
 
 ### Run virtc
 
-All following commands __MUST__ be run as root. By default, and unless you decide to modify it and rebuild it, `virtc` starts empty pods (no container started).
+All following commands __MUST__ be run as root. By default, and unless you decide to modify it and rebuild it, `virtc` starts empty sandboxes (no container started).
 
-#### Run a new pod (Create + Start)
+#### Run a new sandbox (Create + Start)
 ```
-# ./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --shim="ccShim" --shim-path="/usr/libexec/cc-shim"
+# ./virtc sandbox run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --shim="ccShim" --shim-path="/usr/libexec/cc-shim"
 ```
-#### Create a new pod
+#### Create a new sandbox
 ```
-# ./virtc pod run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --shim="ccShim" --shim-path="/usr/libexec/cc-shim"
+# ./virtc sandbox run --agent="hyperstart" --network="CNI" --proxy="ccProxy" --proxy-url="unix:///var/run/clearcontainers/proxy.sock" --shim="ccShim" --shim-path="/usr/libexec/cc-shim"
 ```
 This will generate output similar to the following:
 ```
-Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 created
+Sandbox 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 created
 ```
 
-#### Start an existing pod
+#### Start an existing sandbox
 ```
-# ./virtc pod start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc sandbox start --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
-Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 started
+Sandbox 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 started
 ```
 
-#### Stop an existing pod
+#### Stop an existing sandbox
 ```
-# ./virtc pod stop --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc sandbox stop --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
-Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 stopped
+Sandbox 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 stopped
 ```
 
-#### Get the status of an existing pod and its containers
+#### Get the status of an existing sandbox and its containers
 ```
-# ./virtc pod status --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc sandbox status --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
-This will generate output similar to the following (assuming the pod has been started):
+This will generate output similar to the following (assuming the sandbox has been started):
 ```
-POD ID                                  STATE   HYPERVISOR      AGENT
+SB ID                                  STATE   HYPERVISOR      AGENT
 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8    running qemu            hyperstart
 
 CONTAINER ID    STATE
 ```
 
-#### Delete an existing pod
+#### Delete an existing sandbox
 ```
-# ./virtc pod delete --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc sandbox delete --id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
-Pod 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 deleted
+Sandbox 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 deleted
 ```
 
-#### List all existing pods
+#### List all existing sandboxes
 ```
-# ./virtc pod list
+# ./virtc sandbox list
 ```
 This should generate that kind of output
 ```
-POD ID                                  STATE   HYPERVISOR      AGENT
+SB ID                                  STATE   HYPERVISOR      AGENT
 306ecdcf-0a6f-4a06-a03e-86a7b868ffc8    running qemu            hyperstart
 92d73f74-4514-4a0d-81df-db1cc4c59100    running qemu            hyperstart
 7088148c-049b-4be7-b1be-89b3ae3c551c    ready   qemu            hyperstart
@@ -176,7 +176,7 @@ POD ID                                  STATE   HYPERVISOR      AGENT
 
 #### Create a new container
 ```
-# ./virtc container create --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --rootfs="/tmp/bundles/busybox/rootfs" --cmd="/bin/ifconfig" --console="/dev/pts/30"
+# ./virtc container create --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --rootfs="/tmp/bundles/busybox/rootfs" --cmd="/bin/ifconfig" --console="/dev/pts/30"
 ```
 This will generate output similar to the following:
 ```
@@ -190,7 +190,7 @@ That way, you make sure you have a dedicated input/output terminal.
 
 #### Start an existing container
 ```
-# ./virtc container start --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container start --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
@@ -199,7 +199,7 @@ Container 1 started
 
 #### Run a new process on an existing container
 ```
-# ./virtc container enter --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps" --console="/dev/pts/30"
+# ./virtc container enter --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8 --cmd="/bin/ps" --console="/dev/pts/30"
 ```
 This will generate output similar to the following:
 ```
@@ -213,7 +213,7 @@ That way, you make sure you have a dedicated input/output terminal.
 
 #### Stop an existing container
 ```
-# ./virtc container stop --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container stop --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
@@ -222,7 +222,7 @@ Container 1 stopped
 
 #### Delete an existing container
 ```
-# ./virtc container delete --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container delete --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following:
 ```
@@ -231,7 +231,7 @@ Container 1 deleted
 
 #### Get the status of an existing container
 ```
-# ./virtc container status --id=1 --pod-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
+# ./virtc container status --id=1 --sandbox-id=306ecdcf-0a6f-4a06-a03e-86a7b868ffc8
 ```
 This will generate output similar to the following (assuming the container has been started):
 ```

--- a/virtcontainers/hack/virtc/main.go
+++ b/virtcontainers/hack/virtc/main.go
@@ -37,10 +37,10 @@ var statusFormat = "%s\t%s\n"
 
 var (
 	errNeedContainerID = errors.New("Container ID cannot be empty")
-	errNeedPodID       = errors.New("Pod ID cannot be empty")
+	errNeedSandboxID   = errors.New("Sandbox ID cannot be empty")
 )
 
-var podConfigFlags = []cli.Flag{
+var sandboxConfigFlags = []cli.Flag{
 	cli.GenericFlag{
 		Name:  "agent",
 		Value: new(vc.AgentType),
@@ -50,7 +50,7 @@ var podConfigFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "id",
 		Value: "",
-		Usage: "the pod identifier (default: auto-generated)",
+		Usage: "the sandbox identifier (default: auto-generated)",
 	},
 
 	cli.StringFlag{
@@ -104,13 +104,13 @@ var podConfigFlags = []cli.Flag{
 	cli.UintFlag{
 		Name:  "cpus",
 		Value: 0,
-		Usage: "the number of virtual cpus available for this pod",
+		Usage: "the number of virtual cpus available for this sandbox",
 	},
 
 	cli.UintFlag{
 		Name:  "memory",
 		Value: 0,
-		Usage: "the amount of memory available for this pod in MiB",
+		Usage: "the amount of memory available for this sandbox in MiB",
 	},
 }
 
@@ -143,7 +143,7 @@ func buildKernelParams(config *vc.HypervisorConfig) error {
 	return nil
 }
 
-func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
+func buildSandboxConfig(context *cli.Context) (vc.SandboxConfig, error) {
 	var agConfig interface{}
 
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
@@ -154,22 +154,22 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
 	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert agent type")
+		return vc.SandboxConfig{}, fmt.Errorf("Could not convert agent type")
 	}
 
 	networkModel, ok := context.Generic("network").(*vc.NetworkModel)
 	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert network model")
+		return vc.SandboxConfig{}, fmt.Errorf("Could not convert network model")
 	}
 
 	proxyType, ok := context.Generic("proxy").(*vc.ProxyType)
 	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert proxy type")
+		return vc.SandboxConfig{}, fmt.Errorf("Could not convert proxy type")
 	}
 
 	shimType, ok := context.Generic("shim").(*vc.ShimType)
 	if ok != true {
-		return vc.PodConfig{}, fmt.Errorf("Could not convert shim type")
+		return vc.SandboxConfig{}, fmt.Errorf("Could not convert shim type")
 	}
 
 	kernelPath := "/usr/share/clear-containers/vmlinuz.container"
@@ -184,7 +184,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	}
 
 	if err := buildKernelParams(&hypervisorConfig); err != nil {
-		return vc.PodConfig{}, err
+		return vc.SandboxConfig{}, err
 	}
 
 	netConfig := vc.NetworkConfig{
@@ -211,11 +211,11 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 
 	id := context.String("id")
 	if id == "" {
-		// auto-generate pod name
+		// auto-generate sandbox name
 		id = uuid.Generate().String()
 	}
 
-	podConfig := vc.PodConfig{
+	sandboxConfig := vc.SandboxConfig{
 		ID:       id,
 		VMConfig: vmConfig,
 
@@ -237,7 +237,7 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		Containers: []vc.ContainerConfig{},
 	}
 
-	return podConfig, nil
+	return sandboxConfig, nil
 }
 
 func getProxyConfig(proxyType vc.ProxyType, path string) vc.ProxyConfig {
@@ -271,10 +271,10 @@ func getShimConfig(shimType vc.ShimType, path string) interface{} {
 	return shimConfig
 }
 
-// checkRequiredPodArgs checks to ensure the required command-line
-// arguments have been specified for the pod sub-command specified by
+// checkRequiredSandboxArgs checks to ensure the required command-line
+// arguments have been specified for the sandbox sub-command specified by
 // the context argument.
-func checkRequiredPodArgs(context *cli.Context) error {
+func checkRequiredSandboxArgs(context *cli.Context) error {
 	if context == nil {
 		return fmt.Errorf("BUG: need Context")
 	}
@@ -294,7 +294,7 @@ func checkRequiredPodArgs(context *cli.Context) error {
 
 	id := context.String("id")
 	if id == "" {
-		return errNeedPodID
+		return errNeedSandboxID
 	}
 
 	return nil
@@ -311,9 +311,9 @@ func checkRequiredContainerArgs(context *cli.Context) error {
 	// sub-sub-command name
 	name := context.Command.Name
 
-	podID := context.String("pod-id")
-	if podID == "" {
-		return errNeedPodID
+	sandboxID := context.String("sandbox-id")
+	if sandboxID == "" {
+		return errNeedSandboxID
 	}
 
 	rootfs := context.String("rootfs")
@@ -329,38 +329,38 @@ func checkRequiredContainerArgs(context *cli.Context) error {
 	return nil
 }
 
-func runPod(context *cli.Context) error {
-	podConfig, err := buildPodConfig(context)
+func runSandbox(context *cli.Context) error {
+	sandboxConfig, err := buildSandboxConfig(context)
 	if err != nil {
-		return fmt.Errorf("Could not build pod config: %s", err)
+		return fmt.Errorf("Could not build sandbox config: %s", err)
 	}
 
-	_, err = vc.RunPod(podConfig)
+	_, err = vc.RunSandbox(sandboxConfig)
 	if err != nil {
-		return fmt.Errorf("Could not run pod: %s", err)
+		return fmt.Errorf("Could not run sandbox: %s", err)
 	}
 
 	return nil
 }
 
-func createPod(context *cli.Context) error {
-	podConfig, err := buildPodConfig(context)
+func createSandbox(context *cli.Context) error {
+	sandboxConfig, err := buildSandboxConfig(context)
 	if err != nil {
-		return fmt.Errorf("Could not build pod config: %s", err)
+		return fmt.Errorf("Could not build sandbox config: %s", err)
 	}
 
-	p, err := vc.CreatePod(podConfig)
+	p, err := vc.CreateSandbox(sandboxConfig)
 	if err != nil {
-		return fmt.Errorf("Could not create pod: %s", err)
+		return fmt.Errorf("Could not create sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s created\n", p.ID())
+	fmt.Printf("Sandbox %s created\n", p.ID())
 
 	return nil
 }
 
-func checkPodArgs(context *cli.Context, f func(context *cli.Context) error) error {
-	if err := checkRequiredPodArgs(context); err != nil {
+func checkSandboxArgs(context *cli.Context, f func(context *cli.Context) error) error {
+	if err := checkRequiredSandboxArgs(context); err != nil {
 		return err
 	}
 
@@ -375,73 +375,73 @@ func checkContainerArgs(context *cli.Context, f func(context *cli.Context) error
 	return f(context)
 }
 
-func deletePod(context *cli.Context) error {
-	p, err := vc.DeletePod(context.String("id"))
+func deleteSandbox(context *cli.Context) error {
+	p, err := vc.DeleteSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not delete pod: %s", err)
+		return fmt.Errorf("Could not delete sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s deleted\n", p.ID())
+	fmt.Printf("Sandbox %s deleted\n", p.ID())
 
 	return nil
 }
 
-func startPod(context *cli.Context) error {
-	p, err := vc.StartPod(context.String("id"))
+func startSandbox(context *cli.Context) error {
+	p, err := vc.StartSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not start pod: %s", err)
+		return fmt.Errorf("Could not start sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s started\n", p.ID())
+	fmt.Printf("Sandbox %s started\n", p.ID())
 
 	return nil
 }
 
-func stopPod(context *cli.Context) error {
-	p, err := vc.StopPod(context.String("id"))
+func stopSandbox(context *cli.Context) error {
+	p, err := vc.StopSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not stop pod: %s", err)
+		return fmt.Errorf("Could not stop sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s stopped\n", p.ID())
+	fmt.Printf("Sandbox %s stopped\n", p.ID())
 
 	return nil
 }
 
-func pausePod(context *cli.Context) error {
-	p, err := vc.PausePod(context.String("id"))
+func pauseSandbox(context *cli.Context) error {
+	p, err := vc.PauseSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not pause pod: %s", err)
+		return fmt.Errorf("Could not pause sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s paused\n", p.ID())
+	fmt.Printf("Sandbox %s paused\n", p.ID())
 
 	return nil
 }
 
-func resumePod(context *cli.Context) error {
-	p, err := vc.ResumePod(context.String("id"))
+func resumeSandbox(context *cli.Context) error {
+	p, err := vc.ResumeSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not resume pod: %s", err)
+		return fmt.Errorf("Could not resume sandbox: %s", err)
 	}
 
-	fmt.Printf("Pod %s resumed\n", p.ID())
+	fmt.Printf("Sandbox %s resumed\n", p.ID())
 
 	return nil
 }
 
-func listPods(context *cli.Context) error {
-	podStatusList, err := vc.ListPod()
+func listSandboxes(context *cli.Context) error {
+	sandboxStatusList, err := vc.ListSandbox()
 	if err != nil {
-		return fmt.Errorf("Could not list pod: %s", err)
+		return fmt.Errorf("Could not list sandbox: %s", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 8, 1, '\t', 0)
-	fmt.Fprintf(w, listFormat, "POD ID", "STATE", "HYPERVISOR", "AGENT")
+	fmt.Fprintf(w, listFormat, "SB ID", "STATE", "HYPERVISOR", "AGENT")
 
-	for _, podStatus := range podStatusList {
+	for _, sandboxStatus := range sandboxStatusList {
 		fmt.Fprintf(w, listFormat,
-			podStatus.ID, podStatus.State.State, podStatus.Hypervisor, podStatus.Agent)
+			sandboxStatus.ID, sandboxStatus.State.State, sandboxStatus.Hypervisor, sandboxStatus.Agent)
 	}
 
 	w.Flush()
@@ -449,21 +449,21 @@ func listPods(context *cli.Context) error {
 	return nil
 }
 
-func statusPod(context *cli.Context) error {
-	podStatus, err := vc.StatusPod(context.String("id"))
+func statusSandbox(context *cli.Context) error {
+	sandboxStatus, err := vc.StatusSandbox(context.String("id"))
 	if err != nil {
-		return fmt.Errorf("Could not get pod status: %s", err)
+		return fmt.Errorf("Could not get sandbox status: %s", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 8, 1, '\t', 0)
-	fmt.Fprintf(w, listFormat, "POD ID", "STATE", "HYPERVISOR", "AGENT")
+	fmt.Fprintf(w, listFormat, "SB ID", "STATE", "HYPERVISOR", "AGENT")
 
 	fmt.Fprintf(w, listFormat+"\n",
-		podStatus.ID, podStatus.State.State, podStatus.Hypervisor, podStatus.Agent)
+		sandboxStatus.ID, sandboxStatus.State.State, sandboxStatus.Hypervisor, sandboxStatus.Agent)
 
 	fmt.Fprintf(w, statusFormat, "CONTAINER ID", "STATE")
 
-	for _, contStatus := range podStatus.ContainersStatus {
+	for _, contStatus := range sandboxStatus.ContainersStatus {
 		fmt.Fprintf(w, statusFormat, contStatus.ID, contStatus.State.State)
 	}
 
@@ -472,119 +472,119 @@ func statusPod(context *cli.Context) error {
 	return nil
 }
 
-var runPodCommand = cli.Command{
+var runSandboxCommand = cli.Command{
 	Name:  "run",
-	Usage: "run a pod",
-	Flags: podConfigFlags,
+	Usage: "run a sandbox",
+	Flags: sandboxConfigFlags,
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, runPod)
+		return checkSandboxArgs(context, runSandbox)
 	},
 }
 
-var createPodCommand = cli.Command{
+var createSandboxCommand = cli.Command{
 	Name:  "create",
-	Usage: "create a pod",
-	Flags: podConfigFlags,
+	Usage: "create a sandbox",
+	Flags: sandboxConfigFlags,
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, createPod)
+		return checkSandboxArgs(context, createSandbox)
 	},
 }
 
-var deletePodCommand = cli.Command{
+var deleteSandboxCommand = cli.Command{
 	Name:  "delete",
-	Usage: "delete an existing pod",
+	Usage: "delete an existing sandbox",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, deletePod)
+		return checkSandboxArgs(context, deleteSandbox)
 	},
 }
 
-var startPodCommand = cli.Command{
+var startSandboxCommand = cli.Command{
 	Name:  "start",
-	Usage: "start an existing pod",
+	Usage: "start an existing sandbox",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, startPod)
+		return checkSandboxArgs(context, startSandbox)
 	},
 }
 
-var stopPodCommand = cli.Command{
+var stopSandboxCommand = cli.Command{
 	Name:  "stop",
-	Usage: "stop an existing pod",
+	Usage: "stop an existing sandbox",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, stopPod)
+		return checkSandboxArgs(context, stopSandbox)
 	},
 }
 
-var listPodsCommand = cli.Command{
+var listSandboxesCommand = cli.Command{
 	Name:  "list",
-	Usage: "list all existing pods",
+	Usage: "list all existing sandboxes",
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, listPods)
+		return checkSandboxArgs(context, listSandboxes)
 	},
 }
 
-var statusPodCommand = cli.Command{
+var statusSandboxCommand = cli.Command{
 	Name:  "status",
-	Usage: "returns a detailed pod status",
+	Usage: "returns a detailed sandbox status",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, statusPod)
+		return checkSandboxArgs(context, statusSandbox)
 	},
 }
 
-var pausePodCommand = cli.Command{
+var pauseSandboxCommand = cli.Command{
 	Name:  "pause",
-	Usage: "pause an existing pod",
+	Usage: "pause an existing sandbox",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, pausePod)
+		return checkSandboxArgs(context, pauseSandbox)
 	},
 }
 
-var resumePodCommand = cli.Command{
+var resumeSandboxCommand = cli.Command{
 	Name:  "resume",
-	Usage: "unpause a paused pod",
+	Usage: "unpause a paused sandbox",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
-		return checkPodArgs(context, resumePod)
+		return checkSandboxArgs(context, resumeSandbox)
 	},
 }
 
@@ -623,7 +623,7 @@ func createContainer(context *cli.Context) error {
 		Cmd:    cmd,
 	}
 
-	_, c, err := vc.CreateContainer(context.String("pod-id"), containerConfig)
+	_, c, err := vc.CreateContainer(context.String("sandbox-id"), containerConfig)
 	if err != nil {
 		return fmt.Errorf("Could not create container: %s", err)
 	}
@@ -634,7 +634,7 @@ func createContainer(context *cli.Context) error {
 }
 
 func deleteContainer(context *cli.Context) error {
-	c, err := vc.DeleteContainer(context.String("pod-id"), context.String("id"))
+	c, err := vc.DeleteContainer(context.String("sandbox-id"), context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not delete container: %s", err)
 	}
@@ -645,7 +645,7 @@ func deleteContainer(context *cli.Context) error {
 }
 
 func startContainer(context *cli.Context) error {
-	c, err := vc.StartContainer(context.String("pod-id"), context.String("id"))
+	c, err := vc.StartContainer(context.String("sandbox-id"), context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not start container: %s", err)
 	}
@@ -656,7 +656,7 @@ func startContainer(context *cli.Context) error {
 }
 
 func stopContainer(context *cli.Context) error {
-	c, err := vc.StopContainer(context.String("pod-id"), context.String("id"))
+	c, err := vc.StopContainer(context.String("sandbox-id"), context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not stop container: %s", err)
 	}
@@ -689,7 +689,7 @@ func enterContainer(context *cli.Context) error {
 		Console:     console,
 	}
 
-	_, c, _, err := vc.EnterContainer(context.String("pod-id"), context.String("id"), cmd)
+	_, c, _, err := vc.EnterContainer(context.String("sandbox-id"), context.String("id"), cmd)
 	if err != nil {
 		return fmt.Errorf("Could not enter container: %s", err)
 	}
@@ -700,7 +700,7 @@ func enterContainer(context *cli.Context) error {
 }
 
 func statusContainer(context *cli.Context) error {
-	contStatus, err := vc.StatusContainer(context.String("pod-id"), context.String("id"))
+	contStatus, err := vc.StatusContainer(context.String("sandbox-id"), context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not get container status: %s", err)
 	}
@@ -724,9 +724,9 @@ var createContainerCommand = cli.Command{
 			Usage: "the container identifier (default: auto-generated)",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 		cli.StringFlag{
 			Name:  "rootfs",
@@ -759,9 +759,9 @@ var deleteContainerCommand = cli.Command{
 			Usage: "the container identifier",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -779,9 +779,9 @@ var startContainerCommand = cli.Command{
 			Usage: "the container identifier",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -799,9 +799,9 @@ var stopContainerCommand = cli.Command{
 			Usage: "the container identifier",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -819,9 +819,9 @@ var enterContainerCommand = cli.Command{
 			Usage: "the container identifier",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 		cli.StringFlag{
 			Name:  "cmd",
@@ -849,9 +849,9 @@ var statusContainerCommand = cli.Command{
 			Usage: "the container identifier",
 		},
 		cli.StringFlag{
-			Name:  "pod-id",
+			Name:  "sandbox-id",
 			Value: "",
-			Usage: "the pod identifier",
+			Usage: "the sandbox identifier",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -888,18 +888,18 @@ func main() {
 
 	virtc.Commands = []cli.Command{
 		{
-			Name:  "pod",
-			Usage: "pod commands",
+			Name:  "sandbox",
+			Usage: "sandbox commands",
 			Subcommands: []cli.Command{
-				createPodCommand,
-				deletePodCommand,
-				listPodsCommand,
-				pausePodCommand,
-				resumePodCommand,
-				runPodCommand,
-				startPodCommand,
-				stopPodCommand,
-				statusPodCommand,
+				createSandboxCommand,
+				deleteSandboxCommand,
+				listSandboxesCommand,
+				pauseSandboxCommand,
+				resumeSandboxCommand,
+				runSandboxCommand,
+				startSandboxCommand,
+				stopSandboxCommand,
+				statusSandboxCommand,
 			},
 		},
 		{

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -37,13 +37,13 @@ func TestHyperstartGenerateSocketsSuccessful(t *testing.T) {
 		SockTtyName: "ttySock",
 	}
 
-	pod := Pod{
-		id: testPodID,
+	sandbox := Sandbox{
+		id: testSandboxID,
 	}
 
 	h := &hyper{}
 
-	h.generateSockets(pod, config)
+	h.generateSockets(sandbox, config)
 
 	expectedSockets := []Socket{
 		{
@@ -68,25 +68,25 @@ func TestHyperstartGenerateSocketsSuccessful(t *testing.T) {
 func TestHyperstartGenerateSocketsSuccessfulNoPathProvided(t *testing.T) {
 	config := HyperConfig{}
 
-	pod := Pod{
-		id: testPodID,
+	sandbox := Sandbox{
+		id: testSandboxID,
 	}
 
 	h := &hyper{}
 
-	h.generateSockets(pod, config)
+	h.generateSockets(sandbox, config)
 
 	expectedSockets := []Socket{
 		{
 			DeviceID: fmt.Sprintf(defaultDeviceIDTemplate, 0),
 			ID:       fmt.Sprintf(defaultIDTemplate, 0),
-			HostPath: fmt.Sprintf(defaultSockPathTemplates[0], runStoragePath, pod.id),
+			HostPath: fmt.Sprintf(defaultSockPathTemplates[0], runStoragePath, sandbox.id),
 			Name:     fmt.Sprintf(defaultChannelTemplate, 0),
 		},
 		{
 			DeviceID: fmt.Sprintf(defaultDeviceIDTemplate, 1),
 			ID:       fmt.Sprintf(defaultIDTemplate, 1),
-			HostPath: fmt.Sprintf(defaultSockPathTemplates[1], runStoragePath, pod.id),
+			HostPath: fmt.Sprintf(defaultSockPathTemplates[1], runStoragePath, sandbox.id),
 			Name:     fmt.Sprintf(defaultChannelTemplate, 1),
 		},
 	}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -181,7 +181,7 @@ type HypervisorConfig struct {
 	// customAssets is a map of assets.
 	// Each value in that map takes precedence over the configured assets.
 	// For example, if there is a value for the "kernel" key in this map,
-	// it will be used for the pod's kernel path instead of KernelPath.
+	// it will be used for the sandbox's kernel path instead of KernelPath.
 	customAssets map[assetType]*asset
 
 	// DefaultVCPUs specifies default number of vCPUs for the VM.
@@ -191,7 +191,7 @@ type HypervisorConfig struct {
 	DefaultMaxVCPUs uint32
 
 	// DefaultMem specifies default memory size in MiB for the VM.
-	// Pod configuration VMConfig.Memory overwrites this.
+	// Sandbox configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
 
 	// DefaultBridges specifies default number of bridges for the VM.
@@ -505,16 +505,16 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 // hypervisor is the virtcontainers hypervisor interface.
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
-	init(pod *Pod) error
-	createPod(podConfig PodConfig) error
-	startPod() error
-	waitPod(timeout int) error
-	stopPod() error
-	pausePod() error
-	resumePod() error
+	init(sandbox *Sandbox) error
+	createSandbox(sandboxConfig SandboxConfig) error
+	startSandbox() error
+	waitSandbox(timeout int) error
+	stopSandbox() error
+	pauseSandbox() error
+	resumeSandbox() error
 	addDevice(devInfo interface{}, devType deviceType) error
 	hotplugAddDevice(devInfo interface{}, devType deviceType) error
 	hotplugRemoveDevice(devInfo interface{}, devType deviceType) error
-	getPodConsole(podID string) string
+	getSandboxConsole(sandboxID string) string
 	capabilities() capabilities
 }

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -33,87 +33,87 @@ func (impl *VCImpl) SetLogger(logger logrus.FieldLogger) {
 	SetLogger(logger)
 }
 
-// CreatePod implements the VC function of the same name.
-func (impl *VCImpl) CreatePod(podConfig PodConfig) (VCPod, error) {
-	return CreatePod(podConfig)
+// CreateSandbox implements the VC function of the same name.
+func (impl *VCImpl) CreateSandbox(sandboxConfig SandboxConfig) (VCSandbox, error) {
+	return CreateSandbox(sandboxConfig)
 }
 
-// DeletePod implements the VC function of the same name.
-func (impl *VCImpl) DeletePod(podID string) (VCPod, error) {
-	return DeletePod(podID)
+// DeleteSandbox implements the VC function of the same name.
+func (impl *VCImpl) DeleteSandbox(sandboxID string) (VCSandbox, error) {
+	return DeleteSandbox(sandboxID)
 }
 
-// StartPod implements the VC function of the same name.
-func (impl *VCImpl) StartPod(podID string) (VCPod, error) {
-	return StartPod(podID)
+// StartSandbox implements the VC function of the same name.
+func (impl *VCImpl) StartSandbox(sandboxID string) (VCSandbox, error) {
+	return StartSandbox(sandboxID)
 }
 
-// StopPod implements the VC function of the same name.
-func (impl *VCImpl) StopPod(podID string) (VCPod, error) {
-	return StopPod(podID)
+// StopSandbox implements the VC function of the same name.
+func (impl *VCImpl) StopSandbox(sandboxID string) (VCSandbox, error) {
+	return StopSandbox(sandboxID)
 }
 
-// RunPod implements the VC function of the same name.
-func (impl *VCImpl) RunPod(podConfig PodConfig) (VCPod, error) {
-	return RunPod(podConfig)
+// RunSandbox implements the VC function of the same name.
+func (impl *VCImpl) RunSandbox(sandboxConfig SandboxConfig) (VCSandbox, error) {
+	return RunSandbox(sandboxConfig)
 }
 
-// ListPod implements the VC function of the same name.
-func (impl *VCImpl) ListPod() ([]PodStatus, error) {
-	return ListPod()
+// ListSandbox implements the VC function of the same name.
+func (impl *VCImpl) ListSandbox() ([]SandboxStatus, error) {
+	return ListSandbox()
 }
 
-// StatusPod implements the VC function of the same name.
-func (impl *VCImpl) StatusPod(podID string) (PodStatus, error) {
-	return StatusPod(podID)
+// StatusSandbox implements the VC function of the same name.
+func (impl *VCImpl) StatusSandbox(sandboxID string) (SandboxStatus, error) {
+	return StatusSandbox(sandboxID)
 }
 
-// PausePod implements the VC function of the same name.
-func (impl *VCImpl) PausePod(podID string) (VCPod, error) {
-	return PausePod(podID)
+// PauseSandbox implements the VC function of the same name.
+func (impl *VCImpl) PauseSandbox(sandboxID string) (VCSandbox, error) {
+	return PauseSandbox(sandboxID)
 }
 
-// ResumePod implements the VC function of the same name.
-func (impl *VCImpl) ResumePod(podID string) (VCPod, error) {
-	return ResumePod(podID)
+// ResumeSandbox implements the VC function of the same name.
+func (impl *VCImpl) ResumeSandbox(sandboxID string) (VCSandbox, error) {
+	return ResumeSandbox(sandboxID)
 }
 
 // CreateContainer implements the VC function of the same name.
-func (impl *VCImpl) CreateContainer(podID string, containerConfig ContainerConfig) (VCPod, VCContainer, error) {
-	return CreateContainer(podID, containerConfig)
+func (impl *VCImpl) CreateContainer(sandboxID string, containerConfig ContainerConfig) (VCSandbox, VCContainer, error) {
+	return CreateContainer(sandboxID, containerConfig)
 }
 
 // DeleteContainer implements the VC function of the same name.
-func (impl *VCImpl) DeleteContainer(podID, containerID string) (VCContainer, error) {
-	return DeleteContainer(podID, containerID)
+func (impl *VCImpl) DeleteContainer(sandboxID, containerID string) (VCContainer, error) {
+	return DeleteContainer(sandboxID, containerID)
 }
 
 // StartContainer implements the VC function of the same name.
-func (impl *VCImpl) StartContainer(podID, containerID string) (VCContainer, error) {
-	return StartContainer(podID, containerID)
+func (impl *VCImpl) StartContainer(sandboxID, containerID string) (VCContainer, error) {
+	return StartContainer(sandboxID, containerID)
 }
 
 // StopContainer implements the VC function of the same name.
-func (impl *VCImpl) StopContainer(podID, containerID string) (VCContainer, error) {
-	return StopContainer(podID, containerID)
+func (impl *VCImpl) StopContainer(sandboxID, containerID string) (VCContainer, error) {
+	return StopContainer(sandboxID, containerID)
 }
 
 // EnterContainer implements the VC function of the same name.
-func (impl *VCImpl) EnterContainer(podID, containerID string, cmd Cmd) (VCPod, VCContainer, *Process, error) {
-	return EnterContainer(podID, containerID, cmd)
+func (impl *VCImpl) EnterContainer(sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error) {
+	return EnterContainer(sandboxID, containerID, cmd)
 }
 
 // StatusContainer implements the VC function of the same name.
-func (impl *VCImpl) StatusContainer(podID, containerID string) (ContainerStatus, error) {
-	return StatusContainer(podID, containerID)
+func (impl *VCImpl) StatusContainer(sandboxID, containerID string) (ContainerStatus, error) {
+	return StatusContainer(sandboxID, containerID)
 }
 
 // KillContainer implements the VC function of the same name.
-func (impl *VCImpl) KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
-	return KillContainer(podID, containerID, signal, all)
+func (impl *VCImpl) KillContainer(sandboxID, containerID string, signal syscall.Signal, all bool) error {
+	return KillContainer(sandboxID, containerID, signal, all)
 }
 
 // ProcessListContainer implements the VC function of the same name.
-func (impl *VCImpl) ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error) {
-	return ProcessListContainer(podID, containerID, options)
+func (impl *VCImpl) ProcessListContainer(sandboxID, containerID string, options ProcessListOptions) (ProcessList, error) {
+	return ProcessListContainer(sandboxID, containerID, options)
 }

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -24,29 +24,29 @@ import (
 type VC interface {
 	SetLogger(logger logrus.FieldLogger)
 
-	CreatePod(podConfig PodConfig) (VCPod, error)
-	DeletePod(podID string) (VCPod, error)
-	ListPod() ([]PodStatus, error)
-	PausePod(podID string) (VCPod, error)
-	ResumePod(podID string) (VCPod, error)
-	RunPod(podConfig PodConfig) (VCPod, error)
-	StartPod(podID string) (VCPod, error)
-	StatusPod(podID string) (PodStatus, error)
-	StopPod(podID string) (VCPod, error)
+	CreateSandbox(sandboxConfig SandboxConfig) (VCSandbox, error)
+	DeleteSandbox(sandboxID string) (VCSandbox, error)
+	ListSandbox() ([]SandboxStatus, error)
+	PauseSandbox(sandboxID string) (VCSandbox, error)
+	ResumeSandbox(sandboxID string) (VCSandbox, error)
+	RunSandbox(sandboxConfig SandboxConfig) (VCSandbox, error)
+	StartSandbox(sandboxID string) (VCSandbox, error)
+	StatusSandbox(sandboxID string) (SandboxStatus, error)
+	StopSandbox(sandboxID string) (VCSandbox, error)
 
-	CreateContainer(podID string, containerConfig ContainerConfig) (VCPod, VCContainer, error)
-	DeleteContainer(podID, containerID string) (VCContainer, error)
-	EnterContainer(podID, containerID string, cmd Cmd) (VCPod, VCContainer, *Process, error)
-	KillContainer(podID, containerID string, signal syscall.Signal, all bool) error
-	StartContainer(podID, containerID string) (VCContainer, error)
-	StatusContainer(podID, containerID string) (ContainerStatus, error)
-	StopContainer(podID, containerID string) (VCContainer, error)
-	ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error)
+	CreateContainer(sandboxID string, containerConfig ContainerConfig) (VCSandbox, VCContainer, error)
+	DeleteContainer(sandboxID, containerID string) (VCContainer, error)
+	EnterContainer(sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error)
+	KillContainer(sandboxID, containerID string, signal syscall.Signal, all bool) error
+	StartContainer(sandboxID, containerID string) (VCContainer, error)
+	StatusContainer(sandboxID, containerID string) (ContainerStatus, error)
+	StopContainer(sandboxID, containerID string) (VCContainer, error)
+	ProcessListContainer(sandboxID, containerID string, options ProcessListOptions) (ProcessList, error)
 }
 
-// VCPod is the Pod interface
-// (required since virtcontainers.Pod only contains private fields)
-type VCPod interface {
+// VCSandbox is the Sandbox interface
+// (required since virtcontainers.Sandbox only contains private fields)
+type VCSandbox interface {
 	Annotations(key string) (string, error)
 	GetAllContainers() []VCContainer
 	GetAnnotations() map[string]string
@@ -62,7 +62,7 @@ type VCContainer interface {
 	GetPid() int
 	GetToken() string
 	ID() string
-	Pod() VCPod
+	Sandbox() VCSandbox
 	Process() Process
 	SetPid(pid int) error
 }

--- a/virtcontainers/kata_builtin_shim.go
+++ b/virtcontainers/kata_builtin_shim.go
@@ -21,6 +21,6 @@ type kataBuiltInShim struct{}
 // start is the kataBuiltInShim start implementation for kata builtin shim.
 // It does nothing. The shim functionality is provided by the virtcontainers
 // library.
-func (s *kataBuiltInShim) start(pod Pod, params ShimParams) (int, error) {
+func (s *kataBuiltInShim) start(sandbox Sandbox, params ShimParams) (int, error) {
 	return -1, nil
 }

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -29,8 +29,8 @@ type kataProxy struct {
 }
 
 // start is kataProxy start implementation for proxy interface.
-func (p *kataProxy) start(pod Pod, params proxyParams) (int, string, error) {
-	if pod.agent == nil {
+func (p *kataProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+	if sandbox.agent == nil {
 		return -1, "", fmt.Errorf("No agent")
 	}
 
@@ -38,13 +38,13 @@ func (p *kataProxy) start(pod Pod, params proxyParams) (int, string, error) {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
 
-	config, err := newProxyConfig(pod.config)
+	config, err := newProxyConfig(sandbox.config)
 	if err != nil {
 		return -1, "", err
 	}
 
 	// construct the socket path the proxy instance will use
-	proxyURL, err := defaultProxyURL(pod, SocketTypeUNIX)
+	proxyURL, err := defaultProxyURL(sandbox, SocketTypeUNIX)
 	if err != nil {
 		return -1, "", err
 	}
@@ -52,7 +52,7 @@ func (p *kataProxy) start(pod Pod, params proxyParams) (int, string, error) {
 	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", params.agentURL}
 	if config.Debug {
 		args = append(args, "-log", "debug")
-		args = append(args, "-agent-logs-socket", pod.hypervisor.getPodConsole(pod.id))
+		args = append(args, "-agent-logs-socket", sandbox.hypervisor.getSandboxConsole(sandbox.id))
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)
@@ -64,7 +64,7 @@ func (p *kataProxy) start(pod Pod, params proxyParams) (int, string, error) {
 }
 
 // stop is kataProxy stop implementation for proxy interface.
-func (p *kataProxy) stop(pod Pod, pid int) error {
+func (p *kataProxy) stop(sandbox Sandbox, pid int) error {
 	// Signal the proxy with SIGTERM.
 	return syscall.Kill(pid, syscall.SIGTERM)
 }

--- a/virtcontainers/kata_shim.go
+++ b/virtcontainers/kata_shim.go
@@ -32,12 +32,12 @@ type KataShimConfig struct {
 // start is the ccShim start implementation.
 // It starts the cc-shim binary with URL and token flags provided by
 // the proxy.
-func (s *kataShim) start(pod Pod, params ShimParams) (int, error) {
-	if pod.config == nil {
-		return -1, fmt.Errorf("Pod config cannot be nil")
+func (s *kataShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+	if sandbox.config == nil {
+		return -1, fmt.Errorf("Sandbox config cannot be nil")
 	}
 
-	config, ok := newShimConfig(*(pod.config)).(ShimConfig)
+	config, ok := newShimConfig(*(sandbox.config)).(ShimConfig)
 	if !ok {
 		return -1, fmt.Errorf("Wrong shim config type, should be KataShimConfig type")
 	}

--- a/virtcontainers/kata_shim_test.go
+++ b/virtcontainers/kata_shim_test.go
@@ -40,65 +40,65 @@ func getMockKataShimBinPath() string {
 	return DefaultMockKataShimBinPath
 }
 
-func testKataShimStart(t *testing.T, pod Pod, params ShimParams, expectFail bool) {
+func testKataShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectFail bool) {
 	s := &kataShim{}
 
-	pid, err := s.start(pod, params)
+	pid, err := s.start(sandbox, params)
 	if expectFail {
 		if err == nil || pid != -1 {
-			t.Fatalf("This test should fail (pod %+v, params %+v, expectFail %t)",
-				pod, params, expectFail)
+			t.Fatalf("This test should fail (sandbox %+v, params %+v, expectFail %t)",
+				sandbox, params, expectFail)
 		}
 	} else {
 		if err != nil {
-			t.Fatalf("This test should pass (pod %+v, params %+v, expectFail %t): %s",
-				pod, params, expectFail, err)
+			t.Fatalf("This test should pass (sandbox %+v, params %+v, expectFail %t): %s",
+				sandbox, params, expectFail, err)
 		}
 
 		if pid == -1 {
-			t.Fatalf("This test should pass (pod %+v, params %+v, expectFail %t)",
-				pod, params, expectFail)
+			t.Fatalf("This test should pass (sandbox %+v, params %+v, expectFail %t)",
+				sandbox, params, expectFail)
 		}
 	}
 }
 
-func TestKataShimStartNilPodConfigFailure(t *testing.T) {
-	testKataShimStart(t, Pod{}, ShimParams{}, true)
+func TestKataShimStartNilSandboxConfigFailure(t *testing.T) {
+	testKataShimStart(t, Sandbox{}, ShimParams{}, true)
 }
 
 func TestKataShimStartNilShimConfigFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{},
+	sandbox := Sandbox{
+		config: &SandboxConfig{},
 	}
 
-	testKataShimStart(t, pod, ShimParams{}, true)
+	testKataShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestKataShimStartShimPathEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType:   KataShimType,
 			ShimConfig: ShimConfig{},
 		},
 	}
 
-	testKataShimStart(t, pod, ShimParams{}, true)
+	testKataShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestKataShimStartShimTypeInvalid(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType:   "foo",
 			ShimConfig: ShimConfig{},
 		},
 	}
 
-	testKataShimStart(t, pod, ShimParams{}, true)
+	testKataShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestKataShimStartParamsTokenEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -106,12 +106,12 @@ func TestKataShimStartParamsTokenEmptyFailure(t *testing.T) {
 		},
 	}
 
-	testKataShimStart(t, pod, ShimParams{}, true)
+	testKataShimStart(t, sandbox, ShimParams{}, true)
 }
 
 func TestKataShimStartParamsURLEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -123,12 +123,12 @@ func TestKataShimStartParamsURLEmptyFailure(t *testing.T) {
 		Token: "testToken",
 	}
 
-	testKataShimStart(t, pod, params, true)
+	testKataShimStart(t, sandbox, params, true)
 }
 
 func TestKataShimStartParamsContainerEmptyFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -141,7 +141,7 @@ func TestKataShimStartParamsContainerEmptyFailure(t *testing.T) {
 		URL:   "unix://is/awesome",
 	}
 
-	testKataShimStart(t, pod, params, true)
+	testKataShimStart(t, sandbox, params, true)
 }
 
 func TestKataShimStartParamsInvalidCommand(t *testing.T) {
@@ -153,8 +153,8 @@ func TestKataShimStartParamsInvalidCommand(t *testing.T) {
 
 	cmd := filepath.Join(dir, "does-not-exist")
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: cmd,
@@ -167,20 +167,20 @@ func TestKataShimStartParamsInvalidCommand(t *testing.T) {
 		URL:   "http://foo",
 	}
 
-	testKataShimStart(t, pod, params, true)
+	testKataShimStart(t, sandbox, params, true)
 }
 
-func startKataShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Pod, ShimParams, error) {
+func startKataShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Sandbox, ShimParams, error) {
 	saveStdout := os.Stdout
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {
-		return nil, nil, nil, Pod{}, ShimParams{}, err
+		return nil, nil, nil, Sandbox{}, ShimParams{}, err
 	}
 
 	os.Stdout = wStdout
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -195,11 +195,11 @@ func startKataShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.
 		Detach:    detach,
 	}
 
-	return rStdout, wStdout, saveStdout, pod, params, nil
+	return rStdout, wStdout, saveStdout, sandbox, params, nil
 }
 
 func TestKataShimStartSuccessful(t *testing.T) {
-	rStdout, wStdout, saveStdout, pod, params, err := startKataShimStartWithoutConsoleSuccessful(t, false)
+	rStdout, wStdout, saveStdout, sandbox, params, err := startKataShimStartWithoutConsoleSuccessful(t, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestKataShimStartSuccessful(t *testing.T) {
 		wStdout.Close()
 	}()
 
-	testKataShimStart(t, pod, params, false)
+	testKataShimStart(t, sandbox, params, false)
 
 	bufStdout := make([]byte, 1024)
 	if _, err := rStdout.Read(bufStdout); err != nil {
@@ -223,7 +223,7 @@ func TestKataShimStartSuccessful(t *testing.T) {
 }
 
 func TestKataShimStartDetachSuccessful(t *testing.T) {
-	rStdout, wStdout, saveStdout, pod, params, err := startKataShimStartWithoutConsoleSuccessful(t, true)
+	rStdout, wStdout, saveStdout, sandbox, params, err := startKataShimStartWithoutConsoleSuccessful(t, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestKataShimStartDetachSuccessful(t *testing.T) {
 		rStdout.Close()
 	}()
 
-	testKataShimStart(t, pod, params, false)
+	testKataShimStart(t, sandbox, params, false)
 
 	readCh := make(chan error)
 	go func() {
@@ -264,8 +264,8 @@ func TestKataShimStartDetachSuccessful(t *testing.T) {
 }
 
 func TestKataShimStartWithConsoleNonExistingFailure(t *testing.T) {
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -279,7 +279,7 @@ func TestKataShimStartWithConsoleNonExistingFailure(t *testing.T) {
 		Console: testWrongConsolePath,
 	}
 
-	testKataShimStart(t, pod, params, true)
+	testKataShimStart(t, sandbox, params, true)
 }
 
 func TestKataShimStartWithConsoleSuccessful(t *testing.T) {
@@ -292,8 +292,8 @@ func TestKataShimStartWithConsoleSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pod := Pod{
-		config: &PodConfig{
+	sandbox := Sandbox{
+		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
 				Path: getMockKataShimBinPath(),
@@ -308,6 +308,6 @@ func TestKataShimStartWithConsoleSuccessful(t *testing.T) {
 		Console:   console,
 	}
 
-	testKataShimStart(t, pod, params, false)
+	testKataShimStart(t, sandbox, params, false)
 	master.Close()
 }

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -19,8 +19,8 @@ package virtcontainers
 type mockHypervisor struct {
 }
 
-func (m *mockHypervisor) init(pod *Pod) error {
-	valid, err := pod.config.HypervisorConfig.valid()
+func (m *mockHypervisor) init(sandbox *Sandbox) error {
+	valid, err := sandbox.config.HypervisorConfig.valid()
 	if valid == false || err != nil {
 		return err
 	}
@@ -32,27 +32,27 @@ func (m *mockHypervisor) capabilities() capabilities {
 	return capabilities{}
 }
 
-func (m *mockHypervisor) createPod(podConfig PodConfig) error {
+func (m *mockHypervisor) createSandbox(sandboxConfig SandboxConfig) error {
 	return nil
 }
 
-func (m *mockHypervisor) startPod() error {
+func (m *mockHypervisor) startSandbox() error {
 	return nil
 }
 
-func (m *mockHypervisor) waitPod(timeout int) error {
+func (m *mockHypervisor) waitSandbox(timeout int) error {
 	return nil
 }
 
-func (m *mockHypervisor) stopPod() error {
+func (m *mockHypervisor) stopSandbox() error {
 	return nil
 }
 
-func (m *mockHypervisor) pausePod() error {
+func (m *mockHypervisor) pauseSandbox() error {
 	return nil
 }
 
-func (m *mockHypervisor) resumePod() error {
+func (m *mockHypervisor) resumeSandbox() error {
 	return nil
 }
 
@@ -68,6 +68,6 @@ func (m *mockHypervisor) hotplugRemoveDevice(devInfo interface{}, devType device
 	return nil
 }
 
-func (m *mockHypervisor) getPodConsole(podID string) string {
+func (m *mockHypervisor) getSandboxConsole(sandboxID string) string {
 	return ""
 }

--- a/virtcontainers/mock_hypervisor_test.go
+++ b/virtcontainers/mock_hypervisor_test.go
@@ -24,8 +24,8 @@ import (
 func TestMockHypervisorInit(t *testing.T) {
 	var m *mockHypervisor
 
-	pod := &Pod{
-		config: &PodConfig{
+	sandbox := &Sandbox{
+		config: &SandboxConfig{
 			HypervisorConfig: HypervisorConfig{
 				KernelPath:     "",
 				ImagePath:      "",
@@ -35,52 +35,52 @@ func TestMockHypervisorInit(t *testing.T) {
 	}
 
 	// wrong config
-	if err := m.init(pod); err == nil {
+	if err := m.init(sandbox); err == nil {
 		t.Fatal()
 	}
 
-	pod.config.HypervisorConfig = HypervisorConfig{
+	sandbox.config.HypervisorConfig = HypervisorConfig{
 		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
 		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
 		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
 	}
 
 	// right config
-	if err := m.init(pod); err != nil {
+	if err := m.init(sandbox); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMockHypervisorCreatePod(t *testing.T) {
+func TestMockHypervisorCreateSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	config := PodConfig{}
+	config := SandboxConfig{}
 
-	if err := m.createPod(config); err != nil {
+	if err := m.createSandbox(config); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMockHypervisorStartPod(t *testing.T) {
+func TestMockHypervisorStartSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.startPod(); err != nil {
+	if err := m.startSandbox(); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMockHypervisorWaitPod(t *testing.T) {
+func TestMockHypervisorWaitSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.waitPod(0); err != nil {
+	if err := m.waitSandbox(0); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMockHypervisorStopPod(t *testing.T) {
+func TestMockHypervisorStopSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.stopPod(); err != nil {
+	if err := m.stopSandbox(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,12 +93,12 @@ func TestMockHypervisorAddDevice(t *testing.T) {
 	}
 }
 
-func TestMockHypervisorGetPodConsole(t *testing.T) {
+func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 	var m *mockHypervisor
 
 	expected := ""
 
-	if result := m.getPodConsole("testPodID"); result != expected {
+	if result := m.getSandboxConsole("testSandboxID"); result != expected {
 		t.Fatalf("Got %s\nExpecting %s", result, expected)
 	}
 }

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -259,8 +259,8 @@ func bindMount(source, destination string, readonly bool) error {
 
 // bindMountContainerRootfs bind mounts a container rootfs into a 9pfs shared
 // directory between the guest and the host.
-func bindMountContainerRootfs(sharedDir, podID, cID, cRootFs string, readonly bool) error {
-	rootfsDest := filepath.Join(sharedDir, podID, cID, rootfsDir)
+func bindMountContainerRootfs(sharedDir, sandboxID, cID, cRootFs string, readonly bool) error {
+	rootfsDest := filepath.Join(sharedDir, sandboxID, cID, rootfsDir)
 
 	return bindMount(cRootFs, rootfsDest, readonly)
 }
@@ -288,20 +288,20 @@ type Mount struct {
 	BlockDevice *BlockDevice
 }
 
-func bindUnmountContainerRootfs(sharedDir, podID, cID string) error {
-	rootfsDest := filepath.Join(sharedDir, podID, cID, rootfsDir)
+func bindUnmountContainerRootfs(sharedDir, sandboxID, cID string) error {
+	rootfsDest := filepath.Join(sharedDir, sandboxID, cID, rootfsDir)
 	syscall.Unmount(rootfsDest, 0)
 
 	return nil
 }
 
-func bindUnmountAllRootfs(sharedDir string, pod Pod) {
-	for _, c := range pod.containers {
+func bindUnmountAllRootfs(sharedDir string, sandbox Sandbox) {
+	for _, c := range sandbox.containers {
 		c.unmountHostMounts()
 		if c.state.Fstype == "" {
 			// Need to check for error returned by this call.
 			// See: https://github.com/containers/virtcontainers/issues/295
-			bindUnmountContainerRootfs(sharedDir, pod.id, c.id)
+			bindUnmountContainerRootfs(sharedDir, sandbox.id, c.id)
 		}
 	}
 }

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -600,10 +600,10 @@ func runNetworkCommon(networkNSPath string, cb func() error) error {
 	})
 }
 
-func addNetworkCommon(pod Pod, networkNS *NetworkNamespace) error {
+func addNetworkCommon(sandbox Sandbox, networkNS *NetworkNamespace) error {
 	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
 		for _, endpoint := range networkNS.Endpoints {
-			if err := endpoint.Attach(pod.hypervisor); err != nil {
+			if err := endpoint.Attach(sandbox.hypervisor); err != nil {
 				return err
 			}
 		}
@@ -1376,9 +1376,9 @@ type network interface {
 	run(networkNSPath string, cb func() error) error
 
 	// add adds all needed interfaces inside the network namespace.
-	add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error)
+	add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error)
 
 	// remove unbridges and deletes TAP interfaces. It also removes virtual network
 	// interfaces and deletes the network namespace.
-	remove(pod Pod, networkNS NetworkNamespace) error
+	remove(sandbox Sandbox, networkNS NetworkNamespace) error
 }

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -34,7 +34,7 @@ type noProxy struct {
 }
 
 // start is noProxy start implementation for proxy interface.
-func (p *noProxy) start(pod Pod, params proxyParams) (int, string, error) {
+func (p *noProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
 	if params.agentURL == "" {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
@@ -43,6 +43,6 @@ func (p *noProxy) start(pod Pod, params proxyParams) (int, string, error) {
 }
 
 // stop is noProxy stop implementation for proxy interface.
-func (p *noProxy) stop(pod Pod, pid int) error {
+func (p *noProxy) stop(sandbox Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/no_proxy_test.go
+++ b/virtcontainers/no_proxy_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 func TestNoProxyStart(t *testing.T) {
-	pod := Pod{
+	sandbox := Sandbox{
 		agent: newAgent(NoopAgentType),
 	}
 
 	p := &noProxy{}
 
 	agentURL := "agentURL"
-	pid, vmURL, err := p.start(pod, proxyParams{agentURL: agentURL})
+	pid, vmURL, err := p.start(sandbox, proxyParams{agentURL: agentURL})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestNoProxyStart(t *testing.T) {
 func TestNoProxyStop(t *testing.T) {
 	p := &noProxy{}
 
-	if err := p.stop(Pod{}, 0); err != nil {
+	if err := p.stop(Sandbox{}, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -26,12 +26,12 @@ type noopAgent struct {
 }
 
 // init initializes the Noop agent, i.e. it does nothing.
-func (n *noopAgent) init(pod *Pod, config interface{}) error {
+func (n *noopAgent) init(sandbox *Sandbox, config interface{}) error {
 	return nil
 }
 
-// createPod is the Noop agent pod creation implementation. It does nothing.
-func (n *noopAgent) createPod(pod *Pod) error {
+// createSandbox is the Noop agent sandbox creation implementation. It does nothing.
+func (n *noopAgent) createSandbox(sandbox *Sandbox) error {
 	return nil
 }
 
@@ -41,42 +41,42 @@ func (n *noopAgent) capabilities() capabilities {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
+func (n *noopAgent) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error) {
 	return nil, nil
 }
 
-// startPod is the Noop agent Pod starting implementation. It does nothing.
-func (n *noopAgent) startPod(pod Pod) error {
+// startSandbox is the Noop agent Sandbox starting implementation. It does nothing.
+func (n *noopAgent) startSandbox(sandbox Sandbox) error {
 	return nil
 }
 
-// stopPod is the Noop agent Pod stopping implementation. It does nothing.
-func (n *noopAgent) stopPod(pod Pod) error {
+// stopSandbox is the Noop agent Sandbox stopping implementation. It does nothing.
+func (n *noopAgent) stopSandbox(sandbox Sandbox) error {
 	return nil
 }
 
 // createContainer is the Noop agent Container creation implementation. It does nothing.
-func (n *noopAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
+func (n *noopAgent) createContainer(sandbox *Sandbox, c *Container) (*Process, error) {
 	return &Process{}, nil
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(pod Pod, c *Container) error {
+func (n *noopAgent) startContainer(sandbox Sandbox, c *Container) error {
 	return nil
 }
 
 // stopContainer is the Noop agent Container stopping implementation. It does nothing.
-func (n *noopAgent) stopContainer(pod Pod, c Container) error {
+func (n *noopAgent) stopContainer(sandbox Sandbox, c Container) error {
 	return nil
 }
 
 // killContainer is the Noop agent Container signaling implementation. It does nothing.
-func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
+func (n *noopAgent) killContainer(sandbox Sandbox, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
 
 // processListContainer is the Noop agent Container ps implementation. It does nothing.
-func (n *noopAgent) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+func (n *noopAgent) processListContainer(sandbox Sandbox, c Container, options ProcessListOptions) (ProcessList, error) {
 	return nil, nil
 }
 

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 )
 
-func testCreateNoopContainer() (*Pod, *Container, error) {
+func testCreateNoopContainer() (*Sandbox, *Container, error) {
 	contID := "100"
-	config := newTestPodConfigNoop()
+	config := newTestSandboxConfigNoop()
 
-	p, err := CreatePod(config)
+	p, err := CreateSandbox(config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,14 +36,14 @@ func testCreateNoopContainer() (*Pod, *Container, error) {
 		return nil, nil, err
 	}
 
-	return p.(*Pod), c.(*Container), nil
+	return p.(*Sandbox), c.(*Container), nil
 }
 
 func TestNoopAgentInit(t *testing.T) {
 	n := &noopAgent{}
-	pod := &Pod{}
+	sandbox := &Sandbox{}
 
-	err := n.init(pod, nil)
+	err := n.init(sandbox, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,32 +52,32 @@ func TestNoopAgentInit(t *testing.T) {
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	cmd := Cmd{}
-	pod, container, err := testCreateNoopContainer()
+	sandbox, container, err := testCreateNoopContainer()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanUp()
 
-	if _, err = n.exec(pod, *container, cmd); err != nil {
+	if _, err = n.exec(sandbox, *container, cmd); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestNoopAgentStartPod(t *testing.T) {
+func TestNoopAgentStartSandbox(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	sandbox := Sandbox{}
 
-	err := n.startPod(pod)
+	err := n.startSandbox(sandbox)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestNoopAgentStopPod(t *testing.T) {
+func TestNoopAgentStopSandbox(t *testing.T) {
 	n := &noopAgent{}
-	pod := Pod{}
+	sandbox := Sandbox{}
 
-	err := n.stopPod(pod)
+	err := n.stopSandbox(sandbox)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,30 +85,30 @@ func TestNoopAgentStopPod(t *testing.T) {
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod, container, err := testCreateNoopContainer()
+	sandbox, container, err := testCreateNoopContainer()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanUp()
 
-	if err := n.startPod(*pod); err != nil {
+	if err := n.startSandbox(*sandbox); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := n.createContainer(pod, container); err != nil {
+	if _, err := n.createContainer(sandbox, container); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestNoopAgentStartContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod, container, err := testCreateNoopContainer()
+	sandbox, container, err := testCreateNoopContainer()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanUp()
 
-	err = n.startContainer(*pod, container)
+	err = n.startContainer(*sandbox, container)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,13 +116,13 @@ func TestNoopAgentStartContainer(t *testing.T) {
 
 func TestNoopAgentStopContainer(t *testing.T) {
 	n := &noopAgent{}
-	pod, container, err := testCreateNoopContainer()
+	sandbox, container, err := testCreateNoopContainer()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanUp()
 
-	err = n.stopContainer(*pod, *container)
+	err = n.stopContainer(*sandbox, *container)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/virtcontainers/noop_network.go
+++ b/virtcontainers/noop_network.go
@@ -36,13 +36,13 @@ func (n *noopNetwork) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace the Noop network.
 // It does nothing.
-func (n *noopNetwork) add(pod Pod, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
+func (n *noopNetwork) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
 	return NetworkNamespace{}, nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the Noop network.
 // It does nothing.
-func (n *noopNetwork) remove(pod Pod, networkNS NetworkNamespace) error {
+func (n *noopNetwork) remove(sandbox Sandbox, networkNS NetworkNamespace) error {
 	return nil
 }

--- a/virtcontainers/noop_proxy.go
+++ b/virtcontainers/noop_proxy.go
@@ -24,12 +24,12 @@ var noopProxyURL = "noopProxyURL"
 
 // register is the proxy start implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) start(pod Pod, params proxyParams) (int, string, error) {
+func (p *noopProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
 	return 0, noopProxyURL, nil
 }
 
 // stop is the proxy stop implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) stop(pod Pod, pid int) error {
+func (p *noopProxy) stop(sandbox Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/noop_shim.go
+++ b/virtcontainers/noop_shim.go
@@ -20,6 +20,6 @@ type noopShim struct{}
 
 // start is the noopShim start implementation for testing purpose.
 // It does nothing.
-func (s *noopShim) start(pod Pod, params ShimParams) (int, error) {
+func (s *noopShim) start(sandbox Sandbox, params ShimParams) (int, error) {
 	return 1000, nil
 }

--- a/virtcontainers/noop_shim_test.go
+++ b/virtcontainers/noop_shim_test.go
@@ -22,11 +22,11 @@ import (
 
 func TestNoopShimStart(t *testing.T) {
 	s := &noopShim{}
-	pod := Pod{}
+	sandbox := Sandbox{}
 	params := ShimParams{}
 	expected := 1000
 
-	pid, err := s.start(pod, params)
+	pid, err := s.start(sandbox, params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -19,34 +19,34 @@ package annotations
 const (
 	vcAnnotationsPrefix = "com.github.containers.virtcontainers."
 
-	// KernelPath is a pod annotation for passing a per container path pointing at the kernel needed to boot the container VM.
+	// KernelPath is a sandbox annotation for passing a per container path pointing at the kernel needed to boot the container VM.
 	KernelPath = vcAnnotationsPrefix + "KernelPath"
 
-	// ImagePath is a pod annotation for passing a per container path pointing at the guest image that will run in the container VM.
+	// ImagePath is a sandbox annotation for passing a per container path pointing at the guest image that will run in the container VM.
 	ImagePath = vcAnnotationsPrefix + "ImagePath"
 
-	// InitrdPath is a pod annotation for passing a per container path pointing at the guest initrd image that will run in the container VM.
+	// InitrdPath is a sandbox annotation for passing a per container path pointing at the guest initrd image that will run in the container VM.
 	InitrdPath = vcAnnotationsPrefix + "InitrdPath"
 
-	// HypervisorPath is a pod annotation for passing a per container path pointing at the hypervisor that will run the container VM.
+	// HypervisorPath is a sandbox annotation for passing a per container path pointing at the hypervisor that will run the container VM.
 	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
 
-	// FirmwarePath is a pod annotation for passing a per container path pointing at the guest firmware that will run the container VM.
+	// FirmwarePath is a sandbox annotation for passing a per container path pointing at the guest firmware that will run the container VM.
 	FirmwarePath = vcAnnotationsPrefix + "FirmwarePath"
 
-	// KernelHash is a pod annotation for passing a container kernel image SHA-512 hash value.
+	// KernelHash is a sandbox annotation for passing a container kernel image SHA-512 hash value.
 	KernelHash = vcAnnotationsPrefix + "KernelHash"
 
-	// ImageHash is an pod annotation for passing a container guest image SHA-512 hash value.
+	// ImageHash is an sandbox annotation for passing a container guest image SHA-512 hash value.
 	ImageHash = vcAnnotationsPrefix + "ImageHash"
 
-	// InitrdHash is an pod annotation for passing a container guest initrd SHA-512 hash value.
+	// InitrdHash is an sandbox annotation for passing a container guest initrd SHA-512 hash value.
 	InitrdHash = vcAnnotationsPrefix + "InitrdHash"
 
-	// HypervisorHash is an pod annotation for passing a container hypervisor binary SHA-512 hash value.
+	// HypervisorHash is an sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
 	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"
 
-	// FirmwareHash is an pod annotation for passing a container guest firmware SHA-512 hash value.
+	// FirmwareHash is an sandbox annotation for passing a container guest firmware SHA-512 hash value.
 	FirmwareHash = vcAnnotationsPrefix + "FirmwareHash"
 
 	// AssetHashType is the hash type used for assets verification

--- a/virtcontainers/pkg/annotations/dockershim/annotations.go
+++ b/virtcontainers/pkg/annotations/dockershim/annotations.go
@@ -25,10 +25,10 @@ const (
 	// ContainerTypeLabelKey is the container type (podsandbox or container) annotation
 	ContainerTypeLabelKey = "io.kubernetes.docker.type"
 
-	// ContainerTypeLabelSandbox represents a pod sandbox container
+	// ContainerTypeLabelSandbox represents a sandbox sandbox container
 	ContainerTypeLabelSandbox = "podsandbox"
 
-	// ContainerTypeLabelContainer represents a container running within a pod
+	// ContainerTypeLabelContainer represents a container running within a sandbox
 	ContainerTypeLabelContainer = "container"
 
 	// SandboxIDLabelKey is the sandbox ID annotation

--- a/virtcontainers/pkg/cni/cni.go
+++ b/virtcontainers/pkg/cni/cni.go
@@ -123,17 +123,17 @@ func getDefNetwork(confDir, binDir string) (*cniNetwork, error) {
 	return getNetwork(confDir, binDir, DefNetName, false)
 }
 
-func buildRuntimeConf(podID, podNetNSPath, ifName string) *libcni.RuntimeConf {
+func buildRuntimeConf(sandboxID, sandboxNetNSPath, ifName string) *libcni.RuntimeConf {
 	return &libcni.RuntimeConf{
-		ContainerID: podID,
-		NetNS:       podNetNSPath,
+		ContainerID: sandboxID,
+		NetNS:       sandboxNetNSPath,
 		IfName:      ifName,
 	}
 }
 
 // AddNetwork calls the CNI plugin to create a network between the host and the network namespace.
-func (plugin *NetworkPlugin) AddNetwork(podID, netNSPath, ifName string) (types.Result, error) {
-	rt := buildRuntimeConf(podID, netNSPath, ifName)
+func (plugin *NetworkPlugin) AddNetwork(sandboxID, netNSPath, ifName string) (types.Result, error) {
+	rt := buildRuntimeConf(sandboxID, netNSPath, ifName)
 
 	_, err := plugin.loNetwork.cniConfig.AddNetwork(plugin.loNetwork.networkConfig, rt)
 	if err != nil {
@@ -150,8 +150,8 @@ func (plugin *NetworkPlugin) AddNetwork(podID, netNSPath, ifName string) (types.
 
 // RemoveNetwork calls the CNI plugin to remove a specific network previously created between
 // the host and the network namespace.
-func (plugin *NetworkPlugin) RemoveNetwork(podID, netNSPath, ifName string) error {
-	rt := buildRuntimeConf(podID, netNSPath, ifName)
+func (plugin *NetworkPlugin) RemoveNetwork(sandboxID, netNSPath, ifName string) error {
+	rt := buildRuntimeConf(sandboxID, netNSPath, ifName)
 
 	err := plugin.defNetwork.cniConfig.DelNetwork(plugin.defNetwork.networkConfig, rt)
 	if err != nil {

--- a/virtcontainers/pkg/cni/cni_test.go
+++ b/virtcontainers/pkg/cni/cni_test.go
@@ -267,12 +267,12 @@ func TestNewNetworkPluginFailureWrongNetwork(t *testing.T) {
 
 func TestBuildRuntimeConf(t *testing.T) {
 	expected := libcni.RuntimeConf{
-		ContainerID: "testPodID",
-		NetNS:       "testPodNetNSPath",
+		ContainerID: "testSandboxID",
+		NetNS:       "testSandboxNetNSPath",
 		IfName:      "testIfName",
 	}
 
-	runtimeConf := buildRuntimeConf("testPodID", "testPodNetNSPath", "testIfName")
+	runtimeConf := buildRuntimeConf("testSandboxID", "testSandboxNetNSPath", "testIfName")
 
 	if reflect.DeepEqual(*runtimeConf, expected) == false {
 		t.Fatal("Runtime configuration different from expected one")
@@ -298,7 +298,7 @@ func TestAddNetworkSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = netPlugin.AddNetwork("testPodID", testNetNsPath, "testIfName")
+	_, err = netPlugin.AddNetwork("testSandboxID", testNetNsPath, "testIfName")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +323,7 @@ func TestAddNetworkFailureUnknownNetNs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = netPlugin.AddNetwork("testPodID", invalidNetNsPath, "testIfName")
+	_, err = netPlugin.AddNetwork("testSandboxID", invalidNetNsPath, "testIfName")
 	if err == nil {
 		t.Fatalf("Should fail because netns %s does not exist", invalidNetNsPath)
 	}
@@ -348,12 +348,12 @@ func TestRemoveNetworkSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = netPlugin.AddNetwork("testPodID", testNetNsPath, "testIfName")
+	_, err = netPlugin.AddNetwork("testSandboxID", testNetNsPath, "testIfName")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = netPlugin.RemoveNetwork("testPodID", testNetNsPath, "testIfName")
+	err = netPlugin.RemoveNetwork("testSandboxID", testNetNsPath, "testIfName")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func TestRemoveNetworkSuccessfulNetworkDoesNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = netPlugin.RemoveNetwork("testPodID", testNetNsPath, "testIfName")
+	err = netPlugin.RemoveNetwork("testSandboxID", testNetNsPath, "testIfName")
 	if err != nil {
 		// CNI specification says that no error should be returned
 		// in case we try to tear down a non-existing network.

--- a/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -32,15 +32,15 @@ import (
 // Need to be in sync with hyperstart/src/api.h
 const (
 	Version         = "version"
-	StartPod        = "startpod"
-	DestroyPod      = "destroypod"
+	StartSandbox    = "startsandbox"
+	DestroySandbox  = "destroysandbox"
 	ExecCmd         = "execcmd"
 	Ready           = "ready"
 	Ack             = "ack"
 	Error           = "error"
 	WinSize         = "winsize"
 	Ping            = "ping"
-	FinishPod       = "finishpod"
+	FinishSandbox   = "finishsandbox"
 	Next            = "next"
 	WriteFile       = "writefile"
 	ReadFile        = "readfile"
@@ -57,8 +57,8 @@ const (
 // and its corresponding code.
 var CodeList = map[string]uint32{
 	Version:         VersionCode,
-	StartPod:        StartPodCode,
-	DestroyPod:      DestroyPodCode,
+	StartSandbox:    StartSandboxCode,
+	DestroySandbox:  DestroySandboxCode,
 	ExecCmd:         ExecCmdCode,
 	Ready:           ReadyCode,
 	Ack:             AckCode,

--- a/virtcontainers/pkg/hyperstart/hyperstart_test.go
+++ b/virtcontainers/pkg/hyperstart/hyperstart_test.go
@@ -394,12 +394,12 @@ func TestCodeFromCmdVersion(t *testing.T) {
 	testCodeFromCmd(t, Version, VersionCode)
 }
 
-func TestCodeFromCmdStartPod(t *testing.T) {
-	testCodeFromCmd(t, StartPod, StartPodCode)
+func TestCodeFromCmdStartSandbox(t *testing.T) {
+	testCodeFromCmd(t, StartSandbox, StartSandboxCode)
 }
 
-func TestCodeFromCmdDestroyPod(t *testing.T) {
-	testCodeFromCmd(t, DestroyPod, DestroyPodCode)
+func TestCodeFromCmdDestroySandbox(t *testing.T) {
+	testCodeFromCmd(t, DestroySandbox, DestroySandboxCode)
 }
 
 func TestCodeFromCmdExecCmd(t *testing.T) {
@@ -541,8 +541,8 @@ func TestWaitForReadyError(t *testing.T) {
 
 var cmdList = []string{
 	Version,
-	StartPod,
-	DestroyPod,
+	StartSandbox,
+	DestroySandbox,
 	ExecCmd,
 	Ready,
 	Ack,

--- a/virtcontainers/pkg/hyperstart/mock/hyperstart.go
+++ b/virtcontainers/pkg/hyperstart/mock/hyperstart.go
@@ -31,15 +31,15 @@ import (
 // Control command string IDs
 const (
 	Version         = "version"
-	StartPod        = "startpod"
-	DestroyPod      = "destroypod"
+	StartSandbox    = "startsandbox"
+	DestroySandbox  = "destroysandbox"
 	ExecCmd         = "execcmd"
 	Ready           = "ready"
 	Ack             = "ack"
 	Error           = "error"
 	WinSize         = "winsize"
 	Ping            = "ping"
-	FinishPod       = "finishpod"
+	FinishSandbox   = "finishsandbox"
 	Next            = "next"
 	WriteFile       = "writefile"
 	ReadFile        = "readfile"
@@ -53,8 +53,8 @@ const (
 
 var codeList = map[int]string{
 	hyper.VersionCode:         Version,
-	hyper.StartPodCode:        StartPod,
-	hyper.DestroyPodCode:      DestroyPod,
+	hyper.StartSandboxCode:    StartSandbox,
+	hyper.DestroySandboxCode:  DestroySandbox,
 	hyper.ExecCmdCode:         ExecCmd,
 	hyper.ReadyCode:           Ready,
 	hyper.AckCode:             Ack,

--- a/virtcontainers/pkg/hyperstart/types.go
+++ b/virtcontainers/pkg/hyperstart/types.go
@@ -23,10 +23,10 @@ import (
 // Defines all available commands to communicate with hyperstart agent.
 const (
 	VersionCode = iota
-	StartPodCode
-	GetPodDeprecatedCode
-	StopPodDeprecatedCode
-	DestroyPodCode
+	StartSandboxCode
+	GetSandboxDeprecatedCode
+	StopSandboxDeprecatedCode
+	DestroySandboxCode
 	RestartContainerDeprecatedCode
 	ExecCmdCode
 	FinishCmdDeprecatedCode
@@ -35,7 +35,7 @@ const (
 	ErrorCode
 	WinsizeCode
 	PingCode
-	FinishPodDeprecatedCode
+	FinishSandboxDeprecatedCode
 	NextCode
 	WriteFileCode
 	ReadFileCode
@@ -166,7 +166,7 @@ type Capabilities struct {
 	Ambient []string `json:"ambient"`
 }
 
-// Process describes a process running on a container inside a pod.
+// Process describes a process running on a container inside a sandbox.
 type Process struct {
 	// Args specifies the binary and arguments for the application to execute.
 	Args []string `json:"args"`
@@ -221,7 +221,7 @@ type Constraints struct {
 	CPUShares uint64
 }
 
-// Container describes a container running on a pod.
+// Container describes a container running on a sandbox.
 type Container struct {
 	ID               string              `json:"id"`
 	Rootfs           string              `json:"rootfs"`
@@ -260,8 +260,8 @@ type Route struct {
 	Device  string `json:"device,omitempty"`
 }
 
-// Pod describes the pod configuration to start inside the VM.
-type Pod struct {
+// Sandbox describes the sandbox configuration to start inside the VM.
+type Sandbox struct {
 	Hostname   string         `json:"hostname"`
 	Containers []Container    `json:"containers,omitempty"`
 	Interfaces []NetworkIface `json:"interfaces,omitempty"`

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -51,7 +51,7 @@ func createConfig(fileName string, fileData string) (string, error) {
 	return configPath, nil
 }
 
-func TestMinimalPodConfig(t *testing.T) {
+func TestMinimalSandboxConfig(t *testing.T) {
 	configPath, err := createConfig("config.json", minimalConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func TestMinimalPodConfig(t *testing.T) {
 
 	var minimalOCISpec CompatOCISpec
 
-	//Marshal and unmarshall json to compare  podConfig and expectedPodConfig
+	//Marshal and unmarshall json to compare  sandboxConfig and expectedSandboxConfig
 	if err := json.Unmarshal([]byte(minimalConfig), &minimalOCISpec); err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestMinimalPodConfig(t *testing.T) {
 		NumInterfaces: 1,
 	}
 
-	expectedPodConfig := vc.PodConfig{
+	expectedSandboxConfig := vc.SandboxConfig{
 		ID:       containerID,
 		Hostname: "testHostname",
 
@@ -197,13 +197,13 @@ func TestMinimalPodConfig(t *testing.T) {
 		t.Fatalf("Could not parse config.json: %v", err)
 	}
 
-	podConfig, err := PodConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false)
+	sandboxConfig, err := SandboxConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false)
 	if err != nil {
-		t.Fatalf("Could not create Pod configuration %v", err)
+		t.Fatalf("Could not create Sandbox configuration %v", err)
 	}
 
-	if reflect.DeepEqual(podConfig, expectedPodConfig) == false {
-		t.Fatalf("Got %v\n expecting %v", podConfig, expectedPodConfig)
+	if reflect.DeepEqual(sandboxConfig, expectedSandboxConfig) == false {
+		t.Fatalf("Got %v\n expecting %v", sandboxConfig, expectedSandboxConfig)
 	}
 
 	if err := os.Remove(configPath); err != nil {
@@ -613,34 +613,34 @@ func TestContainerTypeFailure(t *testing.T) {
 	}
 }
 
-func TestPodIDSuccessful(t *testing.T) {
+func TestSandboxIDSuccessful(t *testing.T) {
 	var ociSpec CompatOCISpec
-	testPodID := "testPodID"
+	testSandboxID := "testSandboxID"
 
 	ociSpec.Annotations = map[string]string{
-		annotations.SandboxID: testPodID,
+		annotations.SandboxID: testSandboxID,
 	}
 
-	podID, err := ociSpec.PodID()
+	sandboxID, err := ociSpec.SandboxID()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if podID != testPodID {
-		t.Fatalf("Got %s, Expecting %s", podID, testPodID)
+	if sandboxID != testSandboxID {
+		t.Fatalf("Got %s, Expecting %s", sandboxID, testSandboxID)
 	}
 }
 
-func TestPodIDFailure(t *testing.T) {
+func TestSandboxIDFailure(t *testing.T) {
 	var ociSpec CompatOCISpec
 
-	podID, err := ociSpec.PodID()
+	sandboxID, err := ociSpec.SandboxID()
 	if err == nil {
 		t.Fatalf("This test should fail because annotations is empty")
 	}
 
-	if podID != "" {
-		t.Fatalf("Got %s, Expecting empty pod ID", podID)
+	if sandboxID != "" {
+		t.Fatalf("Got %s, Expecting empty sandbox ID", sandboxID)
 	}
 }
 

--- a/virtcontainers/pkg/vcmock/container.go
+++ b/virtcontainers/pkg/vcmock/container.go
@@ -23,9 +23,9 @@ func (c *Container) ID() string {
 	return c.MockID
 }
 
-// Pod implements the VCContainer function of the same name.
-func (c *Container) Pod() vc.VCPod {
-	return c.MockPod
+// Sandbox implements the VCContainer function of the same name.
+func (c *Container) Sandbox() vc.VCSandbox {
+	return c.MockSandbox
 }
 
 // Process implements the VCContainer function of the same name.

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -16,8 +16,8 @@
 // for testing.
 //
 // This implementation calls the function set in the object that
-// corresponds to the name of the method (for example, when CreatePod()
-// is called, that method will try to call CreatePodFunc). If no
+// corresponds to the name of the method (for example, when CreateSandbox()
+// is called, that method will try to call CreateSandboxFunc). If no
 // function is defined for the method, it will return an error in a
 // well-known format. Callers can detect this scenario by calling
 // IsMockError().
@@ -43,155 +43,155 @@ func (m *VCMock) SetLogger(logger logrus.FieldLogger) {
 	}
 }
 
-// CreatePod implements the VC function of the same name.
-func (m *VCMock) CreatePod(podConfig vc.PodConfig) (vc.VCPod, error) {
-	if m.CreatePodFunc != nil {
-		return m.CreatePodFunc(podConfig)
+// CreateSandbox implements the VC function of the same name.
+func (m *VCMock) CreateSandbox(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+	if m.CreateSandboxFunc != nil {
+		return m.CreateSandboxFunc(sandboxConfig)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podConfig: %v", mockErrorPrefix, getSelf(), m, podConfig)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxConfig: %v", mockErrorPrefix, getSelf(), m, sandboxConfig)
 }
 
-// DeletePod implements the VC function of the same name.
-func (m *VCMock) DeletePod(podID string) (vc.VCPod, error) {
-	if m.DeletePodFunc != nil {
-		return m.DeletePodFunc(podID)
+// DeleteSandbox implements the VC function of the same name.
+func (m *VCMock) DeleteSandbox(sandboxID string) (vc.VCSandbox, error) {
+	if m.DeleteSandboxFunc != nil {
+		return m.DeleteSandboxFunc(sandboxID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
-// StartPod implements the VC function of the same name.
-func (m *VCMock) StartPod(podID string) (vc.VCPod, error) {
-	if m.StartPodFunc != nil {
-		return m.StartPodFunc(podID)
+// StartSandbox implements the VC function of the same name.
+func (m *VCMock) StartSandbox(sandboxID string) (vc.VCSandbox, error) {
+	if m.StartSandboxFunc != nil {
+		return m.StartSandboxFunc(sandboxID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
-// StopPod implements the VC function of the same name.
-func (m *VCMock) StopPod(podID string) (vc.VCPod, error) {
-	if m.StopPodFunc != nil {
-		return m.StopPodFunc(podID)
+// StopSandbox implements the VC function of the same name.
+func (m *VCMock) StopSandbox(sandboxID string) (vc.VCSandbox, error) {
+	if m.StopSandboxFunc != nil {
+		return m.StopSandboxFunc(sandboxID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
-// RunPod implements the VC function of the same name.
-func (m *VCMock) RunPod(podConfig vc.PodConfig) (vc.VCPod, error) {
-	if m.RunPodFunc != nil {
-		return m.RunPodFunc(podConfig)
+// RunSandbox implements the VC function of the same name.
+func (m *VCMock) RunSandbox(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+	if m.RunSandboxFunc != nil {
+		return m.RunSandboxFunc(sandboxConfig)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podConfig: %v", mockErrorPrefix, getSelf(), m, podConfig)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxConfig: %v", mockErrorPrefix, getSelf(), m, sandboxConfig)
 }
 
-// ListPod implements the VC function of the same name.
-func (m *VCMock) ListPod() ([]vc.PodStatus, error) {
-	if m.ListPodFunc != nil {
-		return m.ListPodFunc()
+// ListSandbox implements the VC function of the same name.
+func (m *VCMock) ListSandbox() ([]vc.SandboxStatus, error) {
+	if m.ListSandboxFunc != nil {
+		return m.ListSandboxFunc()
 	}
 
 	return nil, fmt.Errorf("%s: %s", mockErrorPrefix, getSelf())
 }
 
-// StatusPod implements the VC function of the same name.
-func (m *VCMock) StatusPod(podID string) (vc.PodStatus, error) {
-	if m.StatusPodFunc != nil {
-		return m.StatusPodFunc(podID)
+// StatusSandbox implements the VC function of the same name.
+func (m *VCMock) StatusSandbox(sandboxID string) (vc.SandboxStatus, error) {
+	if m.StatusSandboxFunc != nil {
+		return m.StatusSandboxFunc(sandboxID)
 	}
 
-	return vc.PodStatus{}, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return vc.SandboxStatus{}, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
-// PausePod implements the VC function of the same name.
-func (m *VCMock) PausePod(podID string) (vc.VCPod, error) {
-	if m.PausePodFunc != nil {
-		return m.PausePodFunc(podID)
+// PauseSandbox implements the VC function of the same name.
+func (m *VCMock) PauseSandbox(sandboxID string) (vc.VCSandbox, error) {
+	if m.PauseSandboxFunc != nil {
+		return m.PauseSandboxFunc(sandboxID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
-// ResumePod implements the VC function of the same name.
-func (m *VCMock) ResumePod(podID string) (vc.VCPod, error) {
-	if m.ResumePodFunc != nil {
-		return m.ResumePodFunc(podID)
+// ResumeSandbox implements the VC function of the same name.
+func (m *VCMock) ResumeSandbox(sandboxID string) (vc.VCSandbox, error) {
+	if m.ResumeSandboxFunc != nil {
+		return m.ResumeSandboxFunc(sandboxID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v", mockErrorPrefix, getSelf(), m, podID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
 
 // CreateContainer implements the VC function of the same name.
-func (m *VCMock) CreateContainer(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error) {
+func (m *VCMock) CreateContainer(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error) {
 	if m.CreateContainerFunc != nil {
-		return m.CreateContainerFunc(podID, containerConfig)
+		return m.CreateContainerFunc(sandboxID, containerConfig)
 	}
 
-	return nil, nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerConfig: %v", mockErrorPrefix, getSelf(), m, podID, containerConfig)
+	return nil, nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerConfig: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerConfig)
 }
 
 // DeleteContainer implements the VC function of the same name.
-func (m *VCMock) DeleteContainer(podID, containerID string) (vc.VCContainer, error) {
+func (m *VCMock) DeleteContainer(sandboxID, containerID string) (vc.VCContainer, error) {
 	if m.DeleteContainerFunc != nil {
-		return m.DeleteContainerFunc(podID, containerID)
+		return m.DeleteContainerFunc(sandboxID, containerID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
 
 // StartContainer implements the VC function of the same name.
-func (m *VCMock) StartContainer(podID, containerID string) (vc.VCContainer, error) {
+func (m *VCMock) StartContainer(sandboxID, containerID string) (vc.VCContainer, error) {
 	if m.StartContainerFunc != nil {
-		return m.StartContainerFunc(podID, containerID)
+		return m.StartContainerFunc(sandboxID, containerID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
 
 // StopContainer implements the VC function of the same name.
-func (m *VCMock) StopContainer(podID, containerID string) (vc.VCContainer, error) {
+func (m *VCMock) StopContainer(sandboxID, containerID string) (vc.VCContainer, error) {
 	if m.StopContainerFunc != nil {
-		return m.StopContainerFunc(podID, containerID)
+		return m.StopContainerFunc(sandboxID, containerID)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
 
 // EnterContainer implements the VC function of the same name.
-func (m *VCMock) EnterContainer(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
+func (m *VCMock) EnterContainer(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 	if m.EnterContainerFunc != nil {
-		return m.EnterContainerFunc(podID, containerID, cmd)
+		return m.EnterContainerFunc(sandboxID, containerID, cmd)
 	}
 
-	return nil, nil, nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v, cmd: %v", mockErrorPrefix, getSelf(), m, podID, containerID, cmd)
+	return nil, nil, nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v, cmd: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID, cmd)
 }
 
 // StatusContainer implements the VC function of the same name.
-func (m *VCMock) StatusContainer(podID, containerID string) (vc.ContainerStatus, error) {
+func (m *VCMock) StatusContainer(sandboxID, containerID string) (vc.ContainerStatus, error) {
 	if m.StatusContainerFunc != nil {
-		return m.StatusContainerFunc(podID, containerID)
+		return m.StatusContainerFunc(sandboxID, containerID)
 	}
 
-	return vc.ContainerStatus{}, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+	return vc.ContainerStatus{}, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
 
 // KillContainer implements the VC function of the same name.
-func (m *VCMock) KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
+func (m *VCMock) KillContainer(sandboxID, containerID string, signal syscall.Signal, all bool) error {
 	if m.KillContainerFunc != nil {
-		return m.KillContainerFunc(podID, containerID, signal, all)
+		return m.KillContainerFunc(sandboxID, containerID, signal, all)
 	}
 
-	return fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v, signal: %v, all: %v", mockErrorPrefix, getSelf(), m, podID, containerID, signal, all)
+	return fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v, signal: %v, all: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID, signal, all)
 }
 
 // ProcessListContainer implements the VC function of the same name.
-func (m *VCMock) ProcessListContainer(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+func (m *VCMock) ProcessListContainer(sandboxID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
 	if m.ProcessListContainerFunc != nil {
-		return m.ProcessListContainerFunc(podID, containerID, options)
+		return m.ProcessListContainerFunc(sandboxID, containerID, options)
 	}
 
-	return nil, fmt.Errorf("%s: %s (%+v): podID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, podID, containerID)
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	testPodID       = "testPodID"
+	testSandboxID   = "testSandboxID"
 	testContainerID = "testContainerID"
 )
 
@@ -53,14 +53,14 @@ func TestVCImplementations(t *testing.T) {
 	assert.True(t, testImplementsIF)
 }
 
-func TestVCPodImplementations(t *testing.T) {
+func TestVCSandboxImplementations(t *testing.T) {
 	// official implementation
-	mainImpl := &vc.Pod{}
+	mainImpl := &vc.Sandbox{}
 
 	// test implementation
-	testImpl := &Pod{}
+	testImpl := &Sandbox{}
 
-	var interfaceType vc.VCPod
+	var interfaceType vc.VCSandbox
 
 	// check that the official implementation implements the
 	// interface
@@ -117,236 +117,236 @@ func TestVCMockSetLogger(t *testing.T) {
 	assert.Equal(loggerTriggered, 1)
 }
 
-func TestVCMockCreatePod(t *testing.T) {
+func TestVCMockCreateSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.CreatePodFunc)
+	assert.Nil(m.CreateSandboxFunc)
 
-	_, err := m.CreatePod(vc.PodConfig{})
+	_, err := m.CreateSandbox(vc.SandboxConfig{})
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.CreatePodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.CreatePod(vc.PodConfig{})
+	sandbox, err := m.CreateSandbox(vc.SandboxConfig{})
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.CreatePodFunc = nil
+	m.CreateSandboxFunc = nil
 
-	_, err = m.CreatePod(vc.PodConfig{})
+	_, err = m.CreateSandbox(vc.SandboxConfig{})
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockDeletePod(t *testing.T) {
+func TestVCMockDeleteSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.DeletePodFunc)
+	assert.Nil(m.DeleteSandboxFunc)
 
-	_, err := m.DeletePod(testPodID)
+	_, err := m.DeleteSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.DeletePodFunc = func(podID string) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.DeleteSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.DeletePod(testPodID)
+	sandbox, err := m.DeleteSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.DeletePodFunc = nil
+	m.DeleteSandboxFunc = nil
 
-	_, err = m.DeletePod(testPodID)
+	_, err = m.DeleteSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockListPod(t *testing.T) {
+func TestVCMockListSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.ListPodFunc)
+	assert.Nil(m.ListSandboxFunc)
 
-	_, err := m.ListPod()
+	_, err := m.ListSandbox()
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.ListPodFunc = func() ([]vc.PodStatus, error) {
-		return []vc.PodStatus{}, nil
+	m.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+		return []vc.SandboxStatus{}, nil
 	}
 
-	pods, err := m.ListPod()
+	sandboxes, err := m.ListSandbox()
 	assert.NoError(err)
-	assert.Equal(pods, []vc.PodStatus{})
+	assert.Equal(sandboxes, []vc.SandboxStatus{})
 
 	// reset
-	m.ListPodFunc = nil
+	m.ListSandboxFunc = nil
 
-	_, err = m.ListPod()
+	_, err = m.ListSandbox()
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockPausePod(t *testing.T) {
+func TestVCMockPauseSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.PausePodFunc)
+	assert.Nil(m.PauseSandboxFunc)
 
-	_, err := m.PausePod(testPodID)
+	_, err := m.PauseSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.PausePodFunc = func(podID string) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.PauseSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.PausePod(testPodID)
+	sandbox, err := m.PauseSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.PausePodFunc = nil
+	m.PauseSandboxFunc = nil
 
-	_, err = m.PausePod(testPodID)
+	_, err = m.PauseSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockResumePod(t *testing.T) {
+func TestVCMockResumeSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.ResumePodFunc)
+	assert.Nil(m.ResumeSandboxFunc)
 
-	_, err := m.ResumePod(testPodID)
+	_, err := m.ResumeSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.ResumePodFunc = func(podID string) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.ResumeSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.ResumePod(testPodID)
+	sandbox, err := m.ResumeSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.ResumePodFunc = nil
+	m.ResumeSandboxFunc = nil
 
-	_, err = m.ResumePod(testPodID)
+	_, err = m.ResumeSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockRunPod(t *testing.T) {
+func TestVCMockRunSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.RunPodFunc)
+	assert.Nil(m.RunSandboxFunc)
 
-	_, err := m.RunPod(vc.PodConfig{})
+	_, err := m.RunSandbox(vc.SandboxConfig{})
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.RunPodFunc = func(podConfig vc.PodConfig) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.RunSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.RunPod(vc.PodConfig{})
+	sandbox, err := m.RunSandbox(vc.SandboxConfig{})
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.RunPodFunc = nil
+	m.RunSandboxFunc = nil
 
-	_, err = m.RunPod(vc.PodConfig{})
+	_, err = m.RunSandbox(vc.SandboxConfig{})
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockStartPod(t *testing.T) {
+func TestVCMockStartSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.StartPodFunc)
+	assert.Nil(m.StartSandboxFunc)
 
-	_, err := m.StartPod(testPodID)
+	_, err := m.StartSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StartPodFunc = func(podID string) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.StartSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.StartPod(testPodID)
+	sandbox, err := m.StartSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.StartPodFunc = nil
+	m.StartSandboxFunc = nil
 
-	_, err = m.StartPod(testPodID)
+	_, err = m.StartSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockStatusPod(t *testing.T) {
+func TestVCMockStatusSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.StatusPodFunc)
+	assert.Nil(m.StatusSandboxFunc)
 
-	_, err := m.StatusPod(testPodID)
+	_, err := m.StatusSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StatusPodFunc = func(podID string) (vc.PodStatus, error) {
-		return vc.PodStatus{}, nil
+	m.StatusSandboxFunc = func(sandboxID string) (vc.SandboxStatus, error) {
+		return vc.SandboxStatus{}, nil
 	}
 
-	pod, err := m.StatusPod(testPodID)
+	sandbox, err := m.StatusSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, vc.PodStatus{})
+	assert.Equal(sandbox, vc.SandboxStatus{})
 
 	// reset
-	m.StatusPodFunc = nil
+	m.StatusSandboxFunc = nil
 
-	_, err = m.StatusPod(testPodID)
+	_, err = m.StatusSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
 
-func TestVCMockStopPod(t *testing.T) {
+func TestVCMockStopSandbox(t *testing.T) {
 	assert := assert.New(t)
 
 	m := &VCMock{}
-	assert.Nil(m.StopPodFunc)
+	assert.Nil(m.StopSandboxFunc)
 
-	_, err := m.StopPod(testPodID)
+	_, err := m.StopSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StopPodFunc = func(podID string) (vc.VCPod, error) {
-		return &Pod{}, nil
+	m.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
+		return &Sandbox{}, nil
 	}
 
-	pod, err := m.StopPod(testPodID)
+	sandbox, err := m.StopSandbox(testSandboxID)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 
 	// reset
-	m.StopPodFunc = nil
+	m.StopSandboxFunc = nil
 
-	_, err = m.StopPod(testPodID)
+	_, err = m.StopSandbox(testSandboxID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -358,23 +358,23 @@ func TestVCMockCreateContainer(t *testing.T) {
 	assert.Nil(m.CreateContainerFunc)
 
 	config := vc.ContainerConfig{}
-	_, _, err := m.CreateContainer(testPodID, config)
+	_, _, err := m.CreateContainer(testSandboxID, config)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.CreateContainerFunc = func(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error) {
-		return &Pod{}, &Container{}, nil
+	m.CreateContainerFunc = func(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error) {
+		return &Sandbox{}, &Container{}, nil
 	}
 
-	pod, container, err := m.CreateContainer(testPodID, config)
+	sandbox, container, err := m.CreateContainer(testSandboxID, config)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 	assert.Equal(container, &Container{})
 
 	// reset
 	m.CreateContainerFunc = nil
 
-	_, _, err = m.CreateContainer(testPodID, config)
+	_, _, err = m.CreateContainer(testSandboxID, config)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -385,22 +385,22 @@ func TestVCMockDeleteContainer(t *testing.T) {
 	m := &VCMock{}
 	assert.Nil(m.DeleteContainerFunc)
 
-	_, err := m.DeleteContainer(testPodID, testContainerID)
+	_, err := m.DeleteContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.DeleteContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
+	m.DeleteContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &Container{}, nil
 	}
 
-	container, err := m.DeleteContainer(testPodID, testContainerID)
+	container, err := m.DeleteContainer(testSandboxID, testContainerID)
 	assert.NoError(err)
 	assert.Equal(container, &Container{})
 
 	// reset
 	m.DeleteContainerFunc = nil
 
-	_, err = m.DeleteContainer(testPodID, testContainerID)
+	_, err = m.DeleteContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -412,24 +412,24 @@ func TestVCMockEnterContainer(t *testing.T) {
 	assert.Nil(m.EnterContainerFunc)
 
 	cmd := vc.Cmd{}
-	_, _, _, err := m.EnterContainer(testPodID, testContainerID, cmd)
+	_, _, _, err := m.EnterContainer(testSandboxID, testContainerID, cmd)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.EnterContainerFunc = func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error) {
-		return &Pod{}, &Container{}, &vc.Process{}, nil
+	m.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+		return &Sandbox{}, &Container{}, &vc.Process{}, nil
 	}
 
-	pod, container, process, err := m.EnterContainer(testPodID, testContainerID, cmd)
+	sandbox, container, process, err := m.EnterContainer(testSandboxID, testContainerID, cmd)
 	assert.NoError(err)
-	assert.Equal(pod, &Pod{})
+	assert.Equal(sandbox, &Sandbox{})
 	assert.Equal(container, &Container{})
 	assert.Equal(process, &vc.Process{})
 
 	// reset
 	m.EnterContainerFunc = nil
 
-	_, _, _, err = m.EnterContainer(testPodID, testContainerID, cmd)
+	_, _, _, err = m.EnterContainer(testSandboxID, testContainerID, cmd)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -443,17 +443,17 @@ func TestVCMockKillContainer(t *testing.T) {
 	sig := syscall.SIGTERM
 
 	for _, all := range []bool{true, false} {
-		err := m.KillContainer(testPodID, testContainerID, sig, all)
+		err := m.KillContainer(testSandboxID, testContainerID, sig, all)
 		assert.Error(err)
 		assert.True(IsMockError(err))
 	}
 
-	m.KillContainerFunc = func(podID, containerID string, signal syscall.Signal, all bool) error {
+	m.KillContainerFunc = func(sandboxID, containerID string, signal syscall.Signal, all bool) error {
 		return nil
 	}
 
 	for _, all := range []bool{true, false} {
-		err := m.KillContainer(testPodID, testContainerID, sig, all)
+		err := m.KillContainer(testSandboxID, testContainerID, sig, all)
 		assert.NoError(err)
 	}
 
@@ -461,7 +461,7 @@ func TestVCMockKillContainer(t *testing.T) {
 	m.KillContainerFunc = nil
 
 	for _, all := range []bool{true, false} {
-		err := m.KillContainer(testPodID, testContainerID, sig, all)
+		err := m.KillContainer(testSandboxID, testContainerID, sig, all)
 		assert.Error(err)
 		assert.True(IsMockError(err))
 	}
@@ -473,22 +473,22 @@ func TestVCMockStartContainer(t *testing.T) {
 	m := &VCMock{}
 	assert.Nil(m.StartContainerFunc)
 
-	_, err := m.StartContainer(testPodID, testContainerID)
+	_, err := m.StartContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StartContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
+	m.StartContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &Container{}, nil
 	}
 
-	container, err := m.StartContainer(testPodID, testContainerID)
+	container, err := m.StartContainer(testSandboxID, testContainerID)
 	assert.NoError(err)
 	assert.Equal(container, &Container{})
 
 	// reset
 	m.StartContainerFunc = nil
 
-	_, err = m.StartContainer(testPodID, testContainerID)
+	_, err = m.StartContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -499,22 +499,22 @@ func TestVCMockStatusContainer(t *testing.T) {
 	m := &VCMock{}
 	assert.Nil(m.StatusContainerFunc)
 
-	_, err := m.StatusContainer(testPodID, testContainerID)
+	_, err := m.StatusContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StatusContainerFunc = func(podID, containerID string) (vc.ContainerStatus, error) {
+	m.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return vc.ContainerStatus{}, nil
 	}
 
-	status, err := m.StatusContainer(testPodID, testContainerID)
+	status, err := m.StatusContainer(testSandboxID, testContainerID)
 	assert.NoError(err)
 	assert.Equal(status, vc.ContainerStatus{})
 
 	// reset
 	m.StatusContainerFunc = nil
 
-	_, err = m.StatusContainer(testPodID, testContainerID)
+	_, err = m.StatusContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -525,22 +525,22 @@ func TestVCMockStopContainer(t *testing.T) {
 	m := &VCMock{}
 	assert.Nil(m.StopContainerFunc)
 
-	_, err := m.StopContainer(testPodID, testContainerID)
+	_, err := m.StopContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.StopContainerFunc = func(podID, containerID string) (vc.VCContainer, error) {
+	m.StopContainerFunc = func(sandboxID, containerID string) (vc.VCContainer, error) {
 		return &Container{}, nil
 	}
 
-	container, err := m.StopContainer(testPodID, testContainerID)
+	container, err := m.StopContainer(testSandboxID, testContainerID)
 	assert.NoError(err)
 	assert.Equal(container, &Container{})
 
 	// reset
 	m.StopContainerFunc = nil
 
-	_, err = m.StopContainer(testPodID, testContainerID)
+	_, err = m.StopContainer(testSandboxID, testContainerID)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -556,24 +556,24 @@ func TestVCMockProcessListContainer(t *testing.T) {
 		Args:   []string{"-ef"},
 	}
 
-	_, err := m.ProcessListContainer(testPodID, testContainerID, options)
+	_, err := m.ProcessListContainer(testSandboxID, testContainerID, options)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
 	processList := vc.ProcessList("hi")
 
-	m.ProcessListContainerFunc = func(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+	m.ProcessListContainerFunc = func(sandboxID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
 		return processList, nil
 	}
 
-	pList, err := m.ProcessListContainer(testPodID, testContainerID, options)
+	pList, err := m.ProcessListContainer(testSandboxID, testContainerID, options)
 	assert.NoError(err)
 	assert.Equal(pList, processList)
 
 	// reset
 	m.ProcessListContainerFunc = nil
 
-	_, err = m.ProcessListContainer(testPodID, testContainerID, options)
+	_, err = m.ProcessListContainer(testSandboxID, testContainerID, options)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -18,28 +18,28 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
-// ID implements the VCPod function of the same name.
-func (p *Pod) ID() string {
+// ID implements the VCSandbox function of the same name.
+func (p *Sandbox) ID() string {
 	return p.MockID
 }
 
-// Annotations implements the VCPod function of the same name.
-func (p *Pod) Annotations(key string) (string, error) {
+// Annotations implements the VCSandbox function of the same name.
+func (p *Sandbox) Annotations(key string) (string, error) {
 	return p.MockAnnotations[key], nil
 }
 
-// SetAnnotations implements the VCPod function of the same name.
-func (p *Pod) SetAnnotations(annotations map[string]string) error {
+// SetAnnotations implements the VCSandbox function of the same name.
+func (p *Sandbox) SetAnnotations(annotations map[string]string) error {
 	return nil
 }
 
-// GetAnnotations implements the VCPod function of the same name.
-func (p *Pod) GetAnnotations() map[string]string {
+// GetAnnotations implements the VCSandbox function of the same name.
+func (p *Sandbox) GetAnnotations() map[string]string {
 	return p.MockAnnotations
 }
 
-// GetAllContainers implements the VCPod function of the same name.
-func (p *Pod) GetAllContainers() []vc.VCContainer {
+// GetAllContainers implements the VCSandbox function of the same name.
+func (p *Sandbox) GetAllContainers() []vc.VCContainer {
 	var ifa = make([]vc.VCContainer, len(p.MockContainers))
 
 	for i, v := range p.MockContainers {
@@ -49,8 +49,8 @@ func (p *Pod) GetAllContainers() []vc.VCContainer {
 	return ifa
 }
 
-// GetContainer implements the VCPod function of the same name.
-func (p *Pod) GetContainer(containerID string) vc.VCContainer {
+// GetContainer implements the VCSandbox function of the same name.
+func (p *Sandbox) GetContainer(containerID string) vc.VCContainer {
 	for _, c := range p.MockContainers {
 		if c.MockID == containerID {
 			return c

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Pod is a fake Pod type used for testing
-type Pod struct {
+// Sandbox is a fake Sandbox type used for testing
+type Sandbox struct {
 	MockID          string
 	MockURL         string
 	MockAnnotations map[string]string
@@ -36,7 +36,7 @@ type Container struct {
 	MockToken       string
 	MockProcess     vc.Process
 	MockPid         int
-	MockPod         *Pod
+	MockSandbox     *Sandbox
 	MockAnnotations map[string]string
 }
 
@@ -45,22 +45,22 @@ type Container struct {
 type VCMock struct {
 	SetLoggerFunc func(logger logrus.FieldLogger)
 
-	CreatePodFunc func(podConfig vc.PodConfig) (vc.VCPod, error)
-	DeletePodFunc func(podID string) (vc.VCPod, error)
-	ListPodFunc   func() ([]vc.PodStatus, error)
-	PausePodFunc  func(podID string) (vc.VCPod, error)
-	ResumePodFunc func(podID string) (vc.VCPod, error)
-	RunPodFunc    func(podConfig vc.PodConfig) (vc.VCPod, error)
-	StartPodFunc  func(podID string) (vc.VCPod, error)
-	StatusPodFunc func(podID string) (vc.PodStatus, error)
-	StopPodFunc   func(podID string) (vc.VCPod, error)
+	CreateSandboxFunc func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error)
+	DeleteSandboxFunc func(sandboxID string) (vc.VCSandbox, error)
+	ListSandboxFunc   func() ([]vc.SandboxStatus, error)
+	PauseSandboxFunc  func(sandboxID string) (vc.VCSandbox, error)
+	ResumeSandboxFunc func(sandboxID string) (vc.VCSandbox, error)
+	RunSandboxFunc    func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error)
+	StartSandboxFunc  func(sandboxID string) (vc.VCSandbox, error)
+	StatusSandboxFunc func(sandboxID string) (vc.SandboxStatus, error)
+	StopSandboxFunc   func(sandboxID string) (vc.VCSandbox, error)
 
-	CreateContainerFunc      func(podID string, containerConfig vc.ContainerConfig) (vc.VCPod, vc.VCContainer, error)
-	DeleteContainerFunc      func(podID, containerID string) (vc.VCContainer, error)
-	EnterContainerFunc       func(podID, containerID string, cmd vc.Cmd) (vc.VCPod, vc.VCContainer, *vc.Process, error)
-	KillContainerFunc        func(podID, containerID string, signal syscall.Signal, all bool) error
-	StartContainerFunc       func(podID, containerID string) (vc.VCContainer, error)
-	StatusContainerFunc      func(podID, containerID string) (vc.ContainerStatus, error)
-	StopContainerFunc        func(podID, containerID string) (vc.VCContainer, error)
-	ProcessListContainerFunc func(podID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error)
+	CreateContainerFunc      func(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error)
+	DeleteContainerFunc      func(sandboxID, containerID string) (vc.VCContainer, error)
+	EnterContainerFunc       func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error)
+	KillContainerFunc        func(sandboxID, containerID string, signal syscall.Signal, all bool) error
+	StartContainerFunc       func(sandboxID, containerID string) (vc.VCContainer, error)
+	StatusContainerFunc      func(sandboxID, containerID string) (vc.ContainerStatus, error)
+	StopContainerFunc        func(sandboxID, containerID string) (vc.VCContainer, error)
+	ProcessListContainerFunc func(sandboxID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error)
 }

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -131,19 +131,19 @@ func newProxy(pType ProxyType) (proxy, error) {
 	}
 }
 
-// newProxyConfig returns a proxy config from a generic PodConfig handler,
+// newProxyConfig returns a proxy config from a generic SandboxConfig handler,
 // after it properly checked the configuration was valid.
-func newProxyConfig(podConfig *PodConfig) (ProxyConfig, error) {
-	if podConfig == nil {
-		return ProxyConfig{}, fmt.Errorf("Pod config cannot be nil")
+func newProxyConfig(sandboxConfig *SandboxConfig) (ProxyConfig, error) {
+	if sandboxConfig == nil {
+		return ProxyConfig{}, fmt.Errorf("Sandbox config cannot be nil")
 	}
 
 	var config ProxyConfig
-	switch podConfig.ProxyType {
+	switch sandboxConfig.ProxyType {
 	case KataProxyType:
 		fallthrough
 	case CCProxyType:
-		if err := mapstructure.Decode(podConfig.ProxyConfig, &config); err != nil {
+		if err := mapstructure.Decode(sandboxConfig.ProxyConfig, &config); err != nil {
 			return ProxyConfig{}, err
 		}
 	}
@@ -155,10 +155,10 @@ func newProxyConfig(podConfig *PodConfig) (ProxyConfig, error) {
 	return config, nil
 }
 
-func defaultProxyURL(pod Pod, socketType string) (string, error) {
+func defaultProxyURL(sandbox Sandbox, socketType string) (string, error) {
 	switch socketType {
 	case SocketTypeUNIX:
-		socketPath := filepath.Join(runStoragePath, pod.id, "proxy.sock")
+		socketPath := filepath.Join(runStoragePath, sandbox.id, "proxy.sock")
 		return fmt.Sprintf("unix://%s", socketPath), nil
 	case SocketTypeVSOCK:
 		// TODO Build the VSOCK default URL
@@ -174,11 +174,11 @@ func isProxyBuiltIn(pType ProxyType) bool {
 
 // proxy is the virtcontainers proxy interface.
 type proxy interface {
-	// start launches a proxy instance for the specified pod, returning
+	// start launches a proxy instance for the specified sandbox, returning
 	// the PID of the process and the URL used to connect to it.
-	start(pod Pod, params proxyParams) (int, string, error)
+	start(sandbox Sandbox, params proxyParams) (int, string, error)
 
 	// stop terminates a proxy instance after all communications with the
 	// agent inside the VM have been properly stopped.
-	stop(pod Pod, pid int) error
+	stop(sandbox Sandbox, pid int) error
 }

--- a/virtcontainers/proxy_test.go
+++ b/virtcontainers/proxy_test.go
@@ -161,8 +161,8 @@ func TestNewProxyFromUnknownProxyType(t *testing.T) {
 	}
 }
 
-func testNewProxyConfigFromPodConfig(t *testing.T, podConfig PodConfig, expected ProxyConfig) {
-	result, err := newProxyConfig(&podConfig)
+func testNewProxyConfigFromSandboxConfig(t *testing.T, sandboxConfig SandboxConfig, expected ProxyConfig) {
+	result, err := newProxyConfig(&sandboxConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,57 +174,57 @@ func testNewProxyConfigFromPodConfig(t *testing.T, podConfig PodConfig, expected
 
 var testProxyPath = "proxy-path"
 
-func TestNewProxyConfigFromCCProxyPodConfig(t *testing.T) {
+func TestNewProxyConfigFromCCProxySandboxConfig(t *testing.T) {
 	proxyConfig := ProxyConfig{
 		Path: testProxyPath,
 	}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		ProxyType:   CCProxyType,
 		ProxyConfig: proxyConfig,
 	}
 
-	testNewProxyConfigFromPodConfig(t, podConfig, proxyConfig)
+	testNewProxyConfigFromSandboxConfig(t, sandboxConfig, proxyConfig)
 }
 
-func TestNewProxyConfigFromKataProxyPodConfig(t *testing.T) {
+func TestNewProxyConfigFromKataProxySandboxConfig(t *testing.T) {
 	proxyConfig := ProxyConfig{
 		Path: testProxyPath,
 	}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		ProxyType:   KataProxyType,
 		ProxyConfig: proxyConfig,
 	}
 
-	testNewProxyConfigFromPodConfig(t, podConfig, proxyConfig)
+	testNewProxyConfigFromSandboxConfig(t, sandboxConfig, proxyConfig)
 }
 
-func TestNewProxyConfigNilPodConfigFailure(t *testing.T) {
+func TestNewProxyConfigNilSandboxConfigFailure(t *testing.T) {
 	if _, err := newProxyConfig(nil); err == nil {
-		t.Fatal("Should fail because PodConfig provided is nil")
+		t.Fatal("Should fail because SandboxConfig provided is nil")
 	}
 }
 
 func TestNewProxyConfigNoPathFailure(t *testing.T) {
-	podConfig := &PodConfig{
+	sandboxConfig := &SandboxConfig{
 		ProxyType:   CCProxyType,
 		ProxyConfig: ProxyConfig{},
 	}
 
-	if _, err := newProxyConfig(podConfig); err == nil {
+	if _, err := newProxyConfig(sandboxConfig); err == nil {
 		t.Fatal("Should fail because ProxyConfig has no Path")
 	}
 }
 
-const podID = "123456789"
+const sandboxID = "123456789"
 
-func testDefaultProxyURL(expectedURL string, socketType string, podID string) error {
-	pod := &Pod{
-		id: podID,
+func testDefaultProxyURL(expectedURL string, socketType string, sandboxID string) error {
+	sandbox := &Sandbox{
+		id: sandboxID,
 	}
 
-	url, err := defaultProxyURL(*pod, socketType)
+	url, err := defaultProxyURL(*sandbox, socketType)
 	if err != nil {
 		return err
 	}
@@ -237,25 +237,25 @@ func testDefaultProxyURL(expectedURL string, socketType string, podID string) er
 }
 
 func TestDefaultProxyURLUnix(t *testing.T) {
-	path := filepath.Join(runStoragePath, podID, "proxy.sock")
+	path := filepath.Join(runStoragePath, sandboxID, "proxy.sock")
 	socketPath := fmt.Sprintf("unix://%s", path)
 
-	if err := testDefaultProxyURL(socketPath, SocketTypeUNIX, podID); err != nil {
+	if err := testDefaultProxyURL(socketPath, SocketTypeUNIX, sandboxID); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDefaultProxyURLVSock(t *testing.T) {
-	if err := testDefaultProxyURL("", SocketTypeVSOCK, podID); err != nil {
+	if err := testDefaultProxyURL("", SocketTypeVSOCK, sandboxID); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDefaultProxyURLUnknown(t *testing.T) {
-	path := filepath.Join(runStoragePath, podID, "proxy.sock")
+	path := filepath.Join(runStoragePath, sandboxID, "proxy.sock")
 	socketPath := fmt.Sprintf("unix://%s", path)
 
-	if err := testDefaultProxyURL(socketPath, "foobar", podID); err == nil {
+	if err := testDefaultProxyURL(socketPath, "foobar", sandboxID); err == nil {
 		t.Fatal()
 	}
 }

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -269,7 +269,7 @@ func TestQemuArchBaseAppendConsoles(t *testing.T) {
 	assert := assert.New(t)
 	qemuArchBase := newQemuArchBase()
 
-	path := filepath.Join(runStoragePath, podID, defaultConsole)
+	path := filepath.Join(runStoragePath, sandboxID, defaultConsole)
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.SerialDevice{

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -82,21 +82,21 @@ func TestQemuInit(t *testing.T) {
 	qemuConfig := newQemuConfig()
 	q := &qemu{}
 
-	pod := &Pod{
-		id:      "testPod",
+	sandbox := &Sandbox{
+		id:      "testSandbox",
 		storage: &filesystem{},
-		config: &PodConfig{
+		config: &SandboxConfig{
 			HypervisorConfig: qemuConfig,
 		},
 	}
 
 	// Create parent dir path for hypervisor.json
-	parentDir := filepath.Join(runStoragePath, pod.id)
+	parentDir := filepath.Join(runStoragePath, sandbox.id)
 	if err := os.MkdirAll(parentDir, dirMode); err != nil {
 		t.Fatalf("Could not create parent directory %s: %v", parentDir, err)
 	}
 
-	if err := q.init(pod); err != nil {
+	if err := q.init(sandbox); err != nil {
 		t.Fatal(err)
 	}
 
@@ -113,21 +113,21 @@ func TestQemuInitMissingParentDirFail(t *testing.T) {
 	qemuConfig := newQemuConfig()
 	q := &qemu{}
 
-	pod := &Pod{
-		id:      "testPod",
+	sandbox := &Sandbox{
+		id:      "testSandbox",
 		storage: &filesystem{},
-		config: &PodConfig{
+		config: &SandboxConfig{
 			HypervisorConfig: qemuConfig,
 		},
 	}
 
 	// Ensure parent dir path for hypervisor.json does not exist.
-	parentDir := filepath.Join(runStoragePath, pod.id)
+	parentDir := filepath.Join(runStoragePath, sandbox.id)
 	if err := os.RemoveAll(parentDir); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := q.init(pod); err == nil {
+	if err := q.init(sandbox); err == nil {
 		t.Fatal("Qemu init() expected to fail because of missing parent directory for storage")
 	}
 }
@@ -180,11 +180,11 @@ func TestQemuMemoryTopology(t *testing.T) {
 		Memory: uint(mem),
 	}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		VMConfig: vmConfig,
 	}
 
-	memory, err := q.memoryTopology(podConfig)
+	memory, err := q.memoryTopology(sandboxConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,12 +259,12 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
 }
 
-func TestQemuGetPodConsole(t *testing.T) {
+func TestQemuGetSandboxConsole(t *testing.T) {
 	q := &qemu{}
-	podID := "testPodID"
-	expected := filepath.Join(runStoragePath, podID, defaultConsole)
+	sandboxID := "testSandboxID"
+	expected := filepath.Join(runStoragePath, sandboxID, defaultConsole)
 
-	if result := q.getPodConsole(podID); result != expected {
+	if result := q.getSandboxConsole(sandboxID); result != expected {
 		t.Fatalf("Got %s\nExpecting %s", result, expected)
 	}
 }

--- a/virtcontainers/sandboxlist.go
+++ b/virtcontainers/sandboxlist.go
@@ -21,40 +21,40 @@ import (
 	"sync"
 )
 
-type podList struct {
-	lock sync.RWMutex
-	pods map[string]*Pod
+type sandboxList struct {
+	lock      sync.RWMutex
+	sandboxes map[string]*Sandbox
 }
 
-// globalPodList tracks pods globally
-var globalPodList = &podList{pods: make(map[string]*Pod)}
+// globalSandboxList tracks sandboxes globally
+var globalSandboxList = &sandboxList{sandboxes: make(map[string]*Sandbox)}
 
-func (p *podList) addPod(pod *Pod) (err error) {
-	if pod == nil {
+func (p *sandboxList) addSandbox(sandbox *Sandbox) (err error) {
+	if sandbox == nil {
 		return nil
 	}
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	if p.pods[pod.id] == nil {
-		p.pods[pod.id] = pod
+	if p.sandboxes[sandbox.id] == nil {
+		p.sandboxes[sandbox.id] = sandbox
 	} else {
-		err = fmt.Errorf("pod %s exists", pod.id)
+		err = fmt.Errorf("sandbox %s exists", sandbox.id)
 	}
 	return err
 }
 
-func (p *podList) removePod(id string) {
+func (p *sandboxList) removeSandbox(id string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	delete(p.pods, id)
+	delete(p.sandboxes, id)
 }
 
-func (p *podList) lookupPod(id string) (*Pod, error) {
+func (p *sandboxList) lookupSandbox(id string) (*Sandbox, error) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	if p.pods[id] != nil {
-		return p.pods[id], nil
+	if p.sandboxes[id] != nil {
+		return p.sandboxes[id], nil
 	}
-	return nil, fmt.Errorf("pod %s does not exist", id)
+	return nil, fmt.Errorf("sandbox %s does not exist", id)
 }

--- a/virtcontainers/sandboxlist_test.go
+++ b/virtcontainers/sandboxlist_test.go
@@ -22,21 +22,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPodListOperations(t *testing.T) {
-	p := &Pod{id: "testpodListpod"}
-	l := &podList{pods: make(map[string]*Pod)}
-	err := l.addPod(p)
-	assert.Nil(t, err, "addPod failed")
+func TestSandboxListOperations(t *testing.T) {
+	p := &Sandbox{id: "testsandboxListsandbox"}
+	l := &sandboxList{sandboxes: make(map[string]*Sandbox)}
+	err := l.addSandbox(p)
+	assert.Nil(t, err, "addSandbox failed")
 
-	err = l.addPod(p)
-	assert.NotNil(t, err, "add same pod should fail")
+	err = l.addSandbox(p)
+	assert.NotNil(t, err, "add same sandbox should fail")
 
-	np, err := l.lookupPod(p.id)
-	assert.Nil(t, err, "lookupPod failed")
-	assert.Equal(t, np, p, "lookupPod returns different pod %v:%v", np, p)
+	np, err := l.lookupSandbox(p.id)
+	assert.Nil(t, err, "lookupSandbox failed")
+	assert.Equal(t, np, p, "lookupSandbox returns different sandbox %v:%v", np, p)
 
-	_, err = l.lookupPod("some-non-existing-pod-name")
-	assert.NotNil(t, err, "lookupPod for non-existing pod should fail")
+	_, err = l.lookupSandbox("some-non-existing-sandbox-name")
+	assert.NotNil(t, err, "lookupSandbox for non-existing sandbox should fail")
 
-	l.removePod(p.id)
+	l.removeSandbox(p.id)
 }

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -118,8 +118,8 @@ func newShim(pType ShimType) (shim, error) {
 	}
 }
 
-// newShimConfig returns a shim config from a generic PodConfig interface.
-func newShimConfig(config PodConfig) interface{} {
+// newShimConfig returns a shim config from a generic SandboxConfig interface.
+func newShimConfig(config SandboxConfig) interface{} {
 	switch config.ShimType {
 	case NoopShimType, KataBuiltInShimType:
 		return nil
@@ -165,7 +165,7 @@ func stopShim(pid int) error {
 	return nil
 }
 
-func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd,
+func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cmd Cmd,
 	createNSList []ns.NSType, enterNSList []ns.Namespace) (*Process, error) {
 	process := &Process{
 		Token:     token,
@@ -183,7 +183,7 @@ func prepareAndStartShim(pod *Pod, shim shim, cid, token, url string, cmd Cmd,
 		EnterNS:   enterNSList,
 	}
 
-	pid, err := shim.start(*pod, shimParams)
+	pid, err := shim.start(*sandbox, shimParams)
 	if err != nil {
 		return nil, err
 	}
@@ -293,5 +293,5 @@ func waitForShim(pid int) error {
 type shim interface {
 	// start starts the shim relying on its configuration and on
 	// parameters provided.
-	start(pod Pod, params ShimParams) (int, error)
+	start(sandbox Sandbox, params ShimParams) (int, error)
 }

--- a/virtcontainers/shim_test.go
+++ b/virtcontainers/shim_test.go
@@ -143,60 +143,60 @@ func TestNewShimFromUnknownShimType(t *testing.T) {
 	}
 }
 
-func testNewShimConfigFromPodConfig(t *testing.T, podConfig PodConfig, expected interface{}) {
-	result := newShimConfig(podConfig)
+func testNewShimConfigFromSandboxConfig(t *testing.T, sandboxConfig SandboxConfig, expected interface{}) {
+	result := newShimConfig(sandboxConfig)
 
 	if reflect.DeepEqual(result, expected) == false {
 		t.Fatalf("Got %+v\nExpecting %+v", result, expected)
 	}
 }
 
-func TestNewShimConfigFromCCShimPodConfig(t *testing.T) {
+func TestNewShimConfigFromCCShimSandboxConfig(t *testing.T) {
 	shimConfig := ShimConfig{}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		ShimType:   CCShimType,
 		ShimConfig: shimConfig,
 	}
 
-	testNewShimConfigFromPodConfig(t, podConfig, shimConfig)
+	testNewShimConfigFromSandboxConfig(t, sandboxConfig, shimConfig)
 }
 
-func TestNewShimConfigFromKataShimPodConfig(t *testing.T) {
+func TestNewShimConfigFromKataShimSandboxConfig(t *testing.T) {
 	shimConfig := ShimConfig{}
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		ShimType:   KataShimType,
 		ShimConfig: shimConfig,
 	}
 
-	testNewShimConfigFromPodConfig(t, podConfig, shimConfig)
+	testNewShimConfigFromSandboxConfig(t, sandboxConfig, shimConfig)
 }
 
-func TestNewShimConfigFromNoopShimPodConfig(t *testing.T) {
-	podConfig := PodConfig{
+func TestNewShimConfigFromNoopShimSandboxConfig(t *testing.T) {
+	sandboxConfig := SandboxConfig{
 		ShimType: NoopShimType,
 	}
 
-	testNewShimConfigFromPodConfig(t, podConfig, nil)
+	testNewShimConfigFromSandboxConfig(t, sandboxConfig, nil)
 }
 
-func TestNewShimConfigFromKataBuiltInShimPodConfig(t *testing.T) {
-	podConfig := PodConfig{
+func TestNewShimConfigFromKataBuiltInShimSandboxConfig(t *testing.T) {
+	sandboxConfig := SandboxConfig{
 		ShimType: KataBuiltInShimType,
 	}
 
-	testNewShimConfigFromPodConfig(t, podConfig, nil)
+	testNewShimConfigFromSandboxConfig(t, sandboxConfig, nil)
 }
 
-func TestNewShimConfigFromUnknownShimPodConfig(t *testing.T) {
+func TestNewShimConfigFromUnknownShimSandboxConfig(t *testing.T) {
 	var shimType ShimType
 
-	podConfig := PodConfig{
+	sandboxConfig := SandboxConfig{
 		ShimType: shimType,
 	}
 
-	testNewShimConfigFromPodConfig(t, podConfig, nil)
+	testNewShimConfigFromSandboxConfig(t, sandboxConfig, nil)
 }
 
 func testRunSleep0AndGetPid(t *testing.T) int {

--- a/virtcontainers/spawner.go
+++ b/virtcontainers/spawner.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-// SpawnerType describes the type of guest agent a Pod should run.
+// SpawnerType describes the type of guest agent a Sandbox should run.
 type SpawnerType string
 
 const (

--- a/virtcontainers/types.go
+++ b/virtcontainers/types.go
@@ -24,9 +24,9 @@ var (
 	UnknownContainerType ContainerType = "unknown_container_type"
 )
 
-// IsPod determines if the container type can be considered as a pod.
-// We can consider a pod in case we have a PodSandbox or a RegularContainer.
-func (cType ContainerType) IsPod() bool {
+// IsSandbox determines if the container type can be considered as a sandbox.
+// We can consider a sandbox in case we have a PodSandbox or a RegularContainer.
+func (cType ContainerType) IsSandbox() bool {
 	if cType == PodSandbox {
 		return true
 	}

--- a/virtcontainers/types_test.go
+++ b/virtcontainers/types_test.go
@@ -18,20 +18,20 @@ import (
 	"testing"
 )
 
-func testIsPod(t *testing.T, cType ContainerType, expected bool) {
-	if result := cType.IsPod(); result != expected {
+func testIsSandbox(t *testing.T, cType ContainerType, expected bool) {
+	if result := cType.IsSandbox(); result != expected {
 		t.Fatalf("Got %t, Expecting %t", result, expected)
 	}
 }
 
-func TestIsPodPodSandboxTrue(t *testing.T) {
-	testIsPod(t, PodSandbox, true)
+func TestIsPodSandboxTrue(t *testing.T) {
+	testIsSandbox(t, PodSandbox, true)
 }
 
-func TestIsPodPodContainerFalse(t *testing.T) {
-	testIsPod(t, PodContainer, false)
+func TestIsPodContainerFalse(t *testing.T) {
+	testIsSandbox(t, PodContainer, false)
 }
 
-func TestIsPodUnknownContainerTypeFalse(t *testing.T) {
-	testIsPod(t, UnknownContainerType, false)
+func TestIsSandboxUnknownContainerTypeFalse(t *testing.T) {
+	testIsSandbox(t, UnknownContainerType, false)
 }

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const testPodID = "7f49d00d-1995-4156-8c79-5f5ab24ce138"
+const testSandboxID = "7f49d00d-1995-4156-8c79-5f5ab24ce138"
 const testContainerID = "containerID"
 const testKernel = "kernel"
 const testInitrd = "initrd"
@@ -39,12 +39,12 @@ const testDisabledAsNonRoot = "Test disabled as requires root privileges"
 
 // package variables set in TestMain
 var testDir = ""
-var podDirConfig = ""
-var podFileConfig = ""
-var podDirState = ""
-var podDirLock = ""
-var podFileState = ""
-var podFileLock = ""
+var sandboxDirConfig = ""
+var sandboxFileConfig = ""
+var sandboxDirState = ""
+var sandboxDirLock = ""
+var sandboxFileState = ""
+var sandboxFileLock = ""
 var testQemuKernelPath = ""
 var testQemuInitrdPath = ""
 var testQemuImagePath = ""
@@ -52,10 +52,10 @@ var testQemuPath = ""
 var testHyperstartCtlSocket = ""
 var testHyperstartTtySocket = ""
 
-// cleanUp Removes any stale pod/container state that can affect
+// cleanUp Removes any stale sandbox/container state that can affect
 // the next test to run.
 func cleanUp() {
-	globalPodList.removePod(testPodID)
+	globalSandboxList.removeSandbox(testSandboxID)
 	for _, dir := range []string{testDir, defaultSharedDir} {
 		os.RemoveAll(dir)
 		os.MkdirAll(dir, dirMode)
@@ -130,12 +130,12 @@ func TestMain(m *testing.M) {
 	runStoragePath = filepath.Join(testDir, storagePathSuffix, "run")
 
 	// set now that configStoragePath has been overridden.
-	podDirConfig = filepath.Join(configStoragePath, testPodID)
-	podFileConfig = filepath.Join(configStoragePath, testPodID, configFile)
-	podDirState = filepath.Join(runStoragePath, testPodID)
-	podDirLock = filepath.Join(runStoragePath, testPodID)
-	podFileState = filepath.Join(runStoragePath, testPodID, stateFile)
-	podFileLock = filepath.Join(runStoragePath, testPodID, lockFileName)
+	sandboxDirConfig = filepath.Join(configStoragePath, testSandboxID)
+	sandboxFileConfig = filepath.Join(configStoragePath, testSandboxID, configFile)
+	sandboxDirState = filepath.Join(runStoragePath, testSandboxID)
+	sandboxDirLock = filepath.Join(runStoragePath, testSandboxID)
+	sandboxFileState = filepath.Join(runStoragePath, testSandboxID, stateFile)
+	sandboxFileLock = filepath.Join(runStoragePath, testSandboxID, lockFileName)
 
 	testQemuKernelPath = filepath.Join(testDir, testKernel)
 	testQemuInitrdPath = filepath.Join(testDir, testInitrd)


### PR DESCRIPTION
As agreed in [the kata containers API design](https://github.com/kata-containers/documentation/blob/master/design/kata-api-design.md), we need to rename pod notion to sandbox. The patch is a bit big but the actual change is done through the script:
```
sed -i -e 's/pod/sandbox/g' -e 's/Pod/Sandbox/g' -e 's/POD/SB/g'
```

Fixes: #199

Signed-off-by: Peng Tao <bergwolf@gmail.com>