### PR TITLE
docs: update debug runtime link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ tool.
 ## Debugging
 
 See the
-[debugging section of the developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug).
+[debugging section of the developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#troubleshoot-kata-containers).
 
 ## Limitations
 


### PR DESCRIPTION
It pointed to how to enable logs, which is only a small portion of the
debug options for Kata  Containers.  Let's instead point to the
troubleshooting section, which includes pointers to adding logs and to
debug the guest vm.

Signed-off-by: Eric Ernst <eric.ernst@intel.com>