### PR TITLE
versions: change newest supported go version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -139,7 +139,7 @@ languages:
     notes: "'version' is the default minimum version used by this project."
     version: "1.8.3"
     meta:
-      newest-version: "1.10"
+      newest-version: "1.9.2"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
change from go1.10 to 1.9.2.
Our static checks and unit tests fail when using
go 1.10. Since we use go 1.9.2 to test in our CI,
reflect this version in versions.yaml

By doing this, we will be able to remove the hardcoded version
from the jenkins scripts and instead install golang using
`.ci/install_go.sh` from the tests repository. And when moving
to go1.10 using a PR, the CI will test that the static checks
and unit tests pass correctly.

Fixes: #254.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>