### PR TITLE
docs: update README to include links to user guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,20 @@ $ kata-runtime kata-check
 > $ sudo kata-runtime kata-check
 > ```
 
+## Quick start for users
+
+See the [installation guides](https://github.com/kata-containers/documentation/tree/master/install/README.md)
+available for various operating systems.
+
 ## Quick start for developers
 
 See the
 [developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md).
+
+## Architecture overview
+
+See the [architecture overview](https://github.com/kata-containers/documentation/blob/master/architecture.md)
+for details on the Kata Containers design.
 
 ## Configuration
 


### PR DESCRIPTION
Added links to the installation guides, as well as a
pointer to the kata containers architecutre document.

Fixes: #315

Signed-off-by: Eric Ernst <eric.ernst@intel.com>