### PR TITLE
virtcontainers/api: use RW lock to update containers

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -615,7 +615,7 @@ func UpdateContainer(sandboxID, containerID string, resources specs.LinuxResourc
 		return errNeedContainerID
 	}
 
-	lockFile, err := rLockSandbox(sandboxID)
+	lockFile, err := rwLockSandbox(sandboxID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When a container is updated, those modifications are stored, to
avoid race conditions with other operations, a RW lock should be used.

fixes #346

Signed-off-by: Julio Montes <julio.montes@intel.com>