### PR TITLE
config: Add SPDX license header to config file

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -1,3 +1,8 @@
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 # XXX: WARNING: this file is auto-generated.
 # XXX:
 # XXX: Source file: "@CONFIG_IN@"


### PR DESCRIPTION
The config file is in TOML format which supports comments, so add the
license header to it.

Fixes #234.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>