### PR TITLE
qemu: clean up qmp channel

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -23,17 +23,6 @@ import (
 	deviceManager "github.com/kata-containers/runtime/virtcontainers/device/manager"
 )
 
-// controlSocket is the sandbox control socket.
-// It is an hypervisor resource, and for example qemu's control
-// socket is the QMP one.
-const controlSocket = "ctl"
-
-// monitorSocket is the sandbox monitoring socket.
-// It is an hypervisor resource, and is a qmp socket in the qemu case.
-// This is a socket that any monitoring entity will listen to in order
-// to understand if the VM is still alive or not.
-const monitorSocket = "mon"
-
 // vmStartTimeout represents the time in seconds a sandbox can wait before
 // to consider the VM starting operation failed.
 const vmStartTimeout = 10


### PR DESCRIPTION
We only need one qmp channel and it is qemu internal detail thus
sandbox.go does not need to be aware of it.

This was part of #303 and but does not really relate to vm factory so I take it out.