### PR TITLE
virtcontainers: fix codes misunderstanding in virtcontainers

### DIFF
--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -14,30 +14,30 @@ import (
 )
 
 // ID implements the VCSandbox function of the same name.
-func (p *Sandbox) ID() string {
-	return p.MockID
+func (s *Sandbox) ID() string {
+	return s.MockID
 }
 
 // Annotations implements the VCSandbox function of the same name.
-func (p *Sandbox) Annotations(key string) (string, error) {
-	return p.MockAnnotations[key], nil
+func (s *Sandbox) Annotations(key string) (string, error) {
+	return s.MockAnnotations[key], nil
 }
 
 // SetAnnotations implements the VCSandbox function of the same name.
-func (p *Sandbox) SetAnnotations(annotations map[string]string) error {
+func (s *Sandbox) SetAnnotations(annotations map[string]string) error {
 	return nil
 }
 
 // GetAnnotations implements the VCSandbox function of the same name.
-func (p *Sandbox) GetAnnotations() map[string]string {
-	return p.MockAnnotations
+func (s *Sandbox) GetAnnotations() map[string]string {
+	return s.MockAnnotations
 }
 
 // GetAllContainers implements the VCSandbox function of the same name.
-func (p *Sandbox) GetAllContainers() []vc.VCContainer {
-	var ifa = make([]vc.VCContainer, len(p.MockContainers))
+func (s *Sandbox) GetAllContainers() []vc.VCContainer {
+	var ifa = make([]vc.VCContainer, len(s.MockContainers))
 
-	for i, v := range p.MockContainers {
+	for i, v := range s.MockContainers {
 		ifa[i] = v
 	}
 
@@ -45,8 +45,8 @@ func (p *Sandbox) GetAllContainers() []vc.VCContainer {
 }
 
 // GetContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) GetContainer(containerID string) vc.VCContainer {
-	for _, c := range p.MockContainers {
+func (s *Sandbox) GetContainer(containerID string) vc.VCContainer {
+	for _, c := range s.MockContainers {
 		if c.MockID == containerID {
 			return c
 		}
@@ -55,86 +55,86 @@ func (p *Sandbox) GetContainer(containerID string) vc.VCContainer {
 }
 
 // Release implements the VCSandbox function of the same name.
-func (p *Sandbox) Release() error {
+func (s *Sandbox) Release() error {
 	return nil
 }
 
 // Pause implements the VCSandbox function of the same name.
-func (p *Sandbox) Pause() error {
+func (s *Sandbox) Pause() error {
 	return nil
 }
 
 // Resume implements the VCSandbox function of the same name.
-func (p *Sandbox) Resume() error {
+func (s *Sandbox) Resume() error {
 	return nil
 }
 
 // Delete implements the VCSandbox function of the same name.
-func (p *Sandbox) Delete() error {
+func (s *Sandbox) Delete() error {
 	return nil
 }
 
 // CreateContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) CreateContainer(conf vc.ContainerConfig) (vc.VCContainer, error) {
+func (s *Sandbox) CreateContainer(conf vc.ContainerConfig) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 
 // DeleteContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) DeleteContainer(contID string) (vc.VCContainer, error) {
+func (s *Sandbox) DeleteContainer(contID string) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 
 // StartContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) StartContainer(contID string) (vc.VCContainer, error) {
+func (s *Sandbox) StartContainer(contID string) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 
 // StatusContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
+func (s *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
 	return vc.ContainerStatus{}, nil
 }
 
 // StatsContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) StatsContainer(contID string) (vc.ContainerStats, error) {
+func (s *Sandbox) StatsContainer(contID string) (vc.ContainerStats, error) {
 	return vc.ContainerStats{}, nil
 }
 
 // Status implements the VCSandbox function of the same name.
-func (p *Sandbox) Status() vc.SandboxStatus {
+func (s *Sandbox) Status() vc.SandboxStatus {
 	return vc.SandboxStatus{}
 }
 
 // EnterContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) EnterContainer(containerID string, cmd vc.Cmd) (vc.VCContainer, *vc.Process, error) {
+func (s *Sandbox) EnterContainer(containerID string, cmd vc.Cmd) (vc.VCContainer, *vc.Process, error) {
 	return &Container{}, &vc.Process{}, nil
 }
 
 // Monitor implements the VCSandbox function of the same name.
-func (p *Sandbox) Monitor() (chan error, error) {
+func (s *Sandbox) Monitor() (chan error, error) {
 	return nil, nil
 }
 
 // UpdateContainer implements the VCSandbox function of the same name.
-func (p *Sandbox) UpdateContainer(containerID string, resources specs.LinuxResources) error {
+func (s *Sandbox) UpdateContainer(containerID string, resources specs.LinuxResources) error {
 	return nil
 }
 
 // WaitProcess implements the VCSandbox function of the same name.
-func (p *Sandbox) WaitProcess(containerID, processID string) (int32, error) {
+func (s *Sandbox) WaitProcess(containerID, processID string) (int32, error) {
 	return 0, nil
 }
 
 // SignalProcess implements the VCSandbox function of the same name.
-func (p *Sandbox) SignalProcess(containerID, processID string, signal syscall.Signal, all bool) error {
+func (s *Sandbox) SignalProcess(containerID, processID string, signal syscall.Signal, all bool) error {
 	return nil
 }
 
 // WinsizeProcess implements the VCSandbox function of the same name.
-func (p *Sandbox) WinsizeProcess(containerID, processID string, height, width uint32) error {
+func (s *Sandbox) WinsizeProcess(containerID, processID string, height, width uint32) error {
 	return nil
 }
 
 // IOStream implements the VCSandbox function of the same name.
-func (p *Sandbox) IOStream(containerID, processID string) (io.WriteCloser, io.Reader, io.Reader, error) {
+func (s *Sandbox) IOStream(containerID, processID string) (io.WriteCloser, io.Reader, io.Reader, error) {
 	return nil, nil, nil, nil
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1326,22 +1326,22 @@ func togglePauseSandbox(sandboxID string, pause bool) (*Sandbox, error) {
 	defer unlockSandbox(lockFile)
 
 	// Fetch the sandbox from storage and create it.
-	p, err := fetchSandbox(sandboxID)
+	s, err := fetchSandbox(sandboxID)
 	if err != nil {
 		return nil, err
 	}
 
 	if pause {
-		err = p.Pause()
+		err = s.Pause()
 	} else {
-		err = p.Resume()
+		err = s.Resume()
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	return p, nil
+	return s, nil
 }
 
 // HotplugAddDevice is used for add a device to sandbox


### PR DESCRIPTION
Still there are some codes left which
will cause some misunderstanding

Change `p` in short of `pod` into `s` or `sandbox`

Fixes: #325

Signed-off-by: Haomin <caihaomin@huawei.com>