### PR TITLE
oci: Allow environment values to be empty

### DIFF
--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -640,10 +640,6 @@ func EnvVars(envs []string) ([]vc.EnvVar, error) {
 
 		envSlice[1] = strings.Trim(envSlice[1], "' ")
 
-		if envSlice[1] == "" {
-			return []vc.EnvVar{}, fmt.Errorf("Environment value cannot be empty")
-		}
-
 		envVar := vc.EnvVar{
 			Var:   envSlice[0],
 			Value: envSlice[1],

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -479,12 +479,6 @@ func TestMalformedEnvVars(t *testing.T) {
 		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
 	}
 
-	envVars = []string{"TERM="}
-	r, err = EnvVars(envVars)
-	if err == nil {
-		t.Fatalf("EnvVars() succeeded unexpectedly: [%s] variable=%s value=%s", envVars[0], r[0].Var, r[0].Value)
-	}
-
 	envVars = []string{"=foo"}
 	r, err = EnvVars(envVars)
 	if err == nil {


### PR DESCRIPTION
An empty string for an environment variable simply means that the
variable is unset. Do not error out if the env value is empty.

Fixes #288

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>