### PR TITLE
proxy: Pass sandbox to proxy

### DIFF
--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -6,84 +6,11 @@
 package virtcontainers
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCCProxyStart(t *testing.T) {
-	assert := assert.New(t)
-
-	tmpdir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
-
 	proxy := &ccProxy{}
 
-	type testData struct {
-		sandbox     *Sandbox
-		expectedURI string
-		expectError bool
-	}
-
-	invalidPath := filepath.Join(tmpdir, "enoent")
-	expectedSocketPath := filepath.Join(runStoragePath, testSandboxID, "proxy.sock")
-	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
-
-	data := []testData{
-		{&Sandbox{}, "", true},
-		{
-			&Sandbox{
-				config: &SandboxConfig{
-					ProxyType: "invalid",
-				},
-			}, "", true,
-		},
-		{
-			&Sandbox{
-				config: &SandboxConfig{
-					ProxyType: CCProxyType,
-					// invalid - no path
-					ProxyConfig: ProxyConfig{},
-				},
-			}, "", true,
-		},
-		{
-			&Sandbox{
-				config: &SandboxConfig{
-					ProxyType: CCProxyType,
-					ProxyConfig: ProxyConfig{
-						Path: invalidPath,
-					},
-				},
-			}, "", true,
-		},
-		{
-			&Sandbox{
-				id: testSandboxID,
-				config: &SandboxConfig{
-					ProxyType: CCProxyType,
-					ProxyConfig: ProxyConfig{
-						Path: "echo",
-					},
-				},
-			}, expectedURI, false,
-		},
-	}
-
-	for _, d := range data {
-		pid, uri, err := proxy.start(d.sandbox, proxyParams{})
-		if d.expectError {
-			assert.Error(err)
-			continue
-		}
-
-		assert.NoError(err)
-		assert.True(pid > 0)
-		assert.Equal(d.expectedURI, uri)
-	}
+	testProxyStart(t, nil, proxy, CCProxyType)
 }

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -43,7 +43,13 @@ func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, er
 		return -1, "", err
 	}
 
-	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", params.agentURL}
+	args := []string{
+		config.Path,
+		"-listen-socket", proxyURL,
+		"-mux-socket", params.agentURL,
+		"-sandbox", sandbox.ID(),
+	}
+
 	if config.Debug {
 		args = append(args, "-log", "debug")
 		console, err := sandbox.hypervisor.getSandboxConsole(sandbox.id)

--- a/virtcontainers/kata_proxy_test.go
+++ b/virtcontainers/kata_proxy_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+func TestKataProxyStart(t *testing.T) {
+	agent := &kataAgent{}
+	proxy := &kataProxy{}
+
+	testProxyStart(t, agent, proxy, KataProxyType)
+}


### PR DESCRIPTION
Add the `-sandbox` option when launching the proxy. This isn't strictly
required by the proxy, but is extremely useful for log analysis to allow
log entries to be matched to sandboxes as the proxy will add a
`sandbox` field in each log entry.

Fixes #463.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>