### PR TITLE
virtcontainers: Set ppc64le maxmem depending on qemu version

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -64,6 +64,9 @@ const qmpCapErrMsg = "Failed to negoatiate QMP capabilities"
 
 const defaultConsole = "console.sock"
 
+var qemuMajorVersion int
+var qemuMinorVersion int
+
 // agnostic list of kernel parameters
 var defaultKernelParameters = []Param{
 	{"panic", "1"},
@@ -509,6 +512,8 @@ func (q *qemu) waitSandbox(timeout int) error {
 	}
 
 	q.qmpMonitorCh.qmp = qmp
+	qemuMajorVersion = ver.Major
+	qemuMinorVersion = ver.Minor
 
 	q.Logger().WithFields(logrus.Fields{
 		"qmp-major-version": ver.Major,


### PR DESCRIPTION
The "Failed to allocate HTAB of requested size,
try with smaller maxmem" error in ppc64le occurs
when maxmem allocated is very high. This got fixed
in qemu 2.10 and kernel 4.11. Hence put a maxmem
restriction of 32GB per kata-container if qemu
version less than 2.10

Fixes: #415

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>