### PR TITLE
logging: Reset external loggers when cid+sid available

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -16,7 +16,6 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -283,11 +282,7 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 
 func createCgroupsFiles(containerID string, cgroupsDirPath string, cgroupsPathList []string, pid int) error {
 	if len(cgroupsPathList) == 0 {
-		fields := logrus.Fields{
-			"container": containerID,
-			"pid":       pid,
-		}
-		kataLog.WithFields(fields).Info("Cgroups files not created because cgroupsPath was empty")
+		kataLog.WithField("pid", pid).Info("Cgroups files not created because cgroupsPath was empty")
 		return nil
 	}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -89,6 +89,7 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 	var err error
 
 	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
 
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	if bundlePath, err = validCreateParams(containerID, bundlePath); err != nil {
@@ -240,6 +241,7 @@ func createSandbox(ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
 	}
 
 	kataLog = kataLog.WithField("sandbox", sandbox.ID())
+	setExternalLoggers(kataLog)
 
 	containers := sandbox.GetAllContainers()
 	if len(containers) != 1 {
@@ -267,6 +269,7 @@ func createContainer(ociSpec oci.CompatOCISpec, containerID, bundlePath,
 	}
 
 	kataLog = kataLog.WithField("sandbox", sandboxID)
+	setExternalLoggers(kataLog)
 
 	_, c, err := vci.CreateContainer(sandboxID, contConfig)
 	if err != nil {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -64,6 +64,8 @@ func delete(containerID string, force bool) error {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	containerID = status.ID
 
 	containerType, err := oci.GetContainerType(status.Annotations)

--- a/cli/events.go
+++ b/cli/events.go
@@ -156,6 +156,8 @@ information is displayed once every 5 seconds.`,
 			"sandbox":   sandboxID,
 		})
 
+		setExternalLoggers(kataLog)
+
 		if status.State.State == vc.StateStopped {
 			return fmt.Errorf("container with id %s is not running", status.ID)
 		}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -194,6 +194,8 @@ func execute(context *cli.Context) error {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	// Retrieve OCI spec configuration.
 	ociSpec, err := oci.GetOCIConfig(status)
 	if err != nil {

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -104,6 +104,8 @@ func kill(containerID, signal string, all bool) error {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	signum, err := processSignal(signal)
 	if err != nil {
 		return err

--- a/cli/main.go
+++ b/cli/main.go
@@ -187,6 +187,16 @@ func setupSignalHandler() {
 	}()
 }
 
+// setExternalLoggers registers the specified logger with the external
+// packages which accept a logger to handle their own logging.
+func setExternalLoggers(logger *logrus.Entry) {
+	// Set virtcontainers logger.
+	vci.SetLogger(logger)
+
+	// Set the OCI package logger.
+	oci.SetLogger(logger)
+}
+
 // beforeSubcommands is the function to perform preliminary checks
 // before command-line parsing occurs.
 func beforeSubcommands(context *cli.Context) error {
@@ -225,11 +235,7 @@ func beforeSubcommands(context *cli.Context) error {
 		return fmt.Errorf("unknown log-format %q", context.GlobalString("log-format"))
 	}
 
-	// Set virtcontainers logger.
-	vci.SetLogger(kataLog)
-
-	// Set the OCI package logger.
-	oci.SetLogger(kataLog)
+	setExternalLoggers(kataLog)
 
 	ignoreLogging := false
 

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -55,6 +55,8 @@ func toggleContainerPause(containerID string, pause bool) (err error) {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	if pause {
 		err = vci.PauseContainer(sandboxID, containerID)
 	} else {

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -61,6 +61,8 @@ func ps(containerID, format string, args []string) error {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	// container MUST be running
 	if status.State.State != vc.StateRunning {
 		return fmt.Errorf("Container %s is not running", containerID)

--- a/cli/start.go
+++ b/cli/start.go
@@ -52,6 +52,8 @@ func start(containerID string) (vc.VCSandbox, error) {
 		"sandbox":   sandboxID,
 	})
 
+	setExternalLoggers(kataLog)
+
 	containerID = status.ID
 
 	containerType, err := oci.GetContainerType(status.Annotations)

--- a/cli/state.go
+++ b/cli/state.go
@@ -36,6 +36,8 @@ instance of a container.`,
 func state(containerID string) error {
 	kataLog = kataLog.WithField("container", containerID)
 
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, _, err := getExistingContainerInfo(containerID)
 	if err != nil {


### PR DESCRIPTION
Once `containerID` and `sandboxID` fields are available, re-register the logger with the external packages to ensure they too display these important fields.

Fixes #467.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
