### PR TITLE
logging: Add containerID and sandboxID to all log calls

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -89,6 +89,8 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 	runtimeConfig oci.RuntimeConfig) error {
 	var err error
 
+	kataLog = kataLog.WithField("container", containerID)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	if bundlePath, err = validCreateParams(containerID, bundlePath); err != nil {
 		return err
@@ -238,6 +240,8 @@ func createSandbox(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 		return vc.Process{}, err
 	}
 
+	kataLog = kataLog.WithField("sandbox", sandbox.ID())
+
 	containers := sandbox.GetAllContainers()
 	if len(containers) != 1 {
 		return vc.Process{}, fmt.Errorf("BUG: Container list from sandbox is wrong, expecting only one container, found %d containers", len(containers))
@@ -262,6 +266,8 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 	if err != nil {
 		return vc.Process{}, err
 	}
+
+	kataLog = kataLog.WithField("sandbox", sandboxID)
 
 	_, c, err := vci.CreateContainer(sandboxID, contConfig)
 	if err != nil {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -12,6 +12,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -57,6 +58,11 @@ func delete(containerID string, force bool) error {
 	if err != nil {
 		return err
 	}
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	containerID = status.ID
 

--- a/cli/events.go
+++ b/cli/events.go
@@ -151,6 +151,11 @@ information is displayed once every 5 seconds.`,
 			return err
 		}
 
+		kataLog = kataLog.WithFields(logrus.Fields{
+			"container": containerID,
+			"sandbox":   sandboxID,
+		})
+
 		if status.State.State == vc.StateStopped {
 			return fmt.Errorf("container with id %s is not running", status.ID)
 		}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -16,6 +16,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -187,6 +188,11 @@ func execute(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	// Retrieve OCI spec configuration.
 	ociSpec, err := oci.GetOCIConfig(status)

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -13,6 +13,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -97,6 +98,11 @@ func kill(containerID, signal string, all bool) error {
 	}
 
 	containerID = status.ID
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	signum, err := processSignal(signal)
 	if err != nil {

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -48,6 +49,11 @@ func toggleContainerPause(containerID string, pause bool) (err error) {
 	}
 
 	containerID = status.ID
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	if pause {
 		err = vci.PauseContainer(sandboxID, containerID)

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -54,6 +55,11 @@ func ps(containerID, format string, args []string) error {
 	}
 
 	containerID = status.ID
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	// container MUST be running
 	if status.State.State != vc.StateRunning {

--- a/cli/start.go
+++ b/cli/start.go
@@ -11,6 +11,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -45,6 +46,11 @@ func start(containerID string) (vc.VCSandbox, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
 
 	containerID = status.ID
 

--- a/cli/state.go
+++ b/cli/state.go
@@ -34,6 +34,8 @@ instance of a container.`,
 }
 
 func state(containerID string) error {
+	kataLog = kataLog.WithField("container", containerID)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, _, err := getExistingContainerInfo(containerID)
 	if err != nil {

--- a/cli/update.go
+++ b/cli/update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/go-units"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -137,6 +138,12 @@ other options are ignored.
 		}
 
 		containerID = status.ID
+
+		kataLog = kataLog.WithFields(logrus.Fields{
+			"container": containerID,
+			"sandbox":   sandboxID,
+		})
+
 		// container MUST be running
 		if status.State.State != vc.StateRunning {
 			return fmt.Errorf("Container %s is not running", containerID)


### PR DESCRIPTION
Adding cid+sid fields to the log entries generated by most of the CLI
commands will make debugging across the system easier.

Fixes #452.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>