### PR TITLE
virtcontainers: add codes to process the case that kata-agent doesn't start in VM

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -937,10 +937,18 @@ func (s *Sandbox) startVM() error {
 
 	s.Logger().Info("VM started")
 
+
+
 	// Once startVM is done, we want to guarantee
 	// that the sandbox is manageable. For that we need
 	// to start the sandbox inside the VM.
-	return s.agent.startSandbox(s)
+	err := s.agent.startSandbox(s)
+	defer func() {
+		if err != nil {
+			s.hypervisor.stopSandbox()
+		}
+	}()
+	return err
 }
 
 func (s *Sandbox) addContainer(c *Container) error {


### PR DESCRIPTION
virtcontainers: add codes to process the case that kata-agent doesn't start in VM

If kata-agent process is not launched to run in VM, kata-runtime will exit because of timeout,
however kata-proxy and qemu process will still resident in host

Call Check grpc function to check whether grpc server is running in kata-agent process in VM,
if not and then do some rollback operation to stop kata-proxy and qemu processes

Fixes: #297

Signed-off-by: flyflypeng <jiangpengfei9@huawei.com>