### PR TITLE
Makefile: add missing dependencies to install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,11 +377,11 @@ check-go-static:
 coverage:
 	$(QUIET_TEST).ci/go-test.sh html-coverage
 
-install: default install-scripts
+install: default runtime install-scripts
 	$(QUIET_INST)install -D $(TARGET) $(DESTTARGET)
 	$(QUIET_INST)install -D $(CONFIG) $(DESTCONFIG)
 
-install-scripts:
+install-scripts: $(SCRIPTS)
 	$(foreach f,$(SCRIPTS),$(call INSTALL_EXEC,$f,$(SCRIPTS_DIR)))
 
 clean:


### PR DESCRIPTION
"make install" fails on a clean working directory:

  $ make install
  install: cannot stat ‘data/kata-collect-data.sh’: No such file or directory

This happens because install and install-scripts do not depend on the
runtime.  Make doesn't know it needs to build the runtime before it can
be installed.

Add the missing dependencies to the install targets so that "make
install" works on a clean working directory and rebuilds when source
files have been modified.

Note that SCRIPTS contains the generated kata-collect-data.sh script.
That file needs to be generated before it can be installed, so make
SCRIPTS a dependency of install-scripts.

Fixes: #283
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>