### PR TITLE
virtcontainers: Fix unit tests

### DIFF
--- a/virtcontainers/cc_shim_test.go
+++ b/virtcontainers/cc_shim_test.go
@@ -242,8 +242,9 @@ func TestCCShimStartDetachSuccessful(t *testing.T) {
 
 	testCCShimStart(t, sandbox, params, false)
 
-	readCh := make(chan error)
+	readCh := make(chan error, 1)
 	go func() {
+		defer close(readCh)
 		bufStdout := make([]byte, 1024)
 		n, err := rStdout.Read(bufStdout)
 		if err != nil && err != io.EOF {

--- a/virtcontainers/kata_shim_test.go
+++ b/virtcontainers/kata_shim_test.go
@@ -236,8 +236,9 @@ func TestKataShimStartDetachSuccessful(t *testing.T) {
 
 	testKataShimStart(t, sandbox, params, false)
 
-	readCh := make(chan error)
+	readCh := make(chan error, 1)
 	go func() {
+		defer close(readCh)
 		bufStdout := make([]byte, 1024)
 		n, err := rStdout.Read(bufStdout)
 		if err != nil && err != io.EOF {

--- a/virtcontainers/noop_shim.go
+++ b/virtcontainers/noop_shim.go
@@ -21,5 +21,5 @@ type noopShim struct{}
 // start is the noopShim start implementation for testing purpose.
 // It does nothing.
 func (s *noopShim) start(sandbox Sandbox, params ShimParams) (int, error) {
-	return 1000, nil
+	return 0, nil
 }

--- a/virtcontainers/noop_shim_test.go
+++ b/virtcontainers/noop_shim_test.go
@@ -24,7 +24,7 @@ func TestNoopShimStart(t *testing.T) {
 	s := &noopShim{}
 	sandbox := Sandbox{}
 	params := ShimParams{}
-	expected := 1000
+	expected := 0
 
 	pid, err := s.start(sandbox, params)
 	if err != nil {


### PR DESCRIPTION
Several failures have been reported through https://github.com/kata-containers/tests/issues/225 regarding our CI. A panic was triggered after our unit tests were reaching the defined timeout of 10s, and we could have bumped this timeout to a bigger value, but the root cause was our bad management of the go routines from our code and from our tests, leaving a lot of go routines behind, and slowing down our tests.

Fixes #208 