### PR TITLE
Ensure tests clean their tempfiles

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -121,7 +121,7 @@ func TestDeleteInvalidConfig(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 }
 
-func testConfigSetup(t *testing.T) string {
+func testConfigSetup(t *testing.T) (rootPath string, configPath string) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -135,8 +135,8 @@ func testConfigSetup(t *testing.T) string {
 	assert.NoError(err)
 
 	// config json path
-	configPath := filepath.Join(bundlePath, "config.json")
-	return configPath
+	configPath = filepath.Join(bundlePath, "config.json")
+	return tmpdir, configPath
 }
 
 func TestDeleteSandbox(t *testing.T) {
@@ -146,7 +146,8 @@ func TestDeleteSandbox(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -223,7 +224,8 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -261,7 +263,8 @@ func TestDeleteSandboxRunning(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -340,7 +343,8 @@ func TestDeleteRunningContainer(t *testing.T) {
 		},
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -422,7 +426,8 @@ func TestDeleteContainer(t *testing.T) {
 		},
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -523,7 +528,8 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 		},
 	}
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -89,7 +89,8 @@ func TestExecuteErrors(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 
 	// Container state undefined
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -147,7 +148,8 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -195,7 +197,8 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -261,7 +264,8 @@ func TestExecuteWithFlags(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -349,7 +353,8 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -427,7 +432,8 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -478,7 +484,8 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 
@@ -578,7 +585,8 @@ func TestExecuteWithEmptyEnvironmentValue(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 
-	configPath := testConfigSetup(t)
+	rootPath, configPath := testConfigSetup(t)
+	defer os.RemoveAll(rootPath)
 	configJSON, err := readOCIConfigJSON(configPath)
 	assert.NoError(err)
 

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -168,6 +168,7 @@ func testRunContainerSetup(t *testing.T) runContainerData {
 	assert.NoError(err, "unable to start fake container workload %+v: %s", workload, err)
 
 	// temporal dir to place container files
+	// Note - it is returned to the caller, who does the defer remove to clean up.
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
 

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -111,6 +111,7 @@ func TestUpdateCLIFailure(t *testing.T) {
 
 	// json decode error
 	f, err := ioutil.TempFile("", "resources")
+	defer os.Remove(f.Name())
 	assert.NoError(err)
 	assert.NotNil(f)
 	f.WriteString("no json")


### PR DESCRIPTION
A number of tests were not cleaning up after themselves, which left
a bunch of files in the TMPDIR.
Ensure we remove all the tmpfiles and dirs we create.