### PR TITLE
virtcontainers: process the case that kata-agent doesn't start in VM

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -39,6 +39,8 @@ func CreateSandbox(sandboxConfig SandboxConfig, factory Factory) (VCSandbox, err
 }
 
 func createSandboxFromConfig(sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+	var err error
+
 	// Create the sandbox.
 	s, err := createSandbox(sandboxConfig, factory)
 	if err != nil {
@@ -46,22 +48,29 @@ func createSandboxFromConfig(sandboxConfig SandboxConfig, factory Factory) (*San
 	}
 
 	// Create the sandbox network
-	if err := s.createNetwork(); err != nil {
+	if err = s.createNetwork(); err != nil {
 		return nil, err
 	}
 
+	// network rollback
+	defer func() {
+		if err != nil && s.networkNS.NetNsCreated {
+			s.removeNetwork()
+		}
+	}()
+
 	// Start the VM
-	if err := s.startVM(); err != nil {
+	if err = s.startVM(); err != nil {
 		return nil, err
 	}
 
 	// Create Containers
-	if err := s.createContainers(); err != nil {
+	if err = s.createContainers(); err != nil {
 		return nil, err
 	}
 
 	// The sandbox is completely created now, we can store it.
-	if err := s.storeSandbox(); err != nil {
+	if err = s.storeSandbox(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -512,6 +512,11 @@ func (k *kataAgent) startSandbox(sandbox *Sandbox) error {
 		hostname = hostname[:maxHostnameLen]
 	}
 
+	// check grpc server is serving
+	if err = k.check(); err != nil {
+		return err
+	}
+
 	//
 	// Setup network interfaces and routes
 	//

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -971,10 +971,12 @@ func (s *Sandbox) startVM() error {
 
 	s.Logger().Info("VM started")
 
-	// Once startVM is done, we want to guarantee
-	// that the sandbox is manageable. For that we need
-	// to start the sandbox inside the VM.
-	return s.agent.startSandbox(s)
+	return nil
+}
+
+// stopVM: stop the sandbox's VM
+func (s *Sandbox) stopVM() error {
+	return s.hypervisor.stopSandbox()
 }
 
 func (s *Sandbox) addContainer(c *Container) error {


### PR DESCRIPTION
virtcontainers: process the case that kata-agent doesn't start in VM

If kata-agent process is not launched to run in VM, kata-runtime will exit because of timeout,
however kata-proxy and qemu process will still resident in host

Call Check grpc function to check whether grpc server is running in kata-agent process in VM,
if not and then do some rollback operation to stop kata-proxy and qemu processes

Fixes: #297

Signed-off-by: flyflypeng <jiangpengfei9@huawei.com>