### PR TITLE
docs: Delete the VCPUs field

### DIFF
--- a/virtcontainers/documentation/api/1.0/api.md
+++ b/virtcontainers/documentation/api/1.0/api.md
@@ -96,9 +96,6 @@ type SandboxConfig struct {
 ```Go
 // Resources describes VM resources configuration.
 type Resources struct {
-	// VCPUs is the number of available virtual CPUs.
-	VCPUs uint
-
 	// Memory is the amount of available memory in MiB.
 	Memory uint
 }
@@ -902,7 +899,6 @@ func Example_createAndStartSandbox() {
 
 	// VM resources
 	vmConfig := vc.Resources{
-		VCPUs:  4,
 		Memory: 1024,
 	}
 


### PR DESCRIPTION
_VCPUs_ field has been abandoned. 
Please see this issue #339 .

Signed-off-by: ZeroMagic <anthonyliu@zju.edu.cn>