### PR TITLE
versions: Add gometalinter to versions database

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -113,6 +113,11 @@ externals:
     meta:
       swarm-version: "1.12.1"
 
+  gometalinter:
+    description: "utility to run various golang linters"
+    url: "https://github.com/alecthomas/gometalinter"
+    version: "v2.0.5"
+
   kubernetes:
     description: "Kubernetes project container manager"
     url: "https://github.com/kubernetes/kubernetes"


### PR DESCRIPTION
Our tests CI is dependent on `gometalinter` which are run by the static
checks script. However, `gometalinter` changes a lot
and when it does, it breaks (what were) valid PRs.

Add `gometalinter` to the versions database so we can pin the version
we use to a known good one.

Fixes #304.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>