### PR TITLE
cli: Optimize container research

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -239,6 +239,10 @@ func createSandbox(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 		return vc.Process{}, fmt.Errorf("BUG: Container list from sandbox is wrong, expecting only one container, found %d containers", len(containers))
 	}
 
+	if err := addContainerIDMapping(containerID, sandbox.ID()); err != nil {
+		return vc.Process{}, err
+	}
+
 	return containers[0].Process(), nil
 }
 
@@ -257,6 +261,10 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 
 	_, c, err := vci.CreateContainer(sandboxID, contConfig)
 	if err != nil {
+		return vc.Process{}, err
+	}
+
+	if err := addContainerIDMapping(containerID, sandboxID); err != nil {
 		return vc.Process{}, err
 	}
 

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -305,14 +305,13 @@ func TestCreateInvalidArgs(t *testing.T) {
 		return sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
 	}()
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -355,14 +354,10 @@ func TestCreateInvalidArgs(t *testing.T) {
 func TestCreateInvalidConfigJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -393,20 +388,17 @@ func TestCreateInvalidConfigJSON(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateInvalidContainerType(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -440,20 +432,17 @@ func TestCreateInvalidContainerType(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateContainerInvalid(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -488,6 +477,7 @@ func TestCreateContainerInvalid(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
@@ -501,17 +491,16 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -578,6 +567,7 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	for _, detach := range []bool{true, false} {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, detach, runtimeConfig)
 		assert.NoError(err, "detached: %+v", detach)
+		os.RemoveAll(path)
 	}
 }
 
@@ -596,17 +586,16 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -663,6 +652,7 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
@@ -681,17 +671,16 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -739,6 +728,7 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
@@ -752,17 +742,16 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	testingImpl.CreateSandboxFunc = func(sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error) {
 		return sandbox, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 	}()
 
@@ -804,20 +793,17 @@ func TestCreate(t *testing.T) {
 	for detach := range []bool{true, false} {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.NoError(err, "%+v", detach)
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateInvalidKernelParams(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -865,20 +851,17 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
 		assert.False(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateSandboxConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -918,14 +901,10 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 func TestCreateCreateSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -953,14 +932,10 @@ func TestCreateCreateSandboxFail(t *testing.T) {
 func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -991,20 +966,17 @@ func TestCreateCreateContainerContainerConfigFail(t *testing.T) {
 		assert.Error(err)
 		assert.False(vcmock.IsMockError(err))
 		assert.True(strings.Contains(err.Error(), containerType))
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateCreateContainerFail(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
@@ -1034,23 +1006,23 @@ func TestCreateCreateContainerFail(t *testing.T) {
 		_, err = createContainer(spec, testContainerID, bundlePath, testConsole, disableOutput)
 		assert.Error(err)
 		assert.True(vcmock.IsMockError(err))
+		os.RemoveAll(path)
 	}
 }
 
 func TestCreateCreateContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		// No pre-existing sandboxes
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	testingImpl.CreateContainerFunc = func(sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error) {
 		return &vcmock.Sandbox{}, &vcmock.Container{}, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
 		testingImpl.CreateContainerFunc = nil
 	}()
 
@@ -1081,6 +1053,7 @@ func TestCreateCreateContainer(t *testing.T) {
 	for _, disableOutput := range []bool{true, false} {
 		_, err = createContainer(spec, testContainerID, bundlePath, testConsole, disableOutput)
 		assert.NoError(err)
+		os.RemoveAll(path)
 	}
 }
 

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -101,6 +101,10 @@ func delete(containerID string, force bool) error {
 		return err
 	}
 
+	if err := delContainerIDMapping(containerID); err != nil {
+		return err
+	}
+
 	return removeCgroupsPath(containerID, cgroupsPathList)
 }
 

--- a/cli/kill_test.go
+++ b/cli/kill_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"syscall"
 	"testing"
 
@@ -72,13 +73,19 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
 	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
 		testingImpl.StopContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -90,11 +97,12 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 		vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 	}
 
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
+	}
+
 	testingImpl.StopContainerFunc = nil
 	testingImpl.StopSandboxFunc = testStopSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
-	}
 	defer func() {
 		testingImpl.StopSandboxFunc = nil
 	}()
@@ -118,12 +126,18 @@ func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -145,13 +159,19 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
 	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
 		testingImpl.StopContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -163,11 +183,12 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 		vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 	}
 
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
+	}
+
 	testingImpl.StopContainerFunc = nil
 	testingImpl.StopSandboxFunc = testStopSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
-	}
 	defer func() {
 		testingImpl.StopSandboxFunc = nil
 	}()
@@ -194,13 +215,19 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 		return nil
 	}
 	testingImpl.StopContainerFunc = testStopContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
 		testingImpl.StopContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -213,11 +240,12 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 		vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 	}
 
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, annotations), nil
+	}
+
 	testingImpl.StopContainerFunc = nil
 	testingImpl.StopSandboxFunc = testStopSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, annotations), nil
-	}
 	defer func() {
 		testingImpl.StopSandboxFunc = nil
 	}()
@@ -237,12 +265,17 @@ func TestKillCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return vc.ContainerStatus{}, nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -259,12 +292,18 @@ func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -281,12 +320,18 @@ func TestKillCLIFunctionInvalidStatePausedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -303,12 +348,18 @@ func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.KillContainerFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -324,11 +375,16 @@ func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -438,19 +438,11 @@ func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
 }
 
-func newSingleContainerSandboxStatusList(sandboxID, containerID string, sandboxState, containerState vc.State, annotations map[string]string) []vc.SandboxStatus {
-	return []vc.SandboxStatus{
-		{
-			ID:    sandboxID,
-			State: sandboxState,
-			ContainersStatus: []vc.ContainerStatus{
-				{
-					ID:          containerID,
-					State:       containerState,
-					Annotations: annotations,
-				},
-			},
-		},
+func newSingleContainerStatus(containerID string, containerState vc.State, annotations map[string]string) vc.ContainerStatus {
+	return vc.ContainerStatus{
+		ID:          containerID,
+		State:       containerState,
+		Annotations: annotations,
 	}
 }
 
@@ -1101,4 +1093,19 @@ func TestMainResetCLIGlobals(t *testing.T) {
 	assert.Equal(cli.AppHelpTemplate, savedCLIAppHelpTemplate)
 	assert.NotNil(cli.VersionPrinter)
 	assert.NotNil(savedCLIVersionPrinter)
+}
+
+func createTempContainerIDMapping(containerID, sandboxID string) (string, error) {
+	tmpDir, err := ioutil.TempDir("", "containers-mapping")
+	if err != nil {
+		return "", err
+	}
+	ctrsMapTreePath = tmpDir
+
+	path := filepath.Join(ctrsMapTreePath, containerID, sandboxID)
+	if err := os.MkdirAll(path, 0750); err != nil {
+		return "", err
+	}
+
+	return tmpDir, nil
 }

--- a/cli/oci_test.go
+++ b/cli/oci_test.go
@@ -87,57 +87,22 @@ func TestGetContainerInfo(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{
-			{
-				ID:               sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{containerStatus},
-			},
-		}, nil
+	path, err := createTempContainerIDMapping(containerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return containerStatus, nil
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	status, sandboxID, err := getContainerInfo(testContainerID)
 	assert.NoError(err)
 	assert.Equal(sandboxID, sandbox.ID())
 	assert.Equal(status, containerStatus)
-}
-
-func TestGetContainerInfoMismatch(t *testing.T) {
-	assert := assert.New(t)
-
-	sandbox := &vcmock.Sandbox{
-		MockID: testSandboxID,
-	}
-
-	containerID := testContainerID + testContainerID
-
-	containerStatus := vc.ContainerStatus{
-		ID: containerID,
-		Annotations: map[string]string{
-			vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-		},
-	}
-
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{
-			{
-				ID:               sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{containerStatus},
-			},
-		}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
-
-	_, sandboxID, err := getContainerInfo(testContainerID)
-	assert.NoError(err)
-	assert.Equal(sandboxID, "")
 }
 
 func TestValidCreateParamsContainerIDEmptyFailure(t *testing.T) {
@@ -159,75 +124,16 @@ func TestGetExistingContainerInfoContainerIDEmptyFailure(t *testing.T) {
 func TestValidCreateParamsContainerIDNotUnique(t *testing.T) {
 	assert := assert.New(t)
 
-	containerID := testContainerID + testContainerID
+	testSandboxID2 := testSandboxID + "2"
 
-	sandbox := &vcmock.Sandbox{
-		MockID: testSandboxID,
-	}
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	err = os.MkdirAll(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID2), 0750)
+	assert.NoError(err)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					// 2 containers with same ID
-					{
-						ID: containerID,
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-						},
-					},
-					{
-						ID: containerID,
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-						},
-					},
-				},
-			},
-		}, nil
-	}
+	_, err = validCreateParams(testContainerID, "")
 
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
-
-	_, err := validCreateParams(testContainerID, "")
-
-	assert.Error(err)
-	assert.False(vcmock.IsMockError(err))
-}
-
-func TestValidCreateParamsContainerIDNotUnique2(t *testing.T) {
-	assert := assert.New(t)
-
-	containerID := testContainerID + testContainerID
-
-	sandbox := &vcmock.Sandbox{
-		MockID: testSandboxID,
-	}
-
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: containerID,
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-						},
-					},
-				},
-			},
-		}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
-
-	_, err := validCreateParams(testContainerID, "")
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }
@@ -241,13 +147,10 @@ func TestValidCreateParamsInvalidBundle(t *testing.T) {
 
 	bundlePath := filepath.Join(tmpdir, "bundle")
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	_, err = validCreateParams(testContainerID, bundlePath)
 	// bundle is ENOENT
@@ -266,13 +169,10 @@ func TestValidCreateParamsBundleIsAFile(t *testing.T) {
 	err = createEmptyFile(bundlePath)
 	assert.NoError(err)
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
-	}
-
-	defer func() {
-		testingImpl.ListSandboxFunc = nil
-	}()
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	_, err = validCreateParams(testContainerID, bundlePath)
 	// bundle exists as a file, not a directory
@@ -611,4 +511,107 @@ func TestGetCgroupsDirPath(t *testing.T) {
 
 		assert.Equal(d.expectedResult, path)
 	}
+}
+
+func TestFetchContainerIDMappingContainerIDEmptyFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	sandboxID, err := fetchContainerIDMapping("")
+	assert.Error(err)
+	assert.Empty(sandboxID)
+}
+
+func TestFetchContainerIDMappingEmptyMappingSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	sandboxID, err := fetchContainerIDMapping(testContainerID)
+	assert.NoError(err)
+	assert.Empty(sandboxID)
+}
+
+func TestFetchContainerIDMappingTooManyFilesFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	err = os.MkdirAll(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID+"2"), ctrsMappingDirMode)
+	assert.NoError(err)
+
+	sandboxID, err := fetchContainerIDMapping(testContainerID)
+	assert.Error(err)
+	assert.Empty(sandboxID)
+}
+
+func TestFetchContainerIDMappingSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	sandboxID, err := fetchContainerIDMapping(testContainerID)
+	assert.NoError(err)
+	assert.Equal(sandboxID, testSandboxID)
+}
+
+func TestAddContainerIDMappingContainerIDEmptyFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := addContainerIDMapping("", testSandboxID)
+	assert.Error(err)
+}
+
+func TestAddContainerIDMappingSandboxIDEmptyFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := addContainerIDMapping(testContainerID, "")
+	assert.Error(err)
+}
+
+func TestAddContainerIDMappingSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	_, err = os.Stat(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID))
+	assert.True(os.IsNotExist(err))
+
+	err = addContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+
+	_, err = os.Stat(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID))
+	assert.NoError(err)
+}
+
+func TestDelContainerIDMappingContainerIDEmptyFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	err := delContainerIDMapping("")
+	assert.Error(err)
+}
+
+func TestDelContainerIDMappingSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	_, err = os.Stat(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID))
+	assert.NoError(err)
+
+	err = delContainerIDMapping(testContainerID)
+	assert.NoError(err)
+
+	_, err = os.Stat(filepath.Join(ctrsMapTreePath, testContainerID, testSandboxID))
+	assert.True(os.IsNotExist(err))
 }

--- a/cli/pause_test.go
+++ b/cli/pause_test.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
@@ -32,12 +34,18 @@ func TestPauseCLIFunctionSuccessful(t *testing.T) {
 	}
 
 	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.PauseSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -50,12 +58,14 @@ func TestPauseCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.PauseSandboxFunc = testPauseSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
-	}
+
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
 	defer func() {
 		testingImpl.PauseSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -71,11 +81,16 @@ func TestPauseCLIFunctionPauseSandboxFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -92,12 +107,18 @@ func TestResumeCLIFunctionSuccessful(t *testing.T) {
 	}
 
 	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
 		testingImpl.ResumeSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -110,12 +131,13 @@ func TestResumeCLIFunctionContainerNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
 
 	testingImpl.ResumeSandboxFunc = testResumeSandboxFuncReturnNil
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
-	}
+
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
 	defer func() {
 		testingImpl.ResumeSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)
@@ -131,11 +153,16 @@ func TestResumeCLIFunctionPauseSandboxFailure(t *testing.T) {
 		State: vc.StateRunning,
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return newSingleContainerSandboxStatusList(testSandboxID, testContainerID, state, state, map[string]string{}), nil
+	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
 	}
+
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	set := flag.NewFlagSet("", 0)

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -74,14 +74,14 @@ func TestRunInvalidArgs(t *testing.T) {
 		return sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		return []vc.SandboxStatus{}, nil
-	}
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
 
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
 	}()
 
 	// temporal dir to place container files
@@ -237,25 +237,23 @@ func TestRunContainerSuccessful(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -279,13 +277,13 @@ func TestRunContainerSuccessful(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err := run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
 
 	// should return ExitError with the message and exit code
 	e, ok := err.(*cli.ExitError)
@@ -313,25 +311,23 @@ func TestRunContainerDetachSuccessful(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -355,13 +351,13 @@ func TestRunContainerDetachSuccessful(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err := run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, true, d.runtimeConfig)
+	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, true, d.runtimeConfig)
 
 	// should not return ExitError
 	assert.NoError(err)
@@ -386,25 +382,23 @@ func TestRunContainerDeleteFail(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -430,13 +424,13 @@ func TestRunContainerDeleteFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err := run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
 
 	// should not return ExitError
 	err, ok := err.(*cli.ExitError)
@@ -462,25 +456,23 @@ func TestRunContainerWaitFail(t *testing.T) {
 		return d.sandbox, nil
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -509,13 +501,13 @@ func TestRunContainerWaitFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.StartContainerFunc = nil
 		testingImpl.DeleteSandboxFunc = nil
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err := run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
 
 	// should not return ExitError
 	err, ok := err.(*cli.ExitError)
@@ -546,25 +538,23 @@ func TestRunContainerStartFail(t *testing.T) {
 		return nil, fmt.Errorf("StartSandbox")
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
+	path, err := ioutil.TempDir("", "containers-mapping")
+	assert.NoError(err)
+	defer os.RemoveAll(path)
+	ctrsMapTreePath = path
+
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
 		// return an empty list on create
 		if !flagCreate {
-			return []vc.SandboxStatus{}, nil
+			return vc.ContainerStatus{}, nil
 		}
 
 		// return a sandboxStatus with the container status
-		return []vc.SandboxStatus{
-			{
-				ID: d.sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: d.sandbox.ID(),
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-							vcAnnotations.ConfigJSONKey:    d.configJSON,
-						},
-					},
-				},
+		return vc.ContainerStatus{
+			ID: d.sandbox.ID(),
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
+				vcAnnotations.ConfigJSONKey:    d.configJSON,
 			},
 		}, nil
 	}
@@ -572,7 +562,7 @@ func TestRunContainerStartFail(t *testing.T) {
 	defer func() {
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 	}()
 
 	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
@@ -582,10 +572,8 @@ func TestRunContainerStartFail(t *testing.T) {
 	assert.False(ok, "error should not be a cli.ExitError: %s", err)
 }
 
-func TestRunContainerStartFailNoContainers(t *testing.T) {
+func TestRunContainerStartFailExistingContainer(t *testing.T) {
 	assert := assert.New(t)
-
-	listCallCount := 0
 
 	d := testRunContainerSetup(t)
 	defer os.RemoveAll(d.tmpDir)
@@ -601,24 +589,16 @@ func TestRunContainerStartFailNoContainers(t *testing.T) {
 		},
 	}
 
-	testingImpl.ListSandboxFunc = func() ([]vc.SandboxStatus, error) {
-		listCallCount++
+	path, err := createTempContainerIDMapping(testContainerID, sandbox.ID())
+	assert.NoError(err)
+	defer os.RemoveAll(path)
 
-		if listCallCount == 1 {
-			return []vc.SandboxStatus{}, nil
-		}
-
-		return []vc.SandboxStatus{
-			{
-				ID: sandbox.ID(),
-				ContainersStatus: []vc.ContainerStatus{
-					{
-						ID: testContainerID,
-						Annotations: map[string]string{
-							vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-						},
-					},
-				},
+	testingImpl.StatusContainerFunc = func(sandboxID, containerID string) (vc.ContainerStatus, error) {
+		// return the container status
+		return vc.ContainerStatus{
+			ID: testContainerID,
+			Annotations: map[string]string{
+				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
 		}, nil
 	}
@@ -635,12 +615,12 @@ func TestRunContainerStartFailNoContainers(t *testing.T) {
 	}
 
 	defer func() {
-		testingImpl.ListSandboxFunc = nil
+		testingImpl.StatusContainerFunc = nil
 		testingImpl.CreateSandboxFunc = nil
 		testingImpl.StartSandboxFunc = nil
 	}()
 
-	err := run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
 }


### PR DESCRIPTION
This commit will allow for better performance regarding the time spent
to retrieve the sandbox ID related to a container ID.

The way it works is by relying on a specific mapping between container
IDs and sanbox IDs, meaning it allows to retrieve directly the sandbox
ID related to a container ID from the CLI. This lowers complexity from
O(n²) to O(1), because we don't need to call into ListPod() which was
parsing all the pods and all the containers on the system everytime
the CLI need to retrieve this mapping.

This commit also updates the whole unit tests as a consequence. This
is involving most of them since they were all relying on ListPod()
before.

Fixes #212

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>