### PR TITLE
cpuinfo/arm64: Refine CPUInfo in Arm64

### DIFF
--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -74,3 +74,7 @@ func hostIsVMContainerCapable(details vmContainerCapableDetails) error {
 func archKernelParamHandler(onVMM bool, fields logrus.Fields, msg string) bool {
 	return genericArchKernelParamHandler(onVMM, fields, msg)
 }
+
+func getCPUDetails() (vendor, model string, err error) {
+	return genericGetCPUDetails()
+}

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -65,3 +65,7 @@ func kvmIsUsable() error {
 func archKernelParamHandler(onVMM bool, fields logrus.Fields, msg string) bool {
 	return genericArchKernelParamHandler(onVMM, fields, msg)
 }
+
+func getCPUDetails() (vendor, model string, err error) {
+	return genericGetCPUDetails()
+}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -96,10 +96,10 @@ func getDistroDetails() (name, version string, err error) {
 	return "", "", fmt.Errorf("failed to find expected fields in one of %v", files)
 }
 
-// getCPUDetails returns the vendor and model of the CPU.
+// genericGetCPUDetails returns the vendor and model of the CPU.
 // If it is not possible to determine both values an error is
 // returned.
-func getCPUDetails() (vendor, model string, err error) {
+func genericGetCPUDetails() (vendor, model string, err error) {
 	cpuinfo, err := getCPUInfo(procCPUInfo)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
The CPUinfo need to be refined in Arm architecture, because the
vendor and model of CPU may refer to different meaning in Arm architecture.
Besides, relevant contents extracted from /proc/cpuinfo may need to be
normalized for human-readability.

Fixes: #368

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <wei.chen@arm.com>