### PR TITLE
Add cleanup task for failed creates

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -45,23 +45,30 @@ func createSandboxFromConfig(sandboxConfig SandboxConfig) (*Sandbox, error) {
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			s.Logger().WithError(err).WithField("sandboxid", s.id).Error("Creating sandbox failed")
+			s.Cleanup()
+		}
+	}()
+
 	// Create the sandbox network
-	if err := s.createNetwork(); err != nil {
+	if err = s.createNetwork(); err != nil {
 		return nil, err
 	}
 
 	// Start the VM
-	if err := s.startVM(); err != nil {
+	if err = s.startVM(); err != nil {
 		return nil, err
 	}
 
 	// Create Containers
-	if err := s.createContainers(); err != nil {
+	if err = s.createContainers(); err != nil {
 		return nil, err
 	}
 
 	// The sandbox is completely created now, we can store it.
-	if err := s.storeSandbox(); err != nil {
+	if err = s.storeSandbox(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1433,3 +1433,18 @@ func (s *Sandbox) AddVhostUserDevice(devInfo api.VhostUserDevice, devType config
 	}
 	return fmt.Errorf("unsupported device type")
 }
+
+// Cleanup will clean up any dangling mounts created during a startup
+// procedure, as well as terminate the VM. This is used when a sandbox
+// failed during create.
+func (s *Sandbox) Cleanup() {
+	// stop VM
+	s.stop()
+	// unmount and delete mount dirs
+	bindUnmountAllRootfs(kataHostSharedDir, s)
+	os.RemoveAll(filepath.Join(kataHostSharedDir, s.id))
+	// delete any other sandbox dirs (e.g. in /run/vc/sbs)
+	s.storage.deleteSandboxResources(s.id, nil)
+	// delete from shared mem
+	globalSandboxList.removeSandbox(s.id)
+}


### PR DESCRIPTION
Addresses a comment left by @sboeuf https://github.com/kata-containers/runtime/issues/396#issuecomment-397027292.

Not sure whether this is what you had in mind, but I've verified locally that dirs are now being cleaned up. I think a big reason `kata-runtime list` was hanging was due to the large amount of junk folders left around in `/run/vc/sbs`