### PR TITLE
unittest: tiny fix for incorrect parameters

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -98,7 +98,7 @@ func init() {
 	fmt.Printf("INFO: ensuring required docker image (%v) is available\n", testDockerImage)
 
 	// Only hit the network if the image doesn't exist locally
-	_, err = runCommand([]string{"docker", "image", "inspect", testDockerImage})
+	_, err = runCommand([]string{"docker", "inspect", "--type=image", testDockerImage})
 	if err == nil {
 		fmt.Printf("INFO: docker image %v already exists locally\n", testDockerImage)
 	} else {


### PR DESCRIPTION
runCommand([]string{"docker", "image", "inspect", testDockerImage}) will always fail, and it lead testcase pull busybox every time whether it exists or not.

Fixes #347

Signed-off-by: y00316549 <yangshukui@huawei.com>