### PR TITLE
virtcontainers: Disable cpuset and cpumem

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -588,6 +588,8 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil
 	grpcSpec.Linux.Resources.Network = nil
+	grpcSpec.Linux.Resources.CPU.Cpus = ""
+	grpcSpec.Linux.Resources.CPU.Mems = ""
 
 	// Disable network namespace since it is already handled on the host by
 	// virtcontainers. The network is a complex part which cannot be simply


### PR DESCRIPTION
Disable cpuset and cpumem constraints as this is not properly
supported yet.
    
If we add "cpuset_cpus" and "cpuset_mems" to the container.json,
kata-runtime failed to start, so we need to disable them.

Fixes: #221.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>