### PR TITLE
tests: Fix issues introduced by Go 1.10

### DIFF
--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -48,7 +48,7 @@ func TestCCProxyStart(t *testing.T) {
 				config: &SandboxConfig{
 					ProxyType:   CCProxyType,
 					ProxyConfig: ProxyConfig{
-					// invalid - no path
+						// invalid - no path
 					},
 				},
 			}, "", true,


### PR DESCRIPTION
Now that our CI has moved to Go 1.10, we need to update one file
that is not formatted as the new gofmt (1.10) expects it to be
formatted.

Fixes #249

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>