### PR TITLE
versions: update supported docker version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -132,7 +132,7 @@ externals:
     description: "Moby project container manager"
     notes: "Docker Swarm requires an older version of Docker."
     url: "https://github.com/moby/moby"
-    version: "v17.12-ce"
+    version: "v18.03-ce"
     meta:
       swarm-version: "1.12.1"
 


### PR DESCRIPTION
update from v17.12 to v18.03.
18.03 is the version installed in the CI VMs
and when using v17.12 some hotplug cpu tests
fail. then we need to make v18.03 our official
supported version.

Fixes: #418.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>