### PR TITLE
cli: add AMD support

### DIFF
--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -283,6 +283,8 @@ var kataCheckCLICommand = cli.Command{
 	Usage: "tests if system can run " + project,
 	Action: func(context *cli.Context) error {
 
+		setCPUtype()
+
 		details := vmContainerCapableDetails{
 			cpuInfoFile:           procCPUInfo,
 			requiredCPUFlags:      archRequiredCPUFlags,

--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -7,52 +7,124 @@ package main
 
 import (
 	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"strings"
 )
 
 const (
 	cpuFlagsTag        = genericCPUFlagsTag
 	archCPUVendorField = genericCPUVendorField
 	archCPUModelField  = genericCPUModelField
+	archGenuineIntel   = "GenuineIntel"
+	archAuthenticAMD   = "AuthenticAMD"
+	msgKernelVM        = "Kernel-based Virtual Machine"
+	msgKernelVirtio    = "Host kernel accelerator for virtio"
+	msgKernelVirtioNet = "Host kernel accelerator for virtio network"
 )
+
+// CPU types
+const (
+	cpuTypeIntel   = 0
+	cpuTypeAMD     = 1
+	cpuTypeUnknown = -1
+)
+
+// cpuType save the CPU type
+var cpuType int
 
 // archRequiredCPUFlags maps a CPU flag value to search for and a
 // human-readable description of that value.
-var archRequiredCPUFlags = map[string]string{
-	"vmx":    "Virtualization support",
-	"lm":     "64Bit CPU",
-	"sse4_1": "SSE4.1",
-}
+var archRequiredCPUFlags map[string]string
 
 // archRequiredCPUAttribs maps a CPU (non-CPU flag) attribute value to search for
 // and a human-readable description of that value.
-var archRequiredCPUAttribs = map[string]string{
-	"GenuineIntel": "Intel Architecture CPU",
-}
+var archRequiredCPUAttribs map[string]string
 
 // archRequiredKernelModules maps a required module name to a human-readable
 // description of the modules functionality and an optional list of
 // required module parameters.
-var archRequiredKernelModules = map[string]kernelModule{
-	"kvm": {
-		desc: "Kernel-based Virtual Machine",
-	},
-	"kvm_intel": {
-		desc: "Intel KVM",
-		parameters: map[string]string{
-			"nested": "Y",
-			// "VMX Unrestricted mode support". This is used
-			// as a heuristic to determine if the system is
-			// "new enough" to run a Kata Container
-			// (atleast a Westmere).
-			"unrestricted_guest": "Y",
-		},
-	},
-	"vhost": {
-		desc: "Host kernel accelerator for virtio",
-	},
-	"vhost_net": {
-		desc: "Host kernel accelerator for virtio network",
-	},
+var archRequiredKernelModules map[string]kernelModule
+
+func setCPUtype() {
+	cpuType = getCPUtype()
+
+	if cpuType == cpuTypeUnknown {
+		kataLog.Fatal("Unknown CPU Type")
+		exit(1)
+	} else if cpuType == cpuTypeIntel {
+		archRequiredCPUFlags = map[string]string{
+			"vmx":    "Virtualization support",
+			"lm":     "64Bit CPU",
+			"sse4_1": "SSE4.1",
+		}
+		archRequiredCPUAttribs = map[string]string{
+			archGenuineIntel: "Intel Architecture CPU",
+		}
+		archRequiredKernelModules = map[string]kernelModule{
+			"kvm": {
+				desc: msgKernelVM,
+			},
+			"kvm_intel": {
+				desc: "Intel KVM",
+				parameters: map[string]string{
+					"nested": "Y",
+					// "VMX Unrestricted mode support". This is used
+					// as a heuristic to determine if the system is
+					// "new enough" to run a Kata Container
+					// (atleast a Westmere).
+					"unrestricted_guest": "Y",
+				},
+			},
+			"vhost": {
+				desc: msgKernelVirtio,
+			},
+			"vhost_net": {
+				desc: msgKernelVirtioNet,
+			},
+		}
+	} else if cpuType == cpuTypeAMD {
+		archRequiredCPUFlags = map[string]string{
+			"svm":    "Virtualization support",
+			"lm":     "64Bit CPU",
+			"sse4_1": "SSE4.1",
+		}
+		archRequiredCPUAttribs = map[string]string{
+			archAuthenticAMD: "AMD Architecture CPU",
+		}
+		archRequiredKernelModules = map[string]kernelModule{
+			"kvm": {
+				desc: msgKernelVM,
+			},
+			"kvm_amd": {
+				desc: "AMD KVM",
+				parameters: map[string]string{
+					"nested": "1",
+				},
+			},
+			"vhost": {
+				desc: msgKernelVirtio,
+			},
+			"vhost_net": {
+				desc: msgKernelVirtioNet,
+			},
+		}
+	}
+}
+
+func getCPUtype() int {
+	content, err := ioutil.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		kataLog.WithError(err).Error("failed to read file")
+		return cpuTypeUnknown
+	}
+	str := string(content)
+	if strings.Contains(str, archGenuineIntel) {
+		return cpuTypeIntel
+	} else if strings.Contains(str, archAuthenticAMD) {
+		return cpuTypeAMD
+	} else {
+		return cpuTypeUnknown
+	}
 }
 
 // kvmIsUsable determines if it will be possible to create a full virtual machine

--- a/cli/kata-check_arm64.go
+++ b/cli/kata-check_arm64.go
@@ -40,6 +40,9 @@ var archRequiredKernelModules = map[string]kernelModule{
 	},
 }
 
+func setCPUtype() {
+}
+
 // kvmIsUsable determines if it will be possible to create a full virtual machine
 // by creating a minimal VM and then deleting it.
 func kvmIsUsable() error {

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -44,6 +44,9 @@ var archRequiredKernelModules = map[string]kernelModule{
 	},
 }
 
+func setCPUtype() {
+}
+
 func archHostCanCreateVMContainer() error {
 	return kvmIsUsable()
 }


### PR DESCRIPTION
Please review.

This is a patch to add AMD architecture support to kata-runtime.

Tested "kata-runtime kata-check" on both Intel and AMD machines.

There is not a 1:1 match between Intel and AMD virtualization and cpuinfo (i.e. no "unrestricted_guest" in AMD), so not sure what to do with some of the cpuinfo checks.

Also, new to go language and this is my first go language patch.

Ran gofmt on the changes.
