### PR TITLE
config: Error if image+initrd specified

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -309,6 +309,11 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		return vc.HypervisorConfig{}, err
 	}
 
+	if image != "" && initrd != "" {
+		return vc.HypervisorConfig{},
+			errors.New("cannot specify an image and an initrd in configuration file")
+	}
+
 	firmware, err := h.firmware()
 	if err != nil {
 		return vc.HypervisorConfig{}, err

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -625,6 +625,43 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 
 }
 
+func TestNewQemuHypervisorConfigImageAndInitrd(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir(testDir, "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	imagePath := filepath.Join(tmpdir, "image")
+	initrdPath := filepath.Join(tmpdir, "initrd")
+	hypervisorPath := path.Join(tmpdir, "hypervisor")
+	kernelPath := path.Join(tmpdir, "kernel")
+
+	for _, file := range []string{imagePath, initrdPath, hypervisorPath, kernelPath} {
+		err = createEmptyFile(file)
+		assert.NoError(err)
+	}
+
+	machineType := "machineType"
+	disableBlock := true
+	enableIOThreads := true
+
+	hypervisor := hypervisor{
+		Path:                  hypervisorPath,
+		Kernel:                kernelPath,
+		Image:                 imagePath,
+		Initrd:                initrdPath,
+		MachineType:           machineType,
+		DisableBlockDeviceUse: disableBlock,
+		EnableIOThreads:       enableIOThreads,
+	}
+
+	_, err = newQemuHypervisorConfig(hypervisor)
+
+	// specifying both an image+initrd is invalid
+	assert.Error(err)
+}
+
 func TestNewShimConfig(t *testing.T) {
 	dir, err := ioutil.TempDir(testDir, "shim-config-")
 	if err != nil {


### PR DESCRIPTION
If you build and install the runtime, the config file will contain an
entry for both an `initrd=` and an `image=` entry.

The Developer Guide explains that the user must disable one but it is
easy to forget.

Modified the runtime to fail if both an image and an initrd are
specified. Also added a new test for this scenario.

Fixes #318.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>