### PR TITLE
config: Show which config file loaded

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -521,7 +521,8 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		kataLog.WithFields(
 			logrus.Fields{
 				"format": "TOML",
-			}).Debugf("loaded configuration")
+				"file":   resolved,
+			}).Info("loaded configuration")
 	}
 
 	if err := updateRuntimeConfig(resolved, tomlConf, &config); err != nil {


### PR DESCRIPTION
Since the runtime can load its configuration from multiple locations,
add a log field to show which location was used.

Change log level from Debug to Info as this is generally useful
information.

Fixes #335.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>