### PR TITLE
virtcontainers: Reduce path lengths

### DIFF
--- a/virtcontainers/filesystem.go
+++ b/virtcontainers/filesystem.go
@@ -84,7 +84,10 @@ const devicesFile = "devices.json"
 const dirMode = os.FileMode(0750) | os.ModeDir
 
 // storagePathSuffix is the suffix used for all storage paths
-const storagePathSuffix = "/virtcontainers/sandboxes"
+//
+// Note: this very brief path represents "virtcontainers sandboxes". It is as
+// terse as possible to minimise path length.
+const storagePathSuffix = "/vc/sbs"
 
 // configStoragePath is the sandbox configuration directory.
 // It will contain one config.json file for each created sandbox.


### PR DESCRIPTION
Reduce the virtcontainers prefix path to avoid hitting the 107 byte
Unix domain socket path limit.

Related #268.

Fixes #290.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>