### PR TITLE
Versions: Add CNI plugins version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -107,6 +107,11 @@ components:
 externals:
   description: "Third-party projects used by the system"
 
+  cni-plugins:
+    description: "CNI network plugins"
+    url: "https://github.com/containernetworking/plugins"
+    commit: "7f98c94613021d8b57acfa1a2f0c8d0f6fd7ae5a"
+
   crio:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation


### PR DESCRIPTION
The cni-plugins commit will be used to build that specific
version on the CI, instead of using master.

Fixes #407.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>