### PR TITLE
virtcontainers: Add support for ephemeral volumes

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -103,7 +104,6 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 	disableOutput := noNeedForOutput(detach, ociSpec.Process.Terminal)
 
 	var process vc.Process
-
 	switch containerType {
 	case vc.PodSandbox:
 		process, err = createSandbox(ociSpec, runtimeConfig, containerID, bundlePath, console, disableOutput)
@@ -259,6 +259,19 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 		return vc.Process{}, err
 	}
 
+	// Add the ephemeral device if ephemeral volume
+	// has to be attached to the container. For the given pod
+	// ephemeral volume is created only once backed by tmpfs
+	// inside the VM. For successive containers of the same
+	// pod the already existing volume is reused.
+	for _, mnt := range contConfig.Mounts {
+		if IsEphemeralStorage(mnt.Source) {
+			deviceInfo := config.DeviceInfo{}
+			deviceInfo.DevType = "e"
+			deviceInfo.ContainerPath = mnt.Source
+			contConfig.DeviceInfos = append(contConfig.DeviceInfos, deviceInfo)
+		}
+	}
 	_, c, err := vci.CreateContainer(sandboxID, contConfig)
 	if err != nil {
 		return vc.Process{}, err

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -15,7 +15,10 @@ import (
 	"strings"
 )
 
-const unknown = "<<unknown>>"
+const (
+	unknown     = "<<unknown>>"
+	k8sEmptyDir = "kubernetes.io~empty-dir"
+)
 
 // variables to allow tests to modify the values
 var (
@@ -41,6 +44,26 @@ func getFileContents(file string) (string, error) {
 	}
 
 	return string(bytes), nil
+}
+
+// IsEphemeralStorage returns true if the given path
+// to the storage belongs to kubernetes ephemeral storage
+//
+// This method depends on a specific path used by k8s
+// to detect if it's of type ephemeral. As of now,
+// this is a very k8s specific solution that works
+// but in future there should be a better way for this
+// method to determine if the path is for ephemeral
+// volume type
+func IsEphemeralStorage(path string) bool {
+	splitSourceSlice := strings.Split(path, "/")
+	if len(splitSourceSlice) > 1 {
+		storageType := splitSourceSlice[len(splitSourceSlice)-2]
+		if storageType == k8sEmptyDir {
+			return true
+		}
+	}
+	return false
 }
 
 func getKernelVersion() (string, error) {

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -38,6 +38,20 @@ func TestFileExists(t *testing.T) {
 		fmt.Sprintf("File %q should exist", file))
 }
 
+func TestIsEphemeralStorage(t *testing.T) {
+	sampleEphePath := "/var/lib/kubelet/pods/366c3a75-4869-11e8-b479-507b9ddd5ce4/volumes/kubernetes.io~empty-dir/cache-volume"
+	isEphe := IsEphemeralStorage(sampleEphePath)
+	if !isEphe {
+		t.Fatalf("Unable to correctly determine volume type")
+	}
+
+	sampleEphePath = "/var/lib/kubelet/pods/366c3a75-4869-11e8-b479-507b9ddd5ce4/volumes/cache-volume"
+	isEphe = IsEphemeralStorage(sampleEphePath)
+	if isEphe {
+		t.Fatalf("Unable to correctly determine volume type")
+	}
+}
+
 func TestGetFileContents(t *testing.T) {
 	type testData struct {
 		contents string

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -60,6 +60,8 @@ type DeviceInfo struct {
 	// p - FIFO
 	// b - block(buffered) special file
 	// More info in mknod(1).
+	// also,
+	// e - ephemeral volume
 	DevType string
 
 	// Major, minor numbers for device.

--- a/virtcontainers/filesystem.go
+++ b/virtcontainers/filesystem.go
@@ -319,7 +319,6 @@ func (fs *filesystem) fetchDeviceFile(fileData []byte, devices *[]api.Device) er
 			}
 			tempDevices = append(tempDevices, &device)
 			l.Infof("Generic device unmarshalled [%v]", device)
-
 		default:
 			return fmt.Errorf("Unknown device type, could not unmarshal")
 		}

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -19,6 +19,7 @@ import (
 	kataclient "github.com/kata-containers/agent/protocols/client"
 	"github.com/kata-containers/agent/protocols/grpc"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
@@ -51,6 +52,7 @@ var (
 	sharedDir9pOptions    = []string{"trans=virtio,version=9p2000.L", "nodev"}
 	shmDir                = "shm"
 	kataEphemeralDevType  = "ephemeral"
+	ephemeralPath         = filepath.Join(kataGuestSandboxDir, kataEphemeralDevType)
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -775,11 +777,37 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 		return nil, err
 	}
 
+	var devInfos []config.DeviceInfo
+	for _, devInfo := range c.config.DeviceInfos {
+		if devInfo.DevType == "e" {
+			filename := filepath.Join(ephemeralPath, filepath.Base(devInfo.ContainerPath))
+			epheStorage := &grpc.Storage{
+				Driver:     kataEphemeralDevType,
+				Source:     "tmpfs",
+				Fstype:     "tmpfs",
+				MountPoint: filename,
+			}
+			ctrStorages = append(ctrStorages, epheStorage)
+
+		} else {
+			devInfos = append(devInfos, devInfo)
+		}
+	}
+
 	// Handle container mounts
 	newMounts, err := c.mountSharedDirMounts(kataHostSharedDir, kataGuestSharedDir)
 	if err != nil {
 		return nil, err
 	}
+
+	// Modify the mount source for ephemeral volume
+	for idx, mnt := range ociSpec.Mounts {
+		if utils.IsEphemeralDevice(c.config.DeviceInfos, mnt.Source) {
+			ociSpec.Mounts[idx].Source = filepath.Join(ephemeralPath, filepath.Base(mnt.Source))
+		}
+	}
+
+	c.config.DeviceInfos = devInfos
 
 	// We replace all OCI mount sources that match our container mount
 	// with the right source path (The guest one).

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 )
 
 const cpBinaryName = "cp"
@@ -65,6 +67,18 @@ func ReverseString(s string) string {
 	}
 
 	return string(r)
+}
+
+// IsEphemeralDevice returns true if there exists an ephemeral
+// device in the configuration who's ContainerPath matches with
+// the mount source
+func IsEphemeralDevice(deviceInfos []config.DeviceInfo, source string) bool {
+	for _, devInfo := range deviceInfos {
+		if devInfo.DevType == "e" && devInfo.ContainerPath == source {
+			return true
+		}
+	}
+	return false
 }
 
 // CleanupFds closed bundles of open fds in batch


### PR DESCRIPTION
Ephemeral volumes should not be passed at 9pfs mounts.
They should be created inside the VM.

This patch disables ephemeral volumes from getting
mounted as 9pfs from the host and instead a corresponding
tmpfs is created inside the VM.

Fixes : #61

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>