### PR TITLE
docs: Fix invalid URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/kata-containers/runtime.svg?branch=master)](https://travis-ci.org/kata-containers/runtime)
 [![Build Status](http://kata-jenkins-ci.westus2.cloudapp.azure.com/job/kata-containers-runtime-ubuntu-16-04-master/badge/icon)](http://kata-jenkins-ci.westus2.cloudapp.azure.com/job/kata-containers-runtime-ubuntu-16-04-master/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/runtime)](https://goreportcard.com/report/github.com/kata-containers/runtime)
+[![GoDoc](https://godoc.org/github.com/kata-containers/runtime?status.svg)](https://godoc.org/github.com/kata-containers/runtime)
 
 # Runtime
 

--- a/virtcontainers/README.md
+++ b/virtcontainers/README.md
@@ -1,11 +1,3 @@
-[![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
-[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master)
-[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master)
-[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
-[![Coverage Status](https://coveralls.io/repos/github/containers/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/containers/virtcontainers?branch=master)
-[![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)
-
 Table of Contents
 =================
 
@@ -51,7 +43,7 @@ or the [Kubernetes CRI][cri]) to the `virtcontainers` API.
 [runtime][cc-runtime] implementation
 
 [oci]: https://github.com/opencontainers/runtime-spec
-[cri]: https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/container-runtime-interface-v1.md
+[cri]: https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md
 [cc]: https://github.com/clearcontainers/
 [cc-runtime]: https://github.com/clearcontainers/runtime/
 

--- a/virtcontainers/documentation/api/1.0/api.md
+++ b/virtcontainers/documentation/api/1.0/api.md
@@ -12,7 +12,7 @@ The virtcontainers 1.0 API operates on two high level objects:
 The virtcontainers 1.0 sandbox API manages hardware virtualized
 [sandbox lifecycles](#sandbox-functions). The virtcontainers sandbox
 semantics strictly follow the
-[Kubernetes](https://kubernetes.io/docs/concepts/workloads/sandboxes/sandbox/) ones.
+[Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) ones.
 
 The sandbox API allows callers to [create](#createsandbox), [delete](#deletesandbox),
 [start](#startsandbox), [stop](#stopsandbox), [run](#runsandbox), [pause](#pausesandbox),
@@ -557,7 +557,7 @@ virtual machine's guest OS.
 
 A virtcontainers container always belong to one and only one
 virtcontainers sandbox, again following the
-[Kubernetes](https://kubernetes.io/docs/concepts/workloads/sandboxes/sandbox-overview/)
+[Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview).
 logic and semantics.
 
 The container API allows callers to [create](#createcontainer),


### PR DESCRIPTION
Correct the document URLs which have gone stale.

The virtcontainers build status links have been moved to the top-level
README.

Fixes #376.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>