### PR TITLE
network: Use pointer for VhostUserNetDevice for Attach

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -280,7 +280,7 @@ func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
 	}
 	id := hex.EncodeToString(randBytes)
 
-	d := drivers.VhostUserNetDevice{
+	d := &drivers.VhostUserNetDevice{
 		MacAddress: endpoint.HardAddr,
 	}
 	d.SocketPath = endpoint.SocketPath


### PR DESCRIPTION
Use pointer here since api.VhostUserDevice interface is implemented
by VhostUserNetDevice pointer.

Fixes #446

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>