### PR TITLE
Assign address to a pci bridge while appending it

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,7 +85,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "1509acf1862ae5154c5c096f9318bd3eb434d816"
+  revision = "9cf8ce6c6dda19d4a6d529e73714e231f6156820"
 
 [[projects]]
   name = "github.com/kata-containers/agent"
@@ -257,6 +257,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d8a31fdf495bbc93a234bdb9abd5250e2688e50c1c2ac88ae80d4b481cafba0d"
+  inputs-digest = "1d1c6e1edc48dac73618d0ce04d505e22276ad5a3e299dd0964eca608fe8e2f1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "1509acf1862ae5154c5c096f9318bd3eb434d816"
+  revision = "9cf8ce6c6dda19d4a6d529e73714e231f6156820"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -907,6 +907,9 @@ type BridgeDevice struct {
 
 	// SHPC is used to enable or disable the standard hot plug controller
 	SHPC bool
+
+	// PCI Slot
+	Addr string
 }
 
 // Valid returns true if the BridgeDevice structure is valid and complete.
@@ -941,6 +944,13 @@ func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 	}
 
 	deviceParam := fmt.Sprintf("%s,bus=%s,id=%s,chassis_nr=%d,shpc=%s", deviceName, bridgeDev.Bus, bridgeDev.ID, bridgeDev.Chassis, shpc)
+	if bridgeDev.Addr != "" {
+		addr, err := strconv.Atoi(bridgeDev.Addr)
+		if err == nil && addr >= 0 {
+			deviceParam += fmt.Sprintf(",addr=%x", addr)
+		}
+	}
+
 	qemuParams = append(qemuParams, "-device")
 	qemuParams = append(qemuParams, deviceParam)
 

--- a/virtcontainers/bridge.go
+++ b/virtcontainers/bridge.go
@@ -26,6 +26,9 @@ type Bridge struct {
 
 	//ID is used to identify the bridge in the hypervisor
 	ID string
+
+	// Addr is the PCI/e slot of the bridge
+	Addr int
 }
 
 // addDevice on success adds the device ID to the bridge and return the address

--- a/virtcontainers/bridge_test.go
+++ b/virtcontainers/bridge_test.go
@@ -16,7 +16,7 @@ func TestAddRemoveDevice(t *testing.T) {
 	assert := assert.New(t)
 
 	// create a bridge
-	bridges := []*Bridge{{make(map[uint32]string), pciBridge, "rgb123"}}
+	bridges := []*Bridge{{make(map[uint32]string), pciBridge, "rgb123", 5}}
 
 	// add device
 	devID := "abc123"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -353,6 +353,10 @@ func (q *qemu) createSandbox(sandboxConfig SandboxConfig) error {
 		},
 	}
 
+	// Add bridges before any other devices. This way we make sure that
+	// bridge gets the first available PCI address i.e bridgePCIStartAddr
+	devices = q.arch.appendBridges(devices, q.state.Bridges)
+
 	devices = q.arch.append9PVolumes(devices, sandboxConfig.Volumes)
 	devices = q.arch.appendConsole(devices, q.getSandboxConsole(sandboxConfig.ID))
 
@@ -361,11 +365,6 @@ func (q *qemu) createSandbox(sandboxConfig SandboxConfig) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	devices = q.arch.appendBridges(devices, q.state.Bridges)
-	if err != nil {
-		return err
 	}
 
 	var ioThread *govmmQemu.IOThread

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -8,6 +8,7 @@ package virtcontainers
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	govmmQemu "github.com/intel/govmm/qemu"
 )
@@ -204,6 +205,8 @@ func (q *qemuAmd64) appendBridges(devices []govmmQemu.Device, bridges []Bridge) 
 			t = govmmQemu.PCIEBridge
 		}
 
+		b.Addr = bridgePCIStartAddr + idx
+
 		devices = append(devices,
 			govmmQemu.BridgeDevice{
 				Type: t,
@@ -212,6 +215,7 @@ func (q *qemuAmd64) appendBridges(devices []govmmQemu.Device, bridges []Bridge) 
 				// Each bridge is required to be assigned a unique chassis id > 0
 				Chassis: (idx + 1),
 				SHPC:    true,
+				Addr:    strconv.FormatInt(int64(b.Addr), 10),
 			},
 		)
 	}

--- a/virtcontainers/qemu_amd64_test.go
+++ b/virtcontainers/qemu_amd64_test.go
@@ -146,6 +146,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 			ID:      bridges[0].ID,
 			Chassis: 1,
 			SHPC:    true,
+			Addr:    "2",
 		},
 	}
 
@@ -168,6 +169,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 			ID:      bridges[0].ID,
 			Chassis: 1,
 			SHPC:    true,
+			Addr:    "2",
 		},
 	}
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
 
 	govmmQemu "github.com/intel/govmm/qemu"
 )
@@ -99,6 +100,12 @@ const (
 	maxDevIDSize            = 31
 	defaultMsize9p          = 8192
 )
+
+// This is the PCI start address assigned to the first bridge that
+// is added on the qemu command line. In case of x86_64, the first two PCI
+// addresses (0 and 1) are used by the platform while in case of ARM, address
+// 0 is reserved.
+const bridgePCIStartAddr = 2
 
 const (
 	// VirtioBlock means use virtio-blk for hotplugging drives
@@ -321,6 +328,8 @@ func (q *qemuArchBase) appendBridges(devices []govmmQemu.Device, bridges []Bridg
 			t = govmmQemu.PCIEBridge
 		}
 
+		b.Addr = bridgePCIStartAddr + idx
+
 		devices = append(devices,
 			govmmQemu.BridgeDevice{
 				Type: t,
@@ -329,6 +338,7 @@ func (q *qemuArchBase) appendBridges(devices []govmmQemu.Device, bridges []Bridg
 				// Each bridge is required to be assigned a unique chassis id > 0
 				Chassis: (idx + 1),
 				SHPC:    true,
+				Addr:    strconv.FormatInt(int64(b.Addr), 10),
 			},
 		)
 	}

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -327,6 +327,7 @@ func TestQemuArchBaseAppendBridges(t *testing.T) {
 			ID:      bridges[0].ID,
 			Chassis: 1,
 			SHPC:    true,
+			Addr:    "2",
 		},
 	}
 


### PR DESCRIPTION
This will allow to determine the PCI address of the device attached to the bridge within the guest.