### PR TITLE
main: Pass runtime CLI command to vc logger

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -235,16 +235,16 @@ func beforeSubcommands(context *cli.Context) error {
 		return fmt.Errorf("unknown log-format %q", context.GlobalString("log-format"))
 	}
 
-	setExternalLoggers(kataLog)
-
-	ignoreLogging := false
-
 	// Add the name of the sub-command to each log entry for easier
 	// debugging.
 	cmdName := context.Args().First()
 	if context.App.Command(cmdName) != nil {
 		kataLog = kataLog.WithField("command", cmdName)
 	}
+
+	setExternalLoggers(kataLog)
+
+	ignoreLogging := false
 
 	if context.NArg() == 1 && context.Args()[0] == envCmd {
 		// simply report the logging setup


### PR DESCRIPTION
Add the runtime CLI command name to the virtcontainers logger so that it
is clear when reading virtcontainers log entries which runtime command
they refer to.

Fixes #448.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>