### PR TITLE
shm: Create shared /dev/shm

### DIFF
--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -18,6 +18,10 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 )
 
+// DefaultShmSize is the default shm size to be used in case host
+// IPC is used.
+const DefaultShmSize = 65536 * 1024
+
 var rootfsDir = "rootfs"
 
 var systemMountPrefixes = []string{"/proc", "/sys"}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -356,6 +356,8 @@ type SandboxConfig struct {
 	// Annotations keys must be unique strings and must be name-spaced
 	// with e.g. reverse domain notation (org.clearlinux.key).
 	Annotations map[string]string
+
+	ShmSize uint64
 }
 
 // valid checks that the sandbox configuration is valid.
@@ -459,6 +461,8 @@ type Sandbox struct {
 	annotationsLock *sync.RWMutex
 
 	wg *sync.WaitGroup
+
+	shmSize uint64
 }
 
 // ID returns the sandbox identifier string.
@@ -738,6 +742,7 @@ func newSandbox(sandboxConfig SandboxConfig) (*Sandbox, error) {
 		state:           State{},
 		annotationsLock: &sync.RWMutex{},
 		wg:              &sync.WaitGroup{},
+		shmSize:         sandboxConfig.ShmSize,
 	}
 
 	if err = globalSandboxList.addSandbox(s); err != nil {


### PR DESCRIPTION
This commit checks the size of "/dev/shm" for the sandbox container
which is then used to create the shared memory inside the guest.
kata agent then uses this size to set up a sandbox level shm
storage. The containers then simply bind mount this sandbox level
shm.

With this, we will now be able to support docker --shm-size option
as well have a shared shm within containers in a pod, since they are
supposed to be in the same IPC namespace.

Fixed #356

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>