### PR TITLE
cli: Don't wait for OCI delete to stop the sandbox

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -105,8 +105,15 @@ func delete(containerID string, force bool) error {
 }
 
 func deleteSandbox(sandboxID string) error {
-	if _, err := vci.StopSandbox(sandboxID); err != nil {
+	status, err := vci.StatusSandbox(sandboxID)
+	if err != nil {
 		return err
+	}
+
+	if oci.StateToOCIState(status.State) != oci.StateStopped {
+		if _, err := vci.StopSandbox(sandboxID); err != nil {
+			return err
+		}
 	}
 
 	if _, err := vci.DeleteSandbox(sandboxID); err != nil {

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -192,6 +192,23 @@ func TestDeleteSandbox(t *testing.T) {
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
 
+	testingImpl.StatusSandboxFunc = func(sandboxID string) (vc.SandboxStatus, error) {
+		return vc.SandboxStatus{
+			ID: sandbox.ID(),
+			State: vc.State{
+				State: vc.StateReady,
+			},
+		}, nil
+	}
+
+	defer func() {
+		testingImpl.StatusSandboxFunc = nil
+	}()
+
+	err = delete(sandbox.ID(), false)
+	assert.Error(err)
+	assert.True(vcmock.IsMockError(err))
+
 	testingImpl.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
@@ -297,11 +314,21 @@ func TestDeleteSandboxRunning(t *testing.T) {
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 
+	testingImpl.StatusSandboxFunc = func(sandboxID string) (vc.SandboxStatus, error) {
+		return vc.SandboxStatus{
+			ID: sandbox.ID(),
+			State: vc.State{
+				State: vc.StateRunning,
+			},
+		}, nil
+	}
+
 	testingImpl.StopSandboxFunc = func(sandboxID string) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
 
 	defer func() {
+		testingImpl.StatusSandboxFunc = nil
 		testingImpl.StopSandboxFunc = nil
 	}()
 
@@ -521,6 +548,15 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 						},
 					},
 				},
+			},
+		}, nil
+	}
+
+	testingImpl.StatusSandboxFunc = func(sandboxID string) (vc.SandboxStatus, error) {
+		return vc.SandboxStatus{
+			ID: sandbox.ID(),
+			State: vc.State{
+				State: vc.StateReady,
 			},
 		}, nil
 	}

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/urfave/cli"
 )
 
@@ -115,7 +116,20 @@ func kill(containerID, signal string, all bool) error {
 		return nil
 	}
 
-	_, err = vci.StopContainer(sandboxID, containerID)
+	containerType, err := oci.GetContainerType(status.Annotations)
+	if err != nil {
+		return err
+	}
+
+	switch containerType {
+	case vc.PodSandbox:
+		_, err = vci.StopSandbox(sandboxID)
+	case vc.PodContainer:
+		_, err = vci.StopContainer(sandboxID, containerID)
+	default:
+		return fmt.Errorf("Invalid container type found")
+	}
+
 	return err
 }
 


### PR DESCRIPTION
This commit tries to address uses cases where the caller of the
runtime expects a kill to stop the container representing the pod,
meaning in our case the end of the VM.

This leads to some rework of the delete command since we want a
delete --force to always work, even if the container/pod has been
killed before.

Fixes #197

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>