### PR TITLE
virtcontainers: always pass sandbox as a pointer

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -143,27 +143,27 @@ type agent interface {
 	exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error)
 
 	// startSandbox will tell the agent to start all containers related to the Sandbox.
-	startSandbox(sandbox Sandbox) error
+	startSandbox(sandbox *Sandbox) error
 
 	// stopSandbox will tell the agent to stop all containers related to the Sandbox.
-	stopSandbox(sandbox Sandbox) error
+	stopSandbox(sandbox *Sandbox) error
 
 	// createContainer will tell the agent to create a container related to a Sandbox.
 	createContainer(sandbox *Sandbox, c *Container) (*Process, error)
 
 	// startContainer will tell the agent to start a container related to a Sandbox.
-	startContainer(sandbox Sandbox, c *Container) error
+	startContainer(sandbox *Sandbox, c *Container) error
 
 	// stopContainer will tell the agent to stop a container related to a Sandbox.
-	stopContainer(sandbox Sandbox, c Container) error
+	stopContainer(sandbox *Sandbox, c Container) error
 
 	// killContainer will tell the agent to send a signal to a
 	// container related to a Sandbox. If all is true, all processes in
 	// the container will be sent the signal.
-	killContainer(sandbox Sandbox, c Container, signal syscall.Signal, all bool) error
+	killContainer(sandbox *Sandbox, c Container, signal syscall.Signal, all bool) error
 
 	// processListContainer will list the processes running inside the container
-	processListContainer(sandbox Sandbox, c Container, options ProcessListOptions) (ProcessList, error)
+	processListContainer(sandbox *Sandbox, c Container, options ProcessListOptions) (ProcessList, error)
 
 	// onlineCPUMem will online CPUs and Memory inside the Sandbox.
 	// This function should be called after hot adding vCPUs or Memory.

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -528,7 +528,7 @@ func TestStartSandboxHyperstartAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestStartSandboxKataAgentSuccessful(t *testing.T) {
@@ -568,7 +568,7 @@ func TestStartSandboxKataAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestStartSandboxFailing(t *testing.T) {
@@ -800,7 +800,7 @@ func TestRunSandboxHyperstartAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestRunSandboxKataAgentSuccessful(t *testing.T) {
@@ -846,7 +846,7 @@ func TestRunSandboxKataAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestRunSandboxFailing(t *testing.T) {
@@ -1392,7 +1392,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestStartStopSandboxHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
@@ -1649,7 +1649,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	bindUnmountAllRootfs(defaultSharedDir, *pImpl)
+	bindUnmountAllRootfs(defaultSharedDir, pImpl)
 }
 
 func TestEnterContainerFailingNoSandbox(t *testing.T) {

--- a/virtcontainers/cc_proxy.go
+++ b/virtcontainers/cc_proxy.go
@@ -13,7 +13,7 @@ type ccProxy struct {
 }
 
 // start is the proxy start implementation for ccProxy.
-func (p *ccProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+func (p *ccProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	config, err := newProxyConfig(sandbox.config)
 	if err != nil {
 		return -1, "", err
@@ -38,6 +38,6 @@ func (p *ccProxy) start(sandbox Sandbox, params proxyParams) (int, string, error
 	return cmd.Process.Pid, proxyURL, nil
 }
 
-func (p *ccProxy) stop(sandbox Sandbox, pid int) error {
+func (p *ccProxy) stop(sandbox *Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -25,7 +25,7 @@ func TestCCProxyStart(t *testing.T) {
 	proxy := &ccProxy{}
 
 	type testData struct {
-		sandbox     Sandbox
+		sandbox     *Sandbox
 		expectedURI string
 		expectError bool
 	}
@@ -35,16 +35,16 @@ func TestCCProxyStart(t *testing.T) {
 	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
 
 	data := []testData{
-		{Sandbox{}, "", true},
+		{&Sandbox{}, "", true},
 		{
-			Sandbox{
+			&Sandbox{
 				config: &SandboxConfig{
 					ProxyType: "invalid",
 				},
 			}, "", true,
 		},
 		{
-			Sandbox{
+			&Sandbox{
 				config: &SandboxConfig{
 					ProxyType: CCProxyType,
 					// invalid - no path
@@ -53,7 +53,7 @@ func TestCCProxyStart(t *testing.T) {
 			}, "", true,
 		},
 		{
-			Sandbox{
+			&Sandbox{
 				config: &SandboxConfig{
 					ProxyType: CCProxyType,
 					ProxyConfig: ProxyConfig{
@@ -63,7 +63,7 @@ func TestCCProxyStart(t *testing.T) {
 			}, "", true,
 		},
 		{
-			Sandbox{
+			&Sandbox{
 				id: testSandboxID,
 				config: &SandboxConfig{
 					ProxyType: CCProxyType,

--- a/virtcontainers/cc_shim.go
+++ b/virtcontainers/cc_shim.go
@@ -14,7 +14,7 @@ type ccShim struct{}
 // start is the ccShim start implementation.
 // It starts the cc-shim binary with URL and token flags provided by
 // the proxy.
-func (s *ccShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+func (s *ccShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 	if sandbox.config == nil {
 		return -1, fmt.Errorf("Sandbox config cannot be nil")
 	}

--- a/virtcontainers/cc_shim_test.go
+++ b/virtcontainers/cc_shim_test.go
@@ -35,7 +35,7 @@ func getMockCCShimBinPath() string {
 	return DefaultMockCCShimBinPath
 }
 
-func testCCShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectFail bool) {
+func testCCShimStart(t *testing.T, sandbox *Sandbox, params ShimParams, expectFail bool) {
 	s := &ccShim{}
 
 	pid, err := s.start(sandbox, params)
@@ -58,11 +58,11 @@ func testCCShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectFai
 }
 
 func TestCCShimStartNilSandboxConfigFailure(t *testing.T) {
-	testCCShimStart(t, Sandbox{}, ShimParams{}, true)
+	testCCShimStart(t, &Sandbox{}, ShimParams{}, true)
 }
 
 func TestCCShimStartNilShimConfigFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{},
 	}
 
@@ -70,7 +70,7 @@ func TestCCShimStartNilShimConfigFailure(t *testing.T) {
 }
 
 func TestCCShimStartShimPathEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType:   CCShimType,
 			ShimConfig: ShimConfig{},
@@ -81,7 +81,7 @@ func TestCCShimStartShimPathEmptyFailure(t *testing.T) {
 }
 
 func TestCCShimStartShimTypeInvalid(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType:   "foo",
 			ShimConfig: ShimConfig{},
@@ -92,7 +92,7 @@ func TestCCShimStartShimTypeInvalid(t *testing.T) {
 }
 
 func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -105,7 +105,7 @@ func TestCCShimStartParamsTokenEmptyFailure(t *testing.T) {
 }
 
 func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -122,7 +122,7 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 }
 
 func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -148,7 +148,7 @@ func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 
 	cmd := filepath.Join(dir, "does-not-exist")
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -165,16 +165,16 @@ func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 	testCCShimStart(t, sandbox, params, true)
 }
 
-func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Sandbox, ShimParams, error) {
+func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, *Sandbox, ShimParams, error) {
 	saveStdout := os.Stdout
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {
-		return nil, nil, nil, Sandbox{}, ShimParams{}, err
+		return nil, nil, nil, &Sandbox{}, ShimParams{}, err
 	}
 
 	os.Stdout = wStdout
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -260,7 +260,7 @@ func TestCCShimStartDetachSuccessful(t *testing.T) {
 }
 
 func TestCCShimStartWithConsoleNonExistingFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{
@@ -336,7 +336,7 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: CCShimType,
 			ShimConfig: ShimConfig{

--- a/virtcontainers/cni.go
+++ b/virtcontainers/cni.go
@@ -59,7 +59,7 @@ func convertCNIResult(cniResult cniTypes.Result) (NetworkInfo, error) {
 	}
 }
 
-func (n *cni) invokePluginsAdd(sandbox Sandbox, networkNS *NetworkNamespace) (*NetworkInfo, error) {
+func (n *cni) invokePluginsAdd(sandbox *Sandbox, networkNS *NetworkNamespace) (*NetworkInfo, error) {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (n *cni) invokePluginsAdd(sandbox Sandbox, networkNS *NetworkNamespace) (*N
 	return &netInfo, nil
 }
 
-func (n *cni) invokePluginsDelete(sandbox Sandbox, networkNS NetworkNamespace) error {
+func (n *cni) invokePluginsDelete(sandbox *Sandbox, networkNS NetworkNamespace) error {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (n *cni) run(networkNSPath string, cb func() error) error {
 }
 
 // add adds all needed interfaces inside the network namespace for the CNI network.
-func (n *cni) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
+func (n *cni) add(sandbox *Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
 
 	networkNS := NetworkNamespace{
 		NetNsPath:    netNsPath,
@@ -155,7 +155,7 @@ func (n *cni) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNs
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNI network.
-func (n *cni) remove(sandbox Sandbox, networkNS NetworkNamespace) error {
+func (n *cni) remove(sandbox *Sandbox, networkNS NetworkNamespace) error {
 	if err := removeNetworkCommon(networkNS); err != nil {
 		return err
 	}

--- a/virtcontainers/cnm.go
+++ b/virtcontainers/cnm.go
@@ -28,7 +28,7 @@ func (n *cnm) run(networkNSPath string, cb func() error) error {
 }
 
 // add adds all needed interfaces inside the network namespace for the CNM network.
-func (n *cnm) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
+func (n *cnm) add(sandbox *Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
 	endpoints, err := createEndpointsFromScan(netNsPath, config)
 	if err != nil {
 		return NetworkNamespace{}, err
@@ -49,7 +49,7 @@ func (n *cnm) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNs
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the CNM network.
-func (n *cnm) remove(sandbox Sandbox, networkNS NetworkNamespace) error {
+func (n *cnm) remove(sandbox *Sandbox, networkNS NetworkNamespace) error {
 	if err := removeNetworkCommon(networkNS); err != nil {
 		return err
 	}

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -598,7 +598,7 @@ func (c *Container) start() error {
 		return err
 	}
 
-	if err := c.sandbox.agent.startContainer(*(c.sandbox), c); err != nil {
+	if err := c.sandbox.agent.startContainer(c.sandbox, c); err != nil {
 		c.Logger().WithError(err).Error("Failed to start container")
 
 		if err := c.stop(); err != nil {
@@ -652,7 +652,7 @@ func (c *Container) stop() error {
 	// return an error, but instead try to kill it forcefully.
 	if err := waitForShim(c.process.Pid); err != nil {
 		// Force the container to be killed.
-		if err := c.sandbox.agent.killContainer(*(c.sandbox), *c, syscall.SIGKILL, true); err != nil {
+		if err := c.sandbox.agent.killContainer(c.sandbox, *c, syscall.SIGKILL, true); err != nil {
 			return err
 		}
 
@@ -673,9 +673,9 @@ func (c *Container) stop() error {
 	// this signal will ensure the container will get killed to match
 	// the state of the shim. This will allow the following call to
 	// stopContainer() to succeed in such particular case.
-	c.sandbox.agent.killContainer(*(c.sandbox), *c, syscall.SIGKILL, true)
+	c.sandbox.agent.killContainer(c.sandbox, *c, syscall.SIGKILL, true)
 
-	if err := c.sandbox.agent.stopContainer(*(c.sandbox), *c); err != nil {
+	if err := c.sandbox.agent.stopContainer(c.sandbox, *c); err != nil {
 		return err
 	}
 
@@ -722,7 +722,7 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 		return fmt.Errorf("Container not ready or running, impossible to signal the container")
 	}
 
-	return c.sandbox.agent.killContainer(*(c.sandbox), *c, signal, all)
+	return c.sandbox.agent.killContainer(c.sandbox, *c, signal, all)
 }
 
 func (c *Container) processList(options ProcessListOptions) (ProcessList, error) {
@@ -734,7 +734,7 @@ func (c *Container) processList(options ProcessListOptions) (ProcessList, error)
 		return nil, fmt.Errorf("Container not running, impossible to list processes")
 	}
 
-	return c.sandbox.agent.processListContainer(*(c.sandbox), *c, options)
+	return c.sandbox.agent.processListContainer(c.sandbox, *c, options)
 }
 
 func (c *Container) hotplugDrive() error {

--- a/virtcontainers/filesystem.go
+++ b/virtcontainers/filesystem.go
@@ -95,7 +95,7 @@ var runStoragePath = filepath.Join("/run", storagePathSuffix)
 // The default resource storage implementation is filesystem.
 type resourceStorage interface {
 	// Create all resources for a sandbox
-	createAllResources(sandbox Sandbox) error
+	createAllResources(sandbox *Sandbox) error
 
 	// Resources URIs functions return both the URI
 	// for the actual resource and the URI base.
@@ -140,7 +140,7 @@ func (fs *filesystem) Logger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "filesystem")
 }
 
-func (fs *filesystem) createAllResources(sandbox Sandbox) (err error) {
+func (fs *filesystem) createAllResources(sandbox *Sandbox) (err error) {
 	for _, resource := range []sandboxResource{stateFileType, configFileType} {
 		_, path, _ := fs.sandboxURI(sandbox.id, resource)
 		err = os.MkdirAll(path, dirMode)

--- a/virtcontainers/filesystem_test.go
+++ b/virtcontainers/filesystem_test.go
@@ -27,7 +27,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 		Containers: contConfigs,
 	}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		id:      testSandboxID,
 		storage: fs,
 		config:  sandboxConfig,
@@ -96,7 +96,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 func TestFilesystemCreateAllResourcesFailingSandboxIDEmpty(t *testing.T) {
 	fs := &filesystem{}
 
-	sandbox := Sandbox{}
+	sandbox := &Sandbox{}
 
 	err := fs.createAllResources(sandbox)
 	if err == nil {
@@ -111,7 +111,7 @@ func TestFilesystemCreateAllResourcesFailingContainerIDEmpty(t *testing.T) {
 		{id: ""},
 	}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		id:         testSandboxID,
 		containers: containers,
 	}

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -26,7 +26,7 @@ func TestHyperstartGenerateSocketsSuccessful(t *testing.T) {
 		SockTtyName: "ttySock",
 	}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		id: testSandboxID,
 	}
 
@@ -57,7 +57,7 @@ func TestHyperstartGenerateSocketsSuccessful(t *testing.T) {
 func TestHyperstartGenerateSocketsSuccessfulNoPathProvided(t *testing.T) {
 	config := HyperConfig{}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		id: testSandboxID,
 	}
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -105,7 +105,7 @@ func parseVSOCKAddr(sock string) (uint32, uint32, error) {
 	return uint32(cid), uint32(port), nil
 }
 
-func (k *kataAgent) generateVMSocket(sandbox Sandbox, c KataAgentConfig) error {
+func (k *kataAgent) generateVMSocket(sandbox *Sandbox, c KataAgentConfig) error {
 	cid, port, err := parseVSOCKAddr(c.GRPCSocket)
 	if err != nil {
 		// We need to generate a host UNIX socket path for the emulated serial port.
@@ -129,7 +129,7 @@ func (k *kataAgent) generateVMSocket(sandbox Sandbox, c KataAgentConfig) error {
 func (k *kataAgent) init(sandbox *Sandbox, config interface{}) (err error) {
 	switch c := config.(type) {
 	case KataAgentConfig:
-		if err := k.generateVMSocket(*sandbox, c); err != nil {
+		if err := k.generateVMSocket(sandbox, c); err != nil {
 			return err
 		}
 		k.keepConn = c.LongLiveConn
@@ -401,7 +401,7 @@ func (k *kataAgent) generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*
 	return ifaces, routes, nil
 }
 
-func (k *kataAgent) startSandbox(sandbox Sandbox) error {
+func (k *kataAgent) startSandbox(sandbox *Sandbox) error {
 	if k.proxy == nil {
 		return errorMissingProxy
 	}
@@ -505,7 +505,7 @@ func (k *kataAgent) startSandbox(sandbox Sandbox) error {
 	return err
 }
 
-func (k *kataAgent) stopSandbox(sandbox Sandbox) error {
+func (k *kataAgent) stopSandbox(sandbox *Sandbox) error {
 	if k.proxy == nil {
 		return errorMissingProxy
 	}
@@ -840,7 +840,7 @@ func (k *kataAgent) handleBlockVolumes(c *Container) []*grpc.Storage {
 	return volumeStorages
 }
 
-func (k *kataAgent) startContainer(sandbox Sandbox, c *Container) error {
+func (k *kataAgent) startContainer(sandbox *Sandbox, c *Container) error {
 	req := &grpc.StartContainerRequest{
 		ContainerId: c.id,
 	}
@@ -849,7 +849,7 @@ func (k *kataAgent) startContainer(sandbox Sandbox, c *Container) error {
 	return err
 }
 
-func (k *kataAgent) stopContainer(sandbox Sandbox, c Container) error {
+func (k *kataAgent) stopContainer(sandbox *Sandbox, c Container) error {
 	req := &grpc.RemoveContainerRequest{
 		ContainerId: c.id,
 	}
@@ -865,7 +865,7 @@ func (k *kataAgent) stopContainer(sandbox Sandbox, c Container) error {
 	return bindUnmountContainerRootfs(kataHostSharedDir, sandbox.id, c.id)
 }
 
-func (k *kataAgent) killContainer(sandbox Sandbox, c Container, signal syscall.Signal, all bool) error {
+func (k *kataAgent) killContainer(sandbox *Sandbox, c Container, signal syscall.Signal, all bool) error {
 	req := &grpc.SignalProcessRequest{
 		ContainerId: c.id,
 		ExecId:      c.process.Token,
@@ -876,7 +876,7 @@ func (k *kataAgent) killContainer(sandbox Sandbox, c Container, signal syscall.S
 	return err
 }
 
-func (k *kataAgent) processListContainer(sandbox Sandbox, c Container, options ProcessListOptions) (ProcessList, error) {
+func (k *kataAgent) processListContainer(sandbox *Sandbox, c Container, options ProcessListOptions) (ProcessList, error) {
 	req := &grpc.ListProcessesRequest{
 		ContainerId: c.id,
 		Format:      options.Format,

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -24,7 +24,7 @@ type kataBuiltInProxy struct {
 // start is the proxy start implementation for kata builtin proxy.
 // It starts the console watcher for the guest.
 // It returns agentURL to let agent connect directly.
-func (p *kataBuiltInProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+func (p *kataBuiltInProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	if p.conn != nil {
 		return -1, "", fmt.Errorf("kata builtin proxy running for sandbox %s", p.sandboxID)
 	}
@@ -40,7 +40,7 @@ func (p *kataBuiltInProxy) start(sandbox Sandbox, params proxyParams) (int, stri
 }
 
 // stop is the proxy stop implementation for kata builtin proxy.
-func (p *kataBuiltInProxy) stop(sandbox Sandbox, pid int) error {
+func (p *kataBuiltInProxy) stop(sandbox *Sandbox, pid int) error {
 	if p.conn != nil {
 		p.conn.Close()
 		p.conn = nil

--- a/virtcontainers/kata_builtin_shim.go
+++ b/virtcontainers/kata_builtin_shim.go
@@ -10,6 +10,6 @@ type kataBuiltInShim struct{}
 // start is the kataBuiltInShim start implementation for kata builtin shim.
 // It does nothing. The shim functionality is provided by the virtcontainers
 // library.
-func (s *kataBuiltInShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+func (s *kataBuiltInShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 	return -1, nil
 }

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -18,7 +18,7 @@ type kataProxy struct {
 }
 
 // start is kataProxy start implementation for proxy interface.
-func (p *kataProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	if sandbox.agent == nil {
 		return -1, "", fmt.Errorf("No agent")
 	}
@@ -53,7 +53,7 @@ func (p *kataProxy) start(sandbox Sandbox, params proxyParams) (int, string, err
 }
 
 // stop is kataProxy stop implementation for proxy interface.
-func (p *kataProxy) stop(sandbox Sandbox, pid int) error {
+func (p *kataProxy) stop(sandbox *Sandbox, pid int) error {
 	// Signal the proxy with SIGTERM.
 	return syscall.Kill(pid, syscall.SIGTERM)
 }

--- a/virtcontainers/kata_shim.go
+++ b/virtcontainers/kata_shim.go
@@ -21,7 +21,7 @@ type KataShimConfig struct {
 // start is the ccShim start implementation.
 // It starts the cc-shim binary with URL and token flags provided by
 // the proxy.
-func (s *kataShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+func (s *kataShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 	if sandbox.config == nil {
 		return -1, fmt.Errorf("Sandbox config cannot be nil")
 	}

--- a/virtcontainers/kata_shim_test.go
+++ b/virtcontainers/kata_shim_test.go
@@ -29,7 +29,7 @@ func getMockKataShimBinPath() string {
 	return DefaultMockKataShimBinPath
 }
 
-func testKataShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectFail bool) {
+func testKataShimStart(t *testing.T, sandbox *Sandbox, params ShimParams, expectFail bool) {
 	s := &kataShim{}
 
 	pid, err := s.start(sandbox, params)
@@ -52,11 +52,11 @@ func testKataShimStart(t *testing.T, sandbox Sandbox, params ShimParams, expectF
 }
 
 func TestKataShimStartNilSandboxConfigFailure(t *testing.T) {
-	testKataShimStart(t, Sandbox{}, ShimParams{}, true)
+	testKataShimStart(t, &Sandbox{}, ShimParams{}, true)
 }
 
 func TestKataShimStartNilShimConfigFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{},
 	}
 
@@ -64,7 +64,7 @@ func TestKataShimStartNilShimConfigFailure(t *testing.T) {
 }
 
 func TestKataShimStartShimPathEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType:   KataShimType,
 			ShimConfig: ShimConfig{},
@@ -75,7 +75,7 @@ func TestKataShimStartShimPathEmptyFailure(t *testing.T) {
 }
 
 func TestKataShimStartShimTypeInvalid(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType:   "foo",
 			ShimConfig: ShimConfig{},
@@ -86,7 +86,7 @@ func TestKataShimStartShimTypeInvalid(t *testing.T) {
 }
 
 func TestKataShimStartParamsTokenEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -99,7 +99,7 @@ func TestKataShimStartParamsTokenEmptyFailure(t *testing.T) {
 }
 
 func TestKataShimStartParamsURLEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -116,7 +116,7 @@ func TestKataShimStartParamsURLEmptyFailure(t *testing.T) {
 }
 
 func TestKataShimStartParamsContainerEmptyFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -142,7 +142,7 @@ func TestKataShimStartParamsInvalidCommand(t *testing.T) {
 
 	cmd := filepath.Join(dir, "does-not-exist")
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -159,16 +159,16 @@ func TestKataShimStartParamsInvalidCommand(t *testing.T) {
 	testKataShimStart(t, sandbox, params, true)
 }
 
-func startKataShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, Sandbox, ShimParams, error) {
+func startKataShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.File, *os.File, *os.File, *Sandbox, ShimParams, error) {
 	saveStdout := os.Stdout
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {
-		return nil, nil, nil, Sandbox{}, ShimParams{}, err
+		return nil, nil, nil, &Sandbox{}, ShimParams{}, err
 	}
 
 	os.Stdout = wStdout
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -254,7 +254,7 @@ func TestKataShimStartDetachSuccessful(t *testing.T) {
 }
 
 func TestKataShimStartWithConsoleNonExistingFailure(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{
@@ -282,7 +282,7 @@ func TestKataShimStartWithConsoleSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		config: &SandboxConfig{
 			ShimType: KataShimType,
 			ShimConfig: ShimConfig{

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -324,7 +324,7 @@ func bindUnmountContainerRootfs(sharedDir, sandboxID, cID string) error {
 	return nil
 }
 
-func bindUnmountAllRootfs(sharedDir string, sandbox Sandbox) {
+func bindUnmountAllRootfs(sharedDir string, sandbox *Sandbox) {
 	for _, c := range sandbox.containers {
 		c.unmountHostMounts()
 		if c.state.Fstype == "" {

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -589,7 +589,7 @@ func runNetworkCommon(networkNSPath string, cb func() error) error {
 	})
 }
 
-func addNetworkCommon(sandbox Sandbox, networkNS *NetworkNamespace) error {
+func addNetworkCommon(sandbox *Sandbox, networkNS *NetworkNamespace) error {
 	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
 		for _, endpoint := range networkNS.Endpoints {
 			if err := endpoint.Attach(sandbox.hypervisor); err != nil {
@@ -1365,9 +1365,9 @@ type network interface {
 	run(networkNSPath string, cb func() error) error
 
 	// add adds all needed interfaces inside the network namespace.
-	add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error)
+	add(sandbox *Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error)
 
 	// remove unbridges and deletes TAP interfaces. It also removes virtual network
 	// interfaces and deletes the network namespace.
-	remove(sandbox Sandbox, networkNS NetworkNamespace) error
+	remove(sandbox *Sandbox, networkNS NetworkNamespace) error
 }

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -23,7 +23,7 @@ type noProxy struct {
 }
 
 // start is noProxy start implementation for proxy interface.
-func (p *noProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+func (p *noProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	if params.agentURL == "" {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
@@ -32,6 +32,6 @@ func (p *noProxy) start(sandbox Sandbox, params proxyParams) (int, string, error
 }
 
 // stop is noProxy stop implementation for proxy interface.
-func (p *noProxy) stop(sandbox Sandbox, pid int) error {
+func (p *noProxy) stop(sandbox *Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/no_proxy_test.go
+++ b/virtcontainers/no_proxy_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNoProxyStart(t *testing.T) {
-	sandbox := Sandbox{
+	sandbox := &Sandbox{
 		agent: newAgent(NoopAgentType),
 	}
 
@@ -34,7 +34,7 @@ func TestNoProxyStart(t *testing.T) {
 func TestNoProxyStop(t *testing.T) {
 	p := &noProxy{}
 
-	if err := p.stop(Sandbox{}, 0); err != nil {
+	if err := p.stop(&Sandbox{}, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -40,12 +40,12 @@ func (n *noopAgent) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, erro
 }
 
 // startSandbox is the Noop agent Sandbox starting implementation. It does nothing.
-func (n *noopAgent) startSandbox(sandbox Sandbox) error {
+func (n *noopAgent) startSandbox(sandbox *Sandbox) error {
 	return nil
 }
 
 // stopSandbox is the Noop agent Sandbox stopping implementation. It does nothing.
-func (n *noopAgent) stopSandbox(sandbox Sandbox) error {
+func (n *noopAgent) stopSandbox(sandbox *Sandbox) error {
 	return nil
 }
 
@@ -55,22 +55,22 @@ func (n *noopAgent) createContainer(sandbox *Sandbox, c *Container) (*Process, e
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(sandbox Sandbox, c *Container) error {
+func (n *noopAgent) startContainer(sandbox *Sandbox, c *Container) error {
 	return nil
 }
 
 // stopContainer is the Noop agent Container stopping implementation. It does nothing.
-func (n *noopAgent) stopContainer(sandbox Sandbox, c Container) error {
+func (n *noopAgent) stopContainer(sandbox *Sandbox, c Container) error {
 	return nil
 }
 
 // killContainer is the Noop agent Container signaling implementation. It does nothing.
-func (n *noopAgent) killContainer(sandbox Sandbox, c Container, signal syscall.Signal, all bool) error {
+func (n *noopAgent) killContainer(sandbox *Sandbox, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
 
 // processListContainer is the Noop agent Container ps implementation. It does nothing.
-func (n *noopAgent) processListContainer(sandbox Sandbox, c Container, options ProcessListOptions) (ProcessList, error) {
+func (n *noopAgent) processListContainer(sandbox *Sandbox, c Container, options ProcessListOptions) (ProcessList, error) {
 	return nil, nil
 }
 

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -55,7 +55,7 @@ func TestNoopAgentExec(t *testing.T) {
 
 func TestNoopAgentStartSandbox(t *testing.T) {
 	n := &noopAgent{}
-	sandbox := Sandbox{}
+	sandbox := &Sandbox{}
 
 	err := n.startSandbox(sandbox)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestNoopAgentStartSandbox(t *testing.T) {
 
 func TestNoopAgentStopSandbox(t *testing.T) {
 	n := &noopAgent{}
-	sandbox := Sandbox{}
+	sandbox := &Sandbox{}
 
 	err := n.stopSandbox(sandbox)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestNoopAgentCreateContainer(t *testing.T) {
 	}
 	defer cleanUp()
 
-	if err := n.startSandbox(*sandbox); err != nil {
+	if err := n.startSandbox(sandbox); err != nil {
 		t.Fatal(err)
 	}
 
@@ -98,7 +98,7 @@ func TestNoopAgentStartContainer(t *testing.T) {
 	}
 	defer cleanUp()
 
-	err = n.startContainer(*sandbox, container)
+	err = n.startContainer(sandbox, container)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestNoopAgentStopContainer(t *testing.T) {
 	}
 	defer cleanUp()
 
-	err = n.stopContainer(*sandbox, *container)
+	err = n.stopContainer(sandbox, *container)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/virtcontainers/noop_network.go
+++ b/virtcontainers/noop_network.go
@@ -25,13 +25,13 @@ func (n *noopNetwork) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace the Noop network.
 // It does nothing.
-func (n *noopNetwork) add(sandbox Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
+func (n *noopNetwork) add(sandbox *Sandbox, config NetworkConfig, netNsPath string, netNsCreated bool) (NetworkNamespace, error) {
 	return NetworkNamespace{}, nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the Noop network.
 // It does nothing.
-func (n *noopNetwork) remove(sandbox Sandbox, networkNS NetworkNamespace) error {
+func (n *noopNetwork) remove(sandbox *Sandbox, networkNS NetworkNamespace) error {
 	return nil
 }

--- a/virtcontainers/noop_proxy.go
+++ b/virtcontainers/noop_proxy.go
@@ -13,12 +13,12 @@ var noopProxyURL = "noopProxyURL"
 
 // register is the proxy start implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) start(sandbox Sandbox, params proxyParams) (int, string, error) {
+func (p *noopProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	return 0, noopProxyURL, nil
 }
 
 // stop is the proxy stop implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) stop(sandbox Sandbox, pid int) error {
+func (p *noopProxy) stop(sandbox *Sandbox, pid int) error {
 	return nil
 }

--- a/virtcontainers/noop_shim.go
+++ b/virtcontainers/noop_shim.go
@@ -9,6 +9,6 @@ type noopShim struct{}
 
 // start is the noopShim start implementation for testing purpose.
 // It does nothing.
-func (s *noopShim) start(sandbox Sandbox, params ShimParams) (int, error) {
+func (s *noopShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 	return 0, nil
 }

--- a/virtcontainers/noop_shim_test.go
+++ b/virtcontainers/noop_shim_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNoopShimStart(t *testing.T) {
 	s := &noopShim{}
-	sandbox := Sandbox{}
+	sandbox := &Sandbox{}
 	params := ShimParams{}
 	expected := 0
 

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -144,7 +144,7 @@ func newProxyConfig(sandboxConfig *SandboxConfig) (ProxyConfig, error) {
 	return config, nil
 }
 
-func defaultProxyURL(sandbox Sandbox, socketType string) (string, error) {
+func defaultProxyURL(sandbox *Sandbox, socketType string) (string, error) {
 	switch socketType {
 	case SocketTypeUNIX:
 		socketPath := filepath.Join(runStoragePath, sandbox.id, "proxy.sock")
@@ -165,9 +165,9 @@ func isProxyBuiltIn(pType ProxyType) bool {
 type proxy interface {
 	// start launches a proxy instance for the specified sandbox, returning
 	// the PID of the process and the URL used to connect to it.
-	start(sandbox Sandbox, params proxyParams) (int, string, error)
+	start(sandbox *Sandbox, params proxyParams) (int, string, error)
 
 	// stop terminates a proxy instance after all communications with the
 	// agent inside the VM have been properly stopped.
-	stop(sandbox Sandbox, pid int) error
+	stop(sandbox *Sandbox, pid int) error
 }

--- a/virtcontainers/proxy_test.go
+++ b/virtcontainers/proxy_test.go
@@ -213,7 +213,7 @@ func testDefaultProxyURL(expectedURL string, socketType string, sandboxID string
 		id: sandboxID,
 	}
 
-	url, err := defaultProxyURL(*sandbox, socketType)
+	url, err := defaultProxyURL(sandbox, socketType)
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -674,7 +674,7 @@ func newSandbox(sandboxConfig SandboxConfig) (*Sandbox, error) {
 		}
 	}()
 
-	if err = s.storage.createAllResources(*s); err != nil {
+	if err = s.storage.createAllResources(s); err != nil {
 		return nil, err
 	}
 
@@ -826,7 +826,7 @@ func (s *Sandbox) createNetwork() error {
 	}
 
 	// Add the network
-	networkNS, err := s.network.add(*s, s.config.NetworkConfig, netNsPath, netNsCreated)
+	networkNS, err := s.network.add(s, s.config.NetworkConfig, netNsPath, netNsCreated)
 	if err != nil {
 		return err
 	}
@@ -838,7 +838,7 @@ func (s *Sandbox) createNetwork() error {
 
 func (s *Sandbox) removeNetwork() error {
 	if s.networkNS.NetNsCreated {
-		return s.network.remove(*s, s.networkNS)
+		return s.network.remove(s, s.networkNS)
 	}
 
 	return nil
@@ -863,7 +863,7 @@ func (s *Sandbox) startVM() error {
 	// Once startVM is done, we want to guarantee
 	// that the sandbox is manageable. For that we need
 	// to start the sandbox inside the VM.
-	return s.agent.startSandbox(*s)
+	return s.agent.startSandbox(s)
 }
 
 func (s *Sandbox) addContainer(c *Container) error {
@@ -1065,7 +1065,7 @@ func (s *Sandbox) stop() error {
 		}
 	}
 
-	if err := s.agent.stopSandbox(*s); err != nil {
+	if err := s.agent.stopSandbox(s); err != nil {
 		return err
 	}
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -51,7 +51,7 @@ func testCreateSandbox(t *testing.T, id string,
 		return nil, fmt.Errorf("Could not create sandbox: %s", err)
 	}
 
-	if err := sandbox.agent.startSandbox(*sandbox); err != nil {
+	if err := sandbox.agent.startSandbox(sandbox); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -172,7 +172,7 @@ func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cm
 		EnterNS:   enterNSList,
 	}
 
-	pid, err := shim.start(*sandbox, shimParams)
+	pid, err := shim.start(sandbox, shimParams)
 	if err != nil {
 		return nil, err
 	}
@@ -282,5 +282,5 @@ func waitForShim(pid int) error {
 type shim interface {
 	// start starts the shim relying on its configuration and on
 	// parameters provided.
-	start(sandbox Sandbox, params ShimParams) (int, error)
+	start(sandbox *Sandbox, params ShimParams) (int, error)
 }


### PR DESCRIPTION
Currently we sometimes pass it as a pointer and other times not. As
a result, the view of sandbox across virtcontainers may not be the same
and it costs extra memory copy each time we pass it by value. Fix it
by ensuring sandbox is always passed by pointers.

Fixes: #262

Signed-off-by: Peng Tao <bergwolf@gmail.com>