### PR TITLE
kata_agent: print request details

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1269,6 +1269,8 @@ func (k *kataAgent) sendReq(request interface{}) (interface{}, error) {
 	if msgName == "" || handler == nil {
 		return nil, errors.New("Invalid request type")
 	}
+	message := request.(proto.Message)
+	k.Logger().WithField("name", msgName).WithField("req", message.String()).Debug("sending request")
 
 	return handler(context.Background(), request)
 }


### PR DESCRIPTION
It helps tracking each request that is sent and we can match with the
one printed by kata-agent on the guest side to find out any stack
requests in the middle.