### PR TITLE
versions: Update supported cri-o version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -116,7 +116,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/kubernetes-incubator/cri-o"
-    version: "393429d5961ea1f14ff21265b534e98ad2ac40fc"
+    version: "release-1.10"
     meta:
       openshift: "v1.9.11"
 


### PR DESCRIPTION
We need to update the cri-o version to the
HEAD of the release-1.10 branch, which contains a fix
to be able to test cri-o with devicemapper using a
block device.

Fixes #435.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>