### PR TITLE
virtcontainers: Improve container searching

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -305,14 +305,14 @@ func TestCreateInvalidArgs(t *testing.T) {
 		return sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -355,13 +355,13 @@ func TestCreateInvalidArgs(t *testing.T) {
 func TestCreateInvalidConfigJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -399,13 +399,13 @@ func TestCreateInvalidConfigJSON(t *testing.T) {
 func TestCreateInvalidContainerType(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -446,13 +446,13 @@ func TestCreateInvalidContainerType(t *testing.T) {
 func TestCreateContainerInvalid(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -501,9 +501,9 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
@@ -511,7 +511,7 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -596,9 +596,9 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
@@ -606,7 +606,7 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -681,9 +681,9 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
@@ -691,7 +691,7 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -752,9 +752,9 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
@@ -762,7 +762,7 @@ func TestCreate(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -810,13 +810,13 @@ func TestCreate(t *testing.T) {
 func TestCreateInvalidKernelParams(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -871,13 +871,13 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 func TestCreateSandboxConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -918,13 +918,13 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 func TestCreateCreateSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -953,13 +953,13 @@ func TestCreateCreateSandboxFail(t *testing.T) {
 func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -997,13 +997,13 @@ func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 func TestCreateCreateContainerFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -1040,9 +1040,9 @@ func TestCreateCreateContainerFail(t *testing.T) {
 func TestCreateCreateContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
 		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
+		return []string{}, false, nil
 	}
 
 	testingImpl.CreateContainerFunc = func(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error) {
@@ -1050,7 +1050,7 @@ func TestCreateCreateContainer(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 		testingImpl.CreateContainerFunc = nil
 	}()
 

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -68,12 +68,17 @@ func TestExecuteErrors(t *testing.T) {
 		vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, vc.State{}, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, vc.State{}, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	err = execute(ctx)
@@ -91,8 +96,11 @@ func TestExecuteErrors(t *testing.T) {
 	}
 
 	containerState := vc.State{}
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -103,8 +111,11 @@ func TestExecuteErrors(t *testing.T) {
 	containerState = vc.State{
 		State: vc.StatePaused,
 	}
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -115,8 +126,11 @@ func TestExecuteErrors(t *testing.T) {
 	containerState = vc.State{
 		State: vc.StateStopped,
 	}
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, vc.State{}, containerState, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
 	}
 
 	err = execute(ctx)
@@ -152,12 +166,17 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	// Note: flags can only be tested with the CLI command function
@@ -196,12 +215,17 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	// Note: flags can only be tested with the CLI command function
@@ -258,12 +282,17 @@ func TestExecuteWithFlags(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	fn, ok := execCLICommand.Action.(func(context *cli.Context) error)
@@ -342,12 +371,17 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	testingImpl.EnterContainerFunc = func(sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
@@ -416,12 +450,17 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	fn, ok := execCLICommand.Action.(func(context *cli.Context) error)
@@ -463,12 +502,17 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	processJSON := `{
@@ -555,12 +599,17 @@ func TestExecuteWithInvalidEnvironment(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	processJSON := `{

--- a/cli/kill_test.go
+++ b/cli/kill_test.go
@@ -63,12 +63,18 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
 	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -93,12 +99,19 @@ func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -115,12 +128,19 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -143,12 +163,19 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 
 		return nil
 	}
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -170,12 +197,18 @@ func TestKillCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return vc.ContainerStatus{}, nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -192,12 +225,19 @@ func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -214,12 +254,19 @@ func TestKillCLIFunctionInvalidStatePausedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -236,12 +283,19 @@ func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -257,11 +311,17 @@ func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -438,19 +438,11 @@ func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
 }
 
-func newSingleContainerSandboxStatusList(sandboxID, containerID string, sandboxState, containerState vc.State, annotations map[string]string) []vc.SandboxStatus {
-	return []vc.SandboxStatus{
-		{
-			ID:    sandboxID,
-			State: sandboxState,
-			ContainersStatus: []vc.ContainerStatus{
-				{
-					ID:          containerID,
-					State:       containerState,
-					Annotations: annotations,
-				},
-			},
-		},
+func newSingleContainerStatus(containerID string, containerState vc.State, annotations map[string]string) vc.ContainerStatus {
+	return vc.ContainerStatus{
+		ID:          containerID,
+		State:       containerState,
+		Annotations: annotations,
 	}
 }
 

--- a/cli/pause_test.go
+++ b/cli/pause_test.go
@@ -32,12 +32,19 @@ func TestPauseCLIFunctionSuccessful(t *testing.T) {
 	}
 
 	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.PauseSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -50,12 +57,14 @@ func TestPauseCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{}, false, nil
 	}
+
 	defer func() {
 		testingImpl.PauseSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -71,11 +80,17 @@ func TestPauseCLIFunctionPauseSandboxFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -92,12 +107,19 @@ func TestResumeCLIFunctionSuccessful(t *testing.T) {
 	}
 
 	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
 		testingImpl.ResumeSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -110,12 +132,14 @@ func TestResumeCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
+
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{}, false, nil
 	}
+
 	defer func() {
 		testingImpl.ResumeSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -131,11 +155,17 @@ func TestResumeCLIFunctionPauseSandboxFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
 	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/ps_test.go
+++ b/cli/ps_test.go
@@ -47,25 +47,22 @@ func TestPSFailure(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-						},
-					},
-				},
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return vc.ContainerStatus{
+			ID: sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
 		}, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	// inexistent container
@@ -91,22 +88,18 @@ func TestPSSuccessful(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						State: vc.State{
-							State: vc.StateRunning,
-						},
-						ID: sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-						},
-					},
-				},
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return vc.ContainerStatus{
+			State: vc.State{
+				State: vc.StateRunning,
+			},
+			ID: sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
 		}, nil
 	}
@@ -116,7 +109,8 @@ func TestPSSuccessful(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.ProcessListContainerFunc = nil
 	}()
 

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -74,14 +74,14 @@ func TestRunInvalidArgs(t *testing.T) {
 		return sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{}, false, nil
 	}
 
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
 	}()
 
 	// temporal dir to place container files
@@ -237,25 +237,26 @@ func TestRunContainerSuccessful(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		if !flagCreate {
+			return []string{}, false, nil
+		}
+
+		return []string{d.sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -279,7 +280,8 @@ func TestRunContainerSuccessful(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
@@ -313,25 +315,26 @@ func TestRunContainerDetachSuccessful(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		if !flagCreate {
+			return []string{}, false, nil
+		}
+
+		return []string{d.sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -355,7 +358,8 @@ func TestRunContainerDetachSuccessful(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
@@ -386,25 +390,26 @@ func TestRunContainerDeleteFail(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		if !flagCreate {
+			return []string{}, false, nil
+		}
+
+		return []string{d.sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -430,7 +435,8 @@ func TestRunContainerDeleteFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
@@ -462,25 +468,26 @@ func TestRunContainerWaitFail(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		if !flagCreate {
+			return []string{}, false, nil
+		}
+
+		return []string{d.sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -509,7 +516,8 @@ func TestRunContainerWaitFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
@@ -546,25 +554,26 @@ func TestRunContainerStartFail(t *testing.T) {
 		return nil, fmt.Errorf("StartSandbox")
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		if !flagCreate {
+			return []string{}, false, nil
+		}
+
+		return []string{d.sandbox.ID()}, true, nil
+	}
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -572,7 +581,8 @@ func TestRunContainerStartFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
@@ -582,10 +592,8 @@ func TestRunContainerStartFail(t *testing.T) {
 	assert.False(ok, "error should not be a cli.ExitError: %s", err)
 }
 
-func TestRunContainerStartFailNoContainers(t *testing.T) {
+func TestRunContainerStartFailExistingContainer(t *testing.T) {
 	assert := assert.New(t)
-
-	listCallCount := 0
 
 	d := testRunContainerSetup(t)
 	defer os.RemoveAll(d.tmpDir)
@@ -601,24 +609,16 @@ func TestRunContainerStartFailNoContainers(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		listCallCount++
+	testingImpl.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{sandbox.ID()}, true, nil
+	}
 
-		if listCallCount == 1 {
-			return []vc.SandboxStatus{}, nil
-		}
-
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: testContainerID,
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-						},
-					},
-				},
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		// return the container status
+		return vc.ContainerStatus{
+			ID: testContainerID,
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
 		}, nil
 	}
@@ -635,7 +635,8 @@ func TestRunContainerStartFailNoContainers(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.ContainerSandboxListFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
 	}()

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -639,3 +639,25 @@ func ProcessListContainer(sandboxID, containerID string, options ProcessListOpti
 
 	return c.processList(options)
 }
+
+// ContainerSandboxList returns the list of sandboxes IDs for all
+// the sandboxes including the provided container ID.
+// It also provides the information about the container ID being part
+// of the containers map.
+func ContainerSandboxList(containerID string) ([]string, bool, error) {
+	if containerID == "" {
+		return nil, false, errNeedContainerID
+	}
+
+	ctrsMap, err := fetchContainersMap()
+	if err != nil {
+		return nil, false, err
+	}
+
+	sandboxList, exist := ctrsMap[containerID]
+	if !exist {
+		return nil, false, nil
+	}
+
+	return sandboxList, true, nil
+}

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -537,6 +537,13 @@ func createContainer(sandbox *Sandbox, contConfig ContainerConfig) (c *Container
 		return
 	}
 
+	// Update containers map if stateful flag.
+	if !c.sandbox.config.Stateless {
+		if err = addToContainersMap(contConfig.ID, sandbox.id); err != nil {
+			return
+		}
+	}
+
 	return c, nil
 }
 
@@ -551,7 +558,18 @@ func (c *Container) delete() error {
 		return err
 	}
 
-	return c.sandbox.storage.deleteContainerResources(c.sandboxID, c.id, nil)
+	if err := c.sandbox.storage.deleteContainerResources(c.sandboxID, c.id, nil); err != nil {
+		return err
+	}
+
+	// Update containers map if stateful flag.
+	if !c.sandbox.config.Stateless {
+		if err := delFromContainersMap(c.id, c.sandbox.id); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // checkSandboxRunning validates the container state.

--- a/virtcontainers/containers_map.go
+++ b/virtcontainers/containers_map.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// rLockSandboxes locks sandboxes with a shared lock.
+func rLockSandboxes() (*os.File, error) {
+	return lockSandboxes(sharedLock)
+}
+
+// rwLockSandboxes locks sandboxes with an exclusive lock.
+func rwLockSandboxes() (*os.File, error) {
+	return lockSandboxes(exclusiveLock)
+}
+
+// lock takes a lock across all sandboxes.
+func lockSandboxes(lockType int) (*os.File, error) {
+	fs := filesystem{}
+	sandboxesLockFile, parentDir, err := fs.globalSandboxURI(lockFileType)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(parentDir, 0750); err != nil {
+			return nil, err
+		}
+	}
+
+	lockFile, err := os.OpenFile(sandboxesLockFile, os.O_RDONLY|os.O_CREATE, 0640)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Flock(int(lockFile.Fd()), lockType); err != nil {
+		return nil, err
+	}
+
+	return lockFile, nil
+}
+
+// unlock releases the lock taken across all sandboxes.
+func unlockSandboxes(lockFile *os.File) error {
+	if lockFile == nil {
+		return fmt.Errorf("lockFile cannot be empty")
+	}
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+
+	lockFile.Close()
+
+	return nil
+}
+
+// findSliceIndexStr returns the slice index where the value matches
+// the provided string.
+// Returns -1 if it could not find the string.
+func findSliceIndexStr(slice []string, val string) int {
+	for idx, elem := range slice {
+		if elem == val {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+// fetchContainersMap retrieves the containers map from the storage.
+func fetchContainersMap() (map[string][]string, error) {
+	fs := &filesystem{}
+	ctrsMap := make(map[string][]string)
+
+	lockFile, err := rLockSandboxes()
+	if err != nil {
+		return nil, err
+	}
+	defer unlockSandboxes(lockFile)
+
+	if err := fs.fetchContainersMap(&ctrsMap); err != nil {
+		return nil, err
+	}
+
+	return ctrsMap, nil
+}
+
+// addToContainersMap adds a pair containerID/sandboxID to the map and stores
+// the result.
+func addToContainersMap(containerID, sandboxID string) error {
+	if containerID == "" {
+		return errNeedContainerID
+	}
+	if sandboxID == "" {
+		return errNeedSandboxID
+	}
+
+	fs := &filesystem{}
+	ctrsMap := make(map[string][]string)
+
+	lockFile, err := rwLockSandboxes()
+	if err != nil {
+		return err
+	}
+	defer unlockSandboxes(lockFile)
+
+	if err := fs.fetchContainersMap(&ctrsMap); err != nil {
+		return err
+	}
+
+	idx := findSliceIndexStr(ctrsMap[containerID], sandboxID)
+	if idx != -1 {
+		return nil
+	}
+
+	ctrsMap[containerID] = append(ctrsMap[containerID], sandboxID)
+
+	return fs.storeContainersMap(ctrsMap)
+}
+
+// delFromContainersMap removes a pair containerID/sandboxID from the map and
+// stores the result.
+func delFromContainersMap(containerID, sandboxID string) error {
+	if containerID == "" {
+		return errNeedContainerID
+	}
+	if sandboxID == "" {
+		return errNeedSandboxID
+	}
+
+	fs := &filesystem{}
+	ctrsMap := make(map[string][]string)
+
+	lockFile, err := rwLockSandboxes()
+	if err != nil {
+		return err
+	}
+	defer unlockSandboxes(lockFile)
+
+	if err := fs.fetchContainersMap(&ctrsMap); err != nil {
+		return err
+	}
+
+	idx := findSliceIndexStr(ctrsMap[containerID], sandboxID)
+	if idx == -1 {
+		return nil
+	}
+
+	ctrsMap[containerID] = append(ctrsMap[containerID][:idx], ctrsMap[containerID][idx+1:]...)
+
+	if len(ctrsMap[containerID]) == 0 {
+		delete(ctrsMap, containerID)
+	}
+
+	return fs.storeContainersMap(ctrsMap)
+}

--- a/virtcontainers/containers_map_test.go
+++ b/virtcontainers/containers_map_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtcontainers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindSliceIndexStrNilSlice(t *testing.T) {
+	assert := assert.New(t)
+
+	idx := findSliceIndexStr(nil, "")
+	assert.Equal(idx, -1)
+}
+
+func TestFindSliceIndexStr(t *testing.T) {
+	assert := assert.New(t)
+
+	idx := findSliceIndexStr([]string{"val1", "val2"}, "val2")
+	assert.Equal(idx, 1)
+}
+
+func TestFetchContainersMapNotExisting(t *testing.T) {
+	assert := assert.New(t)
+	expected := make(map[string][]string)
+
+	ctrsMap, err := fetchContainersMap()
+	assert.Nil(err)
+	assert.True(reflect.DeepEqual(ctrsMap, expected), "Got %v\nExpecting %v", ctrsMap, expected)
+}
+
+func TestFetchContainersMap(t *testing.T) {
+	assert := assert.New(t)
+
+	ctrID := "12345"
+	sandboxID := "67890"
+	ctrsMap := make(map[string][]string)
+	sandboxList := []string{sandboxID}
+	ctrsMap[ctrID] = sandboxList
+
+	path := filepath.Join(runStoragePath, containersMapFile)
+	err := os.RemoveAll(path)
+	assert.Nil(err)
+
+	f, err := os.Create(path)
+	assert.Nil(err)
+	defer os.RemoveAll(path)
+	defer f.Close()
+
+	jsonOut, err := json.Marshal(ctrsMap)
+	assert.Nil(err)
+
+	_, err = f.Write(jsonOut)
+	assert.Nil(err)
+
+	result, err := fetchContainersMap()
+	assert.Nil(err)
+	assert.True(reflect.DeepEqual(result, ctrsMap), "Got %v\nExpecting %v", result, ctrsMap)
+}
+
+func TestAddToContainersMapNoCtrIDFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := addToContainersMap("", "sandboxID")
+	assert.Error(err)
+	assert.Equal(err, errNeedContainerID)
+}
+
+func TestAddToContainersMapNoSandboxIDFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := addToContainersMap("ctrID", "")
+	assert.Error(err)
+	assert.Equal(err, errNeedSandboxID)
+}
+
+func TestAddToContainersMapSuccessful(t *testing.T) {
+	assert := assert.New(t)
+
+	ctrID := "ctr1"
+	sandboxID := "sb1"
+	ctrsMap := make(map[string][]string)
+	sandboxList := []string{sandboxID}
+	ctrsMap[ctrID] = sandboxList
+
+	additionalCtrID := "ctr2"
+	additionalSandboxID := "sb2"
+
+	expected := map[string][]string{
+		ctrID:           {sandboxID},
+		additionalCtrID: {additionalSandboxID},
+	}
+
+	path := filepath.Join(runStoragePath, containersMapFile)
+	err := os.RemoveAll(path)
+	assert.Nil(err)
+
+	f, err := os.Create(path)
+	assert.Nil(err)
+	defer os.RemoveAll(path)
+	defer f.Close()
+
+	jsonOut, err := json.Marshal(ctrsMap)
+	assert.Nil(err)
+
+	_, err = f.Write(jsonOut)
+	assert.Nil(err)
+
+	err = addToContainersMap(additionalCtrID, additionalSandboxID)
+	assert.Nil(err)
+	result, err := fetchContainersMap()
+	assert.Nil(err)
+	assert.True(reflect.DeepEqual(result, expected), "Got %v\nExpecting %v", result, expected)
+}
+
+func TestDelFromContainersMapNoCtrIDFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := delFromContainersMap("", "sandboxID")
+	assert.Error(err)
+	assert.Equal(err, errNeedContainerID)
+}
+
+func TestDelFromContainersMapNoSandboxIDFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := delFromContainersMap("ctrID", "")
+	assert.Error(err)
+	assert.Equal(err, errNeedSandboxID)
+}
+
+func TestDelFromContainersMapSuccessful(t *testing.T) {
+	assert := assert.New(t)
+
+	ctrID := "ctr1"
+	sandboxID := "sb1"
+	additionalCtrID := "ctr2"
+	additionalSandboxID := "sb2"
+
+	ctrsMap := map[string][]string{
+		ctrID:           {sandboxID},
+		additionalCtrID: {additionalSandboxID},
+	}
+
+	expected := map[string][]string{
+		ctrID: {sandboxID},
+	}
+
+	path := filepath.Join(runStoragePath, containersMapFile)
+	err := os.RemoveAll(path)
+	assert.Nil(err)
+
+	f, err := os.Create(path)
+	assert.Nil(err)
+	defer os.RemoveAll(path)
+	defer f.Close()
+
+	jsonOut, err := json.Marshal(ctrsMap)
+	assert.Nil(err)
+
+	_, err = f.Write(jsonOut)
+	assert.Nil(err)
+
+	err = delFromContainersMap(additionalCtrID, additionalSandboxID)
+	assert.Nil(err)
+	result, err := fetchContainersMap()
+	assert.Nil(err)
+	assert.True(reflect.DeepEqual(result, expected), "Got %v\nExpecting %v", result, expected)
+}

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -108,3 +108,8 @@ func (impl *VCImpl) KillContainer(sandboxID, containerID string, signal syscall.
 func (impl *VCImpl) ProcessListContainer(sandboxID, containerID string, options ProcessListOptions) (ProcessList, error) {
 	return ProcessListContainer(sandboxID, containerID, options)
 }
+
+// ContainerSandboxList implements the VC function of the same name.
+func (impl *VCImpl) ContainerSandboxList(containerID string) ([]string, bool, error) {
+	return ContainerSandboxList(containerID)
+}

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -33,6 +33,8 @@ type VC interface {
 	StatusContainer(sandboxID, containerID string) (ContainerStatus, error)
 	StopContainer(sandboxID, containerID string) (VCContainer, error)
 	ProcessListContainer(sandboxID, containerID string, options ProcessListOptions) (ProcessList, error)
+
+	ContainerSandboxList(containerID string) ([]string, bool, error)
 }
 
 // VCSandbox is the Sandbox interface

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -186,3 +186,12 @@ func (m *VCMock) ProcessListContainer(sandboxID, containerID string, options vc.
 
 	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
+
+// ContainerSandboxList implements the VC function of the same name.
+func (m *VCMock) ContainerSandboxList(containerID string) ([]string, bool, error) {
+	if m.ContainerSandboxListFunc != nil {
+		return m.ContainerSandboxListFunc(containerID)
+	}
+
+	return nil, false, fmt.Errorf("%s: %s (%+v): containerID: %v", mockErrorPrefix, getSelf(), m, containerID)
+}

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -568,3 +568,30 @@ func TestVCMockProcessListContainer(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
+
+func TestVCMockContainerSandboxList(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &VCMock{}
+	assert.Nil(m.ContainerSandboxListFunc)
+
+	_, _, err := m.ContainerSandboxList(testContainerID)
+	assert.Error(err)
+	assert.True(IsMockError(err))
+
+	m.ContainerSandboxListFunc = func(containerID string) ([]string, bool, error) {
+		return []string{testSandboxID}, true, nil
+	}
+
+	sandboxList, exist, err := m.ContainerSandboxList(testContainerID)
+	assert.NoError(err)
+	assert.Equal(exist, true)
+	assert.Equal(sandboxList, []string{testSandboxID})
+
+	// reset
+	m.ContainerSandboxListFunc = nil
+
+	_, _, err = m.ContainerSandboxList(testContainerID)
+	assert.Error(err)
+	assert.True(IsMockError(err))
+}

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -54,4 +54,5 @@ type VCMock struct {
 	StatusContainerFunc      func(sandboxID, containerID string) (vc.ContainerStatus, error)
 	StopContainerFunc        func(sandboxID, containerID string) (vc.VCContainer, error)
 	ProcessListContainerFunc func(sandboxID, containerID string, options vc.ProcessListOptions) (vc.ProcessList, error)
+	ContainerSandboxListFunc func(containerID string) ([]string, bool, error)
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -359,6 +359,11 @@ type SandboxConfig struct {
 	// Annotations keys must be unique strings and must be name-spaced
 	// with e.g. reverse domain notation (org.clearlinux.key).
 	Annotations map[string]string
+
+	// Stateless means the caller is a long living process which will keep
+	// track of changes. For performances reasons, it makes sense not to
+	// store informations from virtcontainers.
+	Stateless bool
 }
 
 // valid checks that the sandbox configuration is valid.


### PR DESCRIPTION
The more we are running some containers on the system, the more
time it takes our runtime to start new ones. The reason behind is
that we always ask the list of all sandboxes in order to parse it
from the CLI. This parsing resulting in finding if a container
exists or not, and in case it does exist, we need its associated
sandbox ID.

An easy way to simplify the current complexity O(n²) into an O(1),
is to use a hash table listing all the containers as a key and their
associated sandbox as a value.

That's what this patch does, it introduces a hash table being stored
on the filesystem through a JSON file. This way, we can keep track of
the containers and their associated sandboxes, even in case of the
short lifetime of the kata-runtime CLI.

Fixes #212

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>