### PR TITLE
virtcontainers: kata_agent: enable cpus and mem sets

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -579,8 +579,6 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil
 	grpcSpec.Linux.Resources.Network = nil
-	grpcSpec.Linux.Resources.CPU.Cpus = ""
-	grpcSpec.Linux.Resources.CPU.Mems = ""
 
 	// Disable network namespace since it is already handled on the host by
 	// virtcontainers. The network is a complex part which cannot be simply


### PR DESCRIPTION
this patch is to honour docker `--cpuset-cpus` and
`--cpuset-mems` options.

fixes #221

Signed-off-by: Julio Montes <julio.montes@intel.com>