### PR TITLE
virtcontainers: Remove unnecessary kernel parameters for ppc64le

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -41,10 +41,8 @@ var kernelParams = []Param{
 	{"reboot", "k"},
 	{"console", "hvc0"},
 	{"console", "hvc1"},
-	{"iommu", "off"},
 	{"cryptomgr.notests", ""},
 	{"net.ifnames", "0"},
-	{"pci", "lastbus=0"},
 }
 
 var supportedQemuMachines = []govmmQemu.Machine{


### PR DESCRIPTION
Fixes: #360

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>