### PR TITLE
Fix no exit static check

### DIFF
--- a/.ci/go-no-os-exit.sh
+++ b/.ci/go-no-os-exit.sh
@@ -2,8 +2,13 @@
 # Copyright (c) 2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Check there are no os.Exit() calls creeping into the code
+# We don't use that exit path in the Kata codebase.
 
 go_packages=.
+
+echo "Checking for no os.Exit() calls for package [${go_packages}]"
 
 candidates=`go list -f '{{.Dir}}/*.go' $go_packages`
 for f in $candidates; do

--- a/.ci/go-no-os-exit.sh
+++ b/.ci/go-no-os-exit.sh
@@ -22,6 +22,8 @@ for f in $candidates; do
 	files="$f $files"
 done
 
+[ -z "$files" ] && echo "No files to check, skipping" && exit 0
+
 if egrep -n '\<os\.Exit\>' $files; then
 	echo "Direct calls to os.Exit() are forbidden, please use exit() so atexit() works"
 	exit 1

--- a/.ci/go-no-os-exit.sh
+++ b/.ci/go-no-os-exit.sh
@@ -6,7 +6,9 @@
 # Check there are no os.Exit() calls creeping into the code
 # We don't use that exit path in the Kata codebase.
 
-go_packages=.
+# Allow the path to check to be over-ridden.
+# Default to the current directory.
+go_packages=${1:-.}
 
 echo "Checking for no os.Exit() calls for package [${go_packages}]"
 

--- a/.ci/go-no-os-exit.sh
+++ b/.ci/go-no-os-exit.sh
@@ -15,12 +15,10 @@ echo "Checking for no os.Exit() calls for package [${go_packages}]"
 candidates=`go list -f '{{.Dir}}/*.go' $go_packages`
 for f in $candidates; do
 	filename=`basename $f`
+	# skip all go test files
+	[[ $filename == *_test.go ]] && continue
 	# skip exit.go where, the only file we should call os.Exit() from.
 	[[ $filename == "exit.go" ]] && continue
-	# skip exit_test.go
-	[[ $filename == "exit_test.go" ]] && continue
-	# skip main_test.go
-	[[ $filename == "main_test.go" ]] && continue
 	files="$f $files"
 done
 

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,8 @@ go-test: $(GENERATED_FILES)
 
 check-go-static:
 	$(QUIET_CHECK).ci/static-checks.sh
-	$(QUIET_CHECK).ci/go-no-os-exit.sh
+	$(QUIET_CHECK).ci/go-no-os-exit.sh ./cli
+	$(QUIET_CHECK).ci/go-no-os-exit.sh ./virtcontainers
 
 coverage:
 	$(QUIET_TEST).ci/go-test.sh html-coverage


### PR DESCRIPTION
The `go-no-os-exit` check seems to have bitrotted, and silently passes.
This looks to have come about when we moved the runtime code into the `cli` subdir.
Whilst there, we should get it to check virtcontainers as well.