### PR TITLE
[RFC] makefile: honor DESTDIR flag.

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -180,8 +180,8 @@ show_runtime_configs()
 	# add in the standard defaults for good measure "just in case"
 	configs+=" /etc/@PROJECT_TAG@/configuration.toml"
 	configs+=" /usr/share/defaults/@PROJECT_TAG@/configuration.toml"
-	configs+=" @DESTCONFIG@"
-	configs+=" @DESTSYSCONFIG@"
+	configs+=" @CONFIG_PATH@"
+	configs+=" @SYSCONFIG@"
 
 	# create a unique list of config files
 	configs=$(echo $configs|tr ' ' '\n'|sort -u)


### PR DESCRIPTION
make install DESTDIR=/tmp/dest/

Before:
```
$tree /tmp/dest/
/tmp/dest/
└── usr
    ├── bin
    │   └── kata-collect-data.sh
    └── share
        └── defaults
            └── kata-containers
                └── configuration.toml
```

Now:
```
$tree /tmp/dest/
/tmp/dest/
└── usr
    ├── local
    │   └── bin
    │       ├── kata-collect-data.sh
    │       └── kata-runtime
    └── share
        ├── bash-completion
        │   └── completions
        │       └── kata-runtime
        └── defaults
            └── kata-containers
                └── configuration.toml
```
New summary:
```
• Summary:

        destination install path (DESTDIR): /tmp/dest/
        binary installation path (BINDIR) : /usr/local/bin
        binaries to install               :
         - kata-runtime
         - data/kata-collect-data.sh
        config to install (CONFIG)      : cli/config/configuration.toml
                install path (CONFIG_PATH): /usr/local/share/defaults/kata-containers/configuration.toml
        alternate config path (SYSCONFIG) : /etc/kata-containers/configuration.toml
        hypervisor path (QEMUPATH)            : /usr/bin/qemu-lite-system-x86_64
        assets path (PKGDATADIR)              : /usr/share/kata-containers
        proxy+shim path (PKGLIBEXECDIR)       : /usr/libexec/kata-containers

```

Now the runtime when installed from source will install the config file in /usr/local/...
See:
  [Runtime.Config]
    Path = "/usr/local/share/defaults/kata-containers/configuration.toml"

Fixes: #401

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>