### PR TITLE
cli: add no-pivot flag to be compatible with docker in ramdisk

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -56,6 +56,10 @@ var createCLICommand = cli.Command{
 			Value: "",
 			Usage: "specify the file to write the process id to",
 		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "warning: this flag is meaningless to kata-runtime, just defined in order to be compatible with docker in ramdisk",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		runtimeConfig, ok := context.App.Metadata["runtimeConfig"].(oci.RuntimeConfig)

--- a/cli/run.go
+++ b/cli/run.go
@@ -52,6 +52,10 @@ var runCLICommand = cli.Command{
 			Name:  "detach, d",
 			Usage: "detach from the container's process",
 		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "warning: this flag is meaningless to kata-runtime, just defined in order to be compatible with docker in ramdisk",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		runtimeConfig, ok := context.App.Metadata["runtimeConfig"].(oci.RuntimeConfig)


### PR DESCRIPTION
This commit add a no-pivot flag (just a warning tip) in kata-runtime create and run cmd.

Fixes: #409 , #134

Signed-off-by: wenqi wang wangwenqi01@baidu.com