### PR TITLE
qemu: Pass sandboxID to agent for logging purposes

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -297,10 +297,14 @@ func (q *qemu) createSandbox(sandboxConfig SandboxConfig) error {
 		return err
 	}
 
+	// Pass the sandbox name to the agent via the kernel command-line to
+	// allow the agent to use it in log messages.
+	params := q.kernelParameters() + " " + "agent.sandbox=" + sandboxConfig.ID
+
 	kernel := govmmQemu.Kernel{
 		Path:       kernelPath,
 		InitrdPath: initrdPath,
-		Params:     q.kernelParameters(),
+		Params:     params,
 	}
 
 	rtc := govmmQemu.RTC{


### PR DESCRIPTION
Add a kernel command-line option that the agent can read to determine
the sandbox ID of the VM. It can use this to create a `sandbox=` log
field for improved log analysis.

Fixes #465.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>