### PR TITLE
 make sure kataAgent/createContainer can decode old specs.Spec

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -421,7 +421,11 @@ func readOCIConfigFile(configPath string) (oci.CompatOCISpec, error) {
 	if err := json.Unmarshal(data, &ociSpec); err != nil {
 		return oci.CompatOCISpec{}, err
 	}
-
+	caps, err := oci.ContainerCapabilities(ociSpec)
+	if err != nil {
+		return oci.CompatOCISpec{}, err
+	}
+	ociSpec.Process.Capabilities = caps
 	return ociSpec, nil
 }
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -320,6 +320,14 @@ func containerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
 	return c, nil
 }
 
+// ContainerCapabilities return a LinuxCapabilities for virtcontainer
+func ContainerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
+	if s.Process == nil {
+		return vc.LinuxCapabilities{}, fmt.Errorf("ContainerCapabilities, Process is nil")
+	}
+	return containerCapabilities(s)
+}
+
 func networkConfig(ocispec CompatOCISpec, config RuntimeConfig) (vc.NetworkConfig, error) {
 	linux := ocispec.Linux
 	if linux == nil {
@@ -365,6 +373,11 @@ func ParseConfigJSON(bundlePath string) (CompatOCISpec, error) {
 	if err := json.Unmarshal(configByte, &ocispec); err != nil {
 		return CompatOCISpec{}, err
 	}
+	caps, err := ContainerCapabilities(ocispec)
+	if err != nil {
+		return CompatOCISpec{}, err
+	}
+	ocispec.Process.Capabilities = caps
 
 	return ocispec, nil
 }
@@ -554,9 +567,12 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 		return vc.ContainerConfig{}, err
 	}
 
-	cmd.Capabilities, err = containerCapabilities(ocispec)
-	if err != nil {
-		return vc.ContainerConfig{}, err
+	if ocispec.Process != nil {
+		caps, ok := ocispec.Process.Capabilities.(vc.LinuxCapabilities)
+		if !ok {
+			return vc.ContainerConfig{}, fmt.Errorf("Unexpected format for capabilities: %v", ocispec.Process.Capabilities)
+		}
+		cmd.Capabilities = caps
 	}
 
 	var resources vc.ContainerResources


### PR DESCRIPTION
In old specs.Spec, Capabilities is [] string, but we don't use CompatOCISpec  for compatibility in kataAgent/createContainer, it lead to docker-1.11.2 failed to start kata-container, this pr will fix this.

before this pr,
```
[root@localhost linux]# docker run --rm -it --runtime kata-runtime busybox sh
docker: Error response from daemon: oci runtime error: json: cannot unmarshal array into Go struct field Process.capabilities of type specs.LinuxCapabilities.
```
after this pr
```
[root@localhost linux]# docker run --rm -it --runtime kata-runtime busybox sh
/ # exit
```