### PR TITLE
makefile: update PREFIX to remove redundant slash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ DESTDIR := /
 installing = $(findstring install,$(MAKECMDGOALS))
 
 ifeq ($(PREFIX),)
-PREFIX        := /usr/
+PREFIX        := /usr
 EXEC_PREFIX   := $(PREFIX)/local
 else
 EXEC_PREFIX   := $(PREFIX)


### PR DESCRIPTION
Resulting configuration file would have an extra '/' in it.  This PR removes the redundant slash from the prefix.