### PR TITLE
CI: Update Jenkins build status URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/kata-containers/runtime.svg?branch=master)](https://travis-ci.org/kata-containers/runtime)
-[![Build Status](http://kata-jenkins-ci.westus2.cloudapp.azure.com/job/kata-containers-runtime-ubuntu-16-04-master/badge/icon)](http://kata-jenkins-ci.westus2.cloudapp.azure.com/job/kata-containers-runtime-ubuntu-16-04-master/)
+[![Build Status](http://199.204.45.34/job/kata-containers-runtime-ubuntu-16-04-master/badge/icon)](http://199.204.45.34/job/kata-containers-runtime-ubuntu-16-04-master/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/runtime)](https://goreportcard.com/report/github.com/kata-containers/runtime)
 [![GoDoc](https://godoc.org/github.com/kata-containers/runtime?status.svg)](https://godoc.org/github.com/kata-containers/runtime)
 


### PR DESCRIPTION
Now that the jenkins url has changed, we need to update
the build status URL.

Fixes: #391

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>