### PR TITLE
socket: Enforce socket length

### DIFF
--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -739,12 +739,17 @@ func (h *hyper) register() error {
 	}
 	defer h.disconnect()
 
+	console, err := h.sandbox.hypervisor.getSandboxConsole(h.sandbox.id)
+	if err != nil {
+		return err
+	}
+
 	registerVMOptions := &proxyClient.RegisterVMOptions{
-		Console:      h.sandbox.hypervisor.getSandboxConsole(h.sandbox.id),
+		Console:      console,
 		NumIOStreams: 0,
 	}
 
-	_, err := h.client.RegisterVM(h.sandbox.id, h.sockets[0].HostPath,
+	_, err = h.client.RegisterVM(h.sandbox.id, h.sockets[0].HostPath,
 		h.sockets[1].HostPath, registerVMOptions)
 	return err
 }

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -501,6 +501,6 @@ type hypervisor interface {
 	addDevice(devInfo interface{}, devType deviceType) error
 	hotplugAddDevice(devInfo interface{}, devType deviceType) error
 	hotplugRemoveDevice(devInfo interface{}, devType deviceType) error
-	getSandboxConsole(sandboxID string) string
+	getSandboxConsole(sandboxID string) (string, error)
 	capabilities() capabilities
 }

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -33,21 +33,21 @@ import (
 )
 
 var (
-	defaultKataSockPathTemplate = "%s/%s/kata.sock"
-	defaultKataChannel          = "agent.channel.0"
-	defaultKataDeviceID         = "channel0"
-	defaultKataID               = "charch0"
-	errorMissingProxy           = errors.New("Missing proxy pointer")
-	errorMissingOCISpec         = errors.New("Missing OCI specification")
-	kataHostSharedDir           = "/run/kata-containers/shared/sandboxes/"
-	kataGuestSharedDir          = "/run/kata-containers/shared/containers/"
-	mountGuest9pTag             = "kataShared"
-	type9pFs                    = "9p"
-	vsockSocketScheme           = "vsock"
-	kata9pDevType               = "9p"
-	kataBlkDevType              = "blk"
-	kataSCSIDevType             = "scsi"
-	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L", "nodev"}
+	defaultKataSocketName = "kata.sock"
+	defaultKataChannel    = "agent.channel.0"
+	defaultKataDeviceID   = "channel0"
+	defaultKataID         = "charch0"
+	errorMissingProxy     = errors.New("Missing proxy pointer")
+	errorMissingOCISpec   = errors.New("Missing OCI specification")
+	kataHostSharedDir     = "/run/kata-containers/shared/sandboxes/"
+	kataGuestSharedDir    = "/run/kata-containers/shared/containers/"
+	mountGuest9pTag       = "kataShared"
+	type9pFs              = "9p"
+	vsockSocketScheme     = "vsock"
+	kata9pDevType         = "9p"
+	kataBlkDevType        = "blk"
+	kataSCSIDevType       = "scsi"
+	sharedDir9pOptions    = []string{"trans=virtio,version=9p2000.L", "nodev"}
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -114,10 +114,15 @@ func (k *kataAgent) generateVMSocket(sandbox *Sandbox, c KataAgentConfig) error 
 	cid, port, err := parseVSOCKAddr(c.GRPCSocket)
 	if err != nil {
 		// We need to generate a host UNIX socket path for the emulated serial port.
+		kataSock, err := utils.BuildSocketPath(runStoragePath, sandbox.id, defaultKataSocketName)
+		if err != nil {
+			return err
+		}
+
 		k.vmSocket = Socket{
 			DeviceID: defaultKataDeviceID,
 			ID:       defaultKataID,
-			HostPath: fmt.Sprintf(defaultKataSockPathTemplate, runStoragePath, sandbox.id),
+			HostPath: kataSock,
 			Name:     defaultKataChannel,
 		}
 	} else {

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -30,8 +30,12 @@ func (p *kataBuiltInProxy) start(sandbox *Sandbox, params proxyParams) (int, str
 	}
 
 	p.sandboxID = sandbox.id
-	console := sandbox.hypervisor.getSandboxConsole(sandbox.id)
-	err := p.watchConsole(consoleProtoUnix, console, params.logger)
+	console, err := sandbox.hypervisor.getSandboxConsole(sandbox.id)
+	if err != nil {
+		return -1, "", err
+	}
+
+	err = p.watchConsole(consoleProtoUnix, console, params.logger)
 	if err != nil {
 		return -1, "", err
 	}

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -41,7 +41,12 @@ func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, er
 	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", params.agentURL}
 	if config.Debug {
 		args = append(args, "-log", "debug")
-		args = append(args, "-agent-logs-socket", sandbox.hypervisor.getSandboxConsole(sandbox.id))
+		console, err := sandbox.hypervisor.getSandboxConsole(sandbox.id)
+		if err != nil {
+			return -1, "", err
+		}
+
+		args = append(args, "-agent-logs-socket", console)
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -57,6 +57,6 @@ func (m *mockHypervisor) hotplugRemoveDevice(devInfo interface{}, devType device
 	return nil
 }
 
-func (m *mockHypervisor) getSandboxConsole(sandboxID string) string {
-	return ""
+func (m *mockHypervisor) getSandboxConsole(sandboxID string) (string, error) {
+	return "", nil
 }

--- a/virtcontainers/mock_hypervisor_test.go
+++ b/virtcontainers/mock_hypervisor_test.go
@@ -87,7 +87,12 @@ func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 
 	expected := ""
 
-	if result := m.getSandboxConsole("testSandboxID"); result != expected {
+	result, err := m.getSandboxConsole("testSandboxID")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != expected {
 		t.Fatalf("Got %s\nExpecting %s", result, expected)
 	}
 }

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -254,7 +254,12 @@ func TestQemuGetSandboxConsole(t *testing.T) {
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(runStoragePath, sandboxID, defaultConsole)
 
-	if result := q.getSandboxConsole(sandboxID); result != expected {
+	result, err := q.getSandboxConsole(sandboxID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != expected {
 		t.Fatalf("Got %s\nExpecting %s", result, expected)
 	}
 }

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 	}
 	SetLogger(logger)
 
-	testDir, err = ioutil.TempDir("", "virtcontainers-tmp-")
+	testDir, err = ioutil.TempDir("", "vc-tmp-")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A Unix domain socket is limited to 107 usable bytes on Linux. However,
not all code creating socket paths was checking for this limits.

Created a new `buildSocketPath()` function (with tests) to encapsulate
the logic and updated all code creating sockets to use it.

Fixes #268.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>