### PR TITLE
fix message too long

### DIFF
--- a/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -327,12 +327,8 @@ func ReadCtlMessage(conn net.Conn) (*DecodedMessage, error) {
 // hyperstart control serial link, use SendCtlMessage.
 func (h *Hyperstart) WriteCtlMessage(conn net.Conn, m *DecodedMessage) error {
 	length := len(m.Message) + CtlHdrSize
-	// XXX: Support sending messages by chunks to support messages over
-	// 10240 bytes. That limit is from hyperstart src/init.c,
-	// hyper_channel_ops, rbuf_size.
-	if length > 10240 {
-		return fmt.Errorf("message too long %d", length)
-	}
+	// Since hyper_ctlfd_read() can realloc buffer, we don't limit 10240
+	// message size.
 	msg := make([]byte, length)
 	binary.BigEndian.PutUint32(msg[:], m.Code)
 	binary.BigEndian.PutUint32(msg[CtlHdrLenOffset:], uint32(length))


### PR DESCRIPTION
Since [hyper_ctlfd_read()](https://github.com/hyperhq/hyperstart/blob/master/src/init.c#L1290) can realloc buffer, we don't limit 10240 message size.
Fixes: #386
Signed-off-by:malc0lm malclee@outlook.com