### PR TITLE
kata-env: Remove static agent version

### DIFF
--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -21,7 +21,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.11"
+const formatVersion = "1.0.12"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -98,8 +98,7 @@ type ShimInfo struct {
 
 // AgentInfo stores agent details
 type AgentInfo struct {
-	Type    string
-	Version string
+	Type string
 }
 
 // DistroInfo stores host operating system distribution details.
@@ -252,8 +251,7 @@ func getShimInfo(config oci.RuntimeConfig) (ShimInfo, error) {
 
 func getAgentInfo(config oci.RuntimeConfig) AgentInfo {
 	agent := AgentInfo{
-		Type:    string(config.AgentType),
-		Version: unknown,
+		Type: string(config.AgentType),
 	}
 
 	return agent

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -148,8 +148,7 @@ func getExpectedShimDetails(config oci.RuntimeConfig) (ShimInfo, error) {
 
 func getExpectedAgentDetails(config oci.RuntimeConfig) (AgentInfo, error) {
 	return AgentInfo{
-		Type:    string(config.AgentType),
-		Version: unknown,
+		Type: string(config.AgentType),
 	}, nil
 }
 
@@ -697,8 +696,7 @@ func testEnvShowSettings(t *testing.T, tmpdir string, tmpfile *os.File) error {
 	}
 
 	agent := AgentInfo{
-		Type:    "agent-type",
-		Version: "agent-version",
+		Type: "agent-type",
 	}
 
 	expectedHostDetails, err := getExpectedHostDetails(tmpdir)


### PR DESCRIPTION
Remove the agent version from the output of `kata-env`. The value was
always a static string (`<<unknown>>`) because the runtime cannot
determine the agent version without creating a container.

Note that agent details, including the version, *are* displayed when
the user runs `kata-collect-data.sh`.

Fixes #310.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>