### PR TITLE
Use VSOCK when is available in the host.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -92,7 +92,7 @@
 [[projects]]
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "ff2401825e0930811919c86c36d64b113aa00083"
+  revision = "6ff20ae2f409df976574d0139b5ec2fa3e314769"
 
 [[projects]]
   name = "github.com/kata-containers/agent"
@@ -264,6 +264,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ea3d6532c4375832a1c79d70af45e6722e526bde97f6caf23d90b91267a3cf0b"
+  inputs-digest = "f57c595789df5fbc01e237cc52c7454911dbc37b9282304b6b1f076606e4c157"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "ff2401825e0930811919c86c36d64b113aa00083"
+  revision = "6ff20ae2f409df976574d0139b5ec2fa3e314769"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/cli/config.go
+++ b/cli/config.go
@@ -428,8 +428,9 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 
 		case kataAgentTableType:
 			config.AgentType = kataAgentTableType
-			config.AgentConfig = vc.KataAgentConfig{}
-
+			config.AgentConfig = vc.KataAgentConfig{
+				UseVSock: config.HypervisorConfig.UseVSock,
+			}
 		}
 	}
 

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -134,6 +134,12 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # used for 9p packet payload.
 #msize_9p = @DEFMSIZE9P@
 
+# If true and vsocks are supported, use vsocks to communicate directly
+# with the agent and no proxy is started, otherwise use unix
+# sockets and start a proxy to communicate with the agent.
+# Default false
+#use_vsock = true
+
 [factory]
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -11,19 +11,20 @@ import (
 	"os"
 	"strings"
 
+	runtim "runtime"
+
 	"github.com/BurntSushi/toml"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
-	runtim "runtime"
 )
 
 // Semantic version for the output of the command.
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.12"
+const formatVersion = "1.0.13"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -80,6 +81,7 @@ type HypervisorInfo struct {
 	BlockDeviceDriver string
 	Msize9p           uint32
 	Debug             bool
+	UseVSock          bool
 }
 
 // ProxyInfo stores proxy details
@@ -276,6 +278,7 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 		Path:              hypervisorPath,
 		BlockDeviceDriver: config.HypervisorConfig.BlockDeviceDriver,
 		Msize9p:           config.HypervisorConfig.Msize9p,
+		UseVSock:          config.HypervisorConfig.UseVSock,
 	}
 }
 

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -214,6 +214,10 @@ func getHostInfo() (HostInfo, error) {
 }
 
 func getProxyInfo(config oci.RuntimeConfig) (ProxyInfo, error) {
+	if config.ProxyType == vc.NoProxyType {
+		return ProxyInfo{Type: string(config.ProxyType)}, nil
+	}
+
 	version, err := getCommandVersion(defaultProxyPath)
 	if err != nil {
 		version = unknown

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -82,6 +82,9 @@ const (
 
 	// VirtioSerialPort is the serial port device driver.
 	VirtioSerialPort = "virtserialport"
+
+	// VHostVSockPCI is the vhost vsock pci driver.
+	VHostVSockPCI = "vhost-vsock-pci"
 )
 
 // ObjectType is a string representing a qemu object type.
@@ -962,6 +965,12 @@ type VSOCKDevice struct {
 	ID string
 
 	ContextID uint32
+
+	// VHostFD vhost file descriptor that holds the ContextID
+	VHostFD *os.File
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 const (
@@ -986,12 +995,22 @@ func (vsock VSOCKDevice) Valid() bool {
 
 // QemuParams returns the qemu parameters built out of the VSOCK device.
 func (vsock VSOCKDevice) QemuParams(config *Config) []string {
+	var deviceParams []string
 	var qemuParams []string
 
-	deviceParam := fmt.Sprintf("%s,id=%s,%s=%d", VhostVSOCKPCI, vsock.ID, VSOCKGuestCID, vsock.ContextID)
+	deviceParams = append(deviceParams, fmt.Sprintf("%s", VhostVSOCKPCI))
+	if vsock.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
+	if vsock.VHostFD != nil {
+		qemuFDs := config.appendFDs([]*os.File{vsock.VHostFD})
+		deviceParams = append(deviceParams, fmt.Sprintf(",vhostfd=%d", qemuFDs[0]))
+	}
+	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", vsock.ID))
+	deviceParams = append(deviceParams, fmt.Sprintf(",%s=%d", VSOCKGuestCID, vsock.ContextID))
 
 	qemuParams = append(qemuParams, "-device")
-	qemuParams = append(qemuParams, deviceParam)
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ""))
 
 	return qemuParams
 }

--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -881,3 +881,13 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 
 	return err
 }
+
+// ExecutePCIVSockAdd adds a vhost-vsock-pci bus
+func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID string) error {
+	args := map[string]interface{}{
+		"driver":    VHostVSockPCI,
+		"id":        id,
+		"guest-cid": guestCID,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}

--- a/virtcontainers/agent_test.go
+++ b/virtcontainers/agent_test.go
@@ -128,7 +128,7 @@ func TestNewAgentConfigFromHyperstartAgentType(t *testing.T) {
 }
 
 func TestNewAgentConfigFromKataAgentType(t *testing.T) {
-	agentConfig := KataAgentConfig{}
+	agentConfig := KataAgentConfig{UseVSock: true}
 
 	sandboxConfig := SandboxConfig{
 		AgentType:   KataContainersAgent,

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -68,6 +68,9 @@ const (
 	// SerialPortDev is the serial port device type.
 	serialPortDev
 
+	// vSockPCIDev is the vhost vsock PCI device type.
+	vSockPCIDev
+
 	// VFIODevice is VFIO device type
 	vfioDev
 

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -217,6 +217,9 @@ type HypervisorConfig struct {
 	// Msize9p is used as the msize for 9p shares
 	Msize9p uint32
 
+	// UseVSock use a vsock for agent communication
+	UseVSock bool
+
 	// BootToBeTemplate used to indicate if the VM is created to be a template VM
 	BootToBeTemplate bool
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -59,7 +59,6 @@ var (
 // KataAgentConfig is a structure storing information needed
 // to reach the Kata Containers agent.
 type KataAgentConfig struct {
-	GRPCSocket   string
 	LongLiveConn bool
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -99,27 +99,6 @@ func (k *kataAgent) Logger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "kata_agent")
 }
 
-func parseVSOCKAddr(sock string) (uint32, uint32, error) {
-	sp := strings.Split(sock, ":")
-	if len(sp) != 3 {
-		return 0, 0, fmt.Errorf("Invalid vsock address: %s", sock)
-	}
-	if sp[0] != vsockSocketScheme {
-		return 0, 0, fmt.Errorf("Invalid vsock URL scheme: %s", sp[0])
-	}
-
-	cid, err := strconv.ParseUint(sp[1], 10, 32)
-	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid vsock cid: %s", sp[1])
-	}
-	port, err := strconv.ParseUint(sp[2], 10, 32)
-	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid vsock port: %s", sp[2])
-	}
-
-	return uint32(cid), uint32(port), nil
-}
-
 func (k *kataAgent) getVMPath(id string) string {
 	return filepath.Join(RunVMStoragePath, id)
 }

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1200,6 +1200,7 @@ func (k *kataAgent) connect() error {
 		return nil
 	}
 
+	k.Logger().WithField("url", k.state.URL).Info("New client")
 	client, err := kataclient.NewAgentClient(k.state.URL, k.proxyBuiltIn)
 	if err != nil {
 		return err

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -671,13 +671,11 @@ func TestAgentPathAPI(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(k1, k2)
 
-	c.GRPCSocket = "unixsocket"
 	err = k1.generateVMSocket(id, c)
 	assert.Nil(err)
 	_, ok := k1.vmSocket.(Socket)
 	assert.True(ok)
 
-	c.GRPCSocket = "vsock:100:200"
 	err = k2.generateVMSocket(id, c)
 	assert.Nil(err)
 	_, ok = k2.vmSocket.(kataVSOCK)
@@ -692,7 +690,7 @@ func TestAgentConfigure(t *testing.T) {
 
 	k := &kataAgent{}
 	h := &mockHypervisor{}
-	c := KataAgentConfig{GRPCSocket: "vsock:100:200"}
+	c := KataAgentConfig{}
 	id := "foobar"
 
 	invalidAgent := HyperConfig{}
@@ -702,7 +700,6 @@ func TestAgentConfigure(t *testing.T) {
 	err = k.configure(h, id, dir, true, c)
 	assert.Nil(err)
 
-	c.GRPCSocket = "foobarfoobar"
 	err = k.configure(h, id, dir, true, c)
 	assert.Nil(err)
 

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -708,36 +708,6 @@ func TestAgentConfigure(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestParseVSOCKAddr(t *testing.T) {
-	assert := assert.New(t)
-
-	sock := "randomfoobar"
-	_, _, err := parseVSOCKAddr(sock)
-	assert.Error(err)
-
-	sock = "vsock://1:2"
-	_, _, err = parseVSOCKAddr(sock)
-	assert.Error(err)
-
-	sock = "unix:1:2"
-	_, _, err = parseVSOCKAddr(sock)
-	assert.Error(err)
-
-	sock = "vsock:foo:2"
-	_, _, err = parseVSOCKAddr(sock)
-	assert.Error(err)
-
-	sock = "vsock:1:bar"
-	_, _, err = parseVSOCKAddr(sock)
-	assert.Error(err)
-
-	sock = "vsock:1:2"
-	cid, port, err := parseVSOCKAddr(sock)
-	assert.Nil(err)
-	assert.Equal(cid, uint32(1))
-	assert.Equal(port, uint32(2))
-}
-
 func TestCmdToKataProcess(t *testing.T) {
 	assert := assert.New(t)
 

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -676,6 +676,7 @@ func TestAgentPathAPI(t *testing.T) {
 	_, ok := k1.vmSocket.(Socket)
 	assert.True(ok)
 
+	c.UseVSock = true
 	err = k2.generateVMSocket(id, c)
 	assert.Nil(err)
 	_, ok = k2.vmSocket.(kataVSOCK)

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -24,6 +24,7 @@ func (p *kataProxy) consoleWatched() bool {
 
 // start is kataProxy start implementation for proxy interface.
 func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
+	sandbox.Logger().Info("Starting regular Kata proxy rather than built-in")
 	if sandbox.agent == nil {
 		return -1, "", fmt.Errorf("No agent")
 	}

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -24,6 +24,7 @@ type noProxy struct {
 
 // start is noProxy start implementation for proxy interface.
 func (p *noProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
+	sandbox.Logger().Info("No proxy started because of no-proxy implementation")
 	if params.agentURL == "" {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -68,6 +68,9 @@ type qemuArch interface {
 	// appendSocket appends a socket to devices
 	appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device
 
+	// appendVSockPCI appends a vsock PCI to devices
+	appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOCK) []govmmQemu.Device
+
 	// appendNetwork appends a endpoint device to devices
 	appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device
 
@@ -387,6 +390,20 @@ func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket Socket) [
 	)
 
 	return devices
+}
+
+func (q *qemuArchBase) appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOCK) []govmmQemu.Device {
+	devices = append(devices,
+		govmmQemu.VSOCKDevice{
+			ID:            fmt.Sprintf("vsock-%d", vsock.contextID),
+			ContextID:     vsock.contextID,
+			VHostFD:       vsock.vhostFd,
+			DisableModern: q.nestedRun,
+		},
+	)
+
+	return devices
+
 }
 
 func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType {

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -246,6 +246,28 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
 }
 
+func TestQemuAddDeviceKataVSOCK(t *testing.T) {
+	contextID := uint32(3)
+	port := uint32(1024)
+	vHostFD := os.NewFile(1, "vsock")
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VSOCKDevice{
+			ID:        fmt.Sprintf("vsock-%d", contextID),
+			ContextID: contextID,
+			VHostFD:   vHostFD,
+		},
+	}
+
+	vsock := kataVSOCK{
+		contextID: contextID,
+		port:      port,
+		vhostFd:   vHostFD,
+	}
+
+	testQemuAddDevice(t, vsock, vSockPCIDev, expectedOut)
+}
+
 func TestQemuGetSandboxConsole(t *testing.T) {
 	q := &qemu{}
 	sandboxID := "testSandboxID"

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -23,6 +23,12 @@ const fileMode0755 = os.FileMode(0755)
 // See unix(7).
 const MaxSocketPathLen = 107
 
+// VSockDevicePath path to vsock device
+var VSockDevicePath = "/dev/vsock"
+
+// VHostVSockDevicePath path to vhost-vsock device
+var VHostVSockDevicePath = "/dev/vhost-vsock"
+
 // FileCopy copys files from srcPath to dstPath
 func FileCopy(srcPath, dstPath string) error {
 	if srcPath == "" {
@@ -199,4 +205,17 @@ func BuildSocketPath(elements ...string) (string, error) {
 	}
 
 	return result, nil
+}
+
+// SupportsVsocks returns true if vsocks are supported, otherwise false
+func SupportsVsocks() bool {
+	if _, err := os.Stat(VSockDevicePath); err != nil {
+		return false
+	}
+
+	if _, err := os.Stat(VHostVSockDevicePath); err != nil {
+		return false
+	}
+
+	return true
 }

--- a/virtcontainers/utils/utils_linux.go
+++ b/virtcontainers/utils/utils_linux.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// from <linux/vhost.h>
+// VHOST_VSOCK_SET_GUEST_CID = _IOW(VHOST_VIRTIO, 0x60, __u64)
+const ioctlVhostVsockSetGuestCid = 0x4008AF60
+
+var ioctlFunc = ioctl
+
+var maxUInt uint32 = 1<<32 - 1
+
+func ioctl(fd uintptr, request int, arg1 uint32) error {
+	if _, _, errno := unix.Syscall(
+		unix.SYS_IOCTL,
+		fd,
+		uintptr(request),
+		uintptr(unsafe.Pointer(&arg1)),
+	); errno != 0 {
+		return os.NewSyscallError("ioctl", fmt.Errorf("%d", int(errno)))
+	}
+
+	return nil
+}
+
+// FindContextID finds a unique context ID by generating a random number between 3 and max unsigned int (maxUint).
+// Using the ioctl VHOST_VSOCK_SET_GUEST_CID, findContextID asks to the kernel if the given
+// context ID (N) is available, when the context ID is not available, incrementing by 1 findContextID
+// iterates from N to maxUint until an available context ID is found, otherwise decrementing by 1
+// findContextID iterates from N to 3 until an available context ID is found, this is the last chance
+// to find a context ID available.
+// On success vhost file and a context ID greater or equal than 3 are returned, otherwise 0 and an error are returned.
+// vhost file can be used to send vhost file decriptor to QEMU. It's the caller's responsibility to
+// close vhost file descriptor.
+//
+// Benefits of using random context IDs:
+// - Reduce the probability of a *DoS attack*, since other processes don't know whatis the initial context ID
+//   used by findContextID to find a context ID available
+//
+func FindContextID() (*os.File, uint32, error) {
+	// context IDs 0x0, 0x1 and 0x2 are reserved, 0x3 is the first context ID usable.
+	var firstContextID uint32 = 0x3
+	var contextID = firstContextID
+
+	// Generate a random number
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(maxUInt)))
+	if err == nil && n.Int64() >= int64(firstContextID) {
+		contextID = uint32(n.Int64())
+	}
+
+	// Open vhost-vsock device to check what context ID is available.
+	// This file descriptor holds/locks the context ID and it should be
+	// inherited by QEMU process.
+	vsockFd, err := os.OpenFile(VHostVSockDevicePath, syscall.O_RDWR, 0666)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Looking for the first available context ID.
+	for cid := contextID; cid <= maxUInt; cid++ {
+		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
+			return vsockFd, cid, nil
+		}
+	}
+
+	// Last chance to get a free context ID.
+	for cid := contextID - 1; cid >= firstContextID; cid-- {
+		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
+			return vsockFd, cid, nil
+		}
+	}
+
+	vsockFd.Close()
+	return nil, 0, fmt.Errorf("Could not get a unique context ID for the vsock")
+}

--- a/virtcontainers/utils/utils_linux_test.go
+++ b/virtcontainers/utils/utils_linux_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindContextID(t *testing.T) {
+	assert := assert.New(t)
+
+	ioctlFunc = func(fd uintptr, request int, arg1 uint32) error {
+		return errors.New("ioctl")
+	}
+
+	orgVHostVSockDevicePath := VHostVSockDevicePath
+	orgMaxUInt := maxUInt
+	defer func() {
+		VHostVSockDevicePath = orgVHostVSockDevicePath
+		maxUInt = orgMaxUInt
+	}()
+	VHostVSockDevicePath = "/dev/null"
+	maxUInt = uint32(1000000)
+
+	f, cid, err := FindContextID()
+	assert.Nil(f)
+	assert.Zero(cid)
+	assert.Error(err)
+}

--- a/virtcontainers/utils/utils_test.go
+++ b/virtcontainers/utils/utils_test.go
@@ -294,3 +294,34 @@ func TestBuildSocketPath(t *testing.T) {
 		assert.Equal(d.expected, result)
 	}
 }
+
+func TestSupportsVsocks(t *testing.T) {
+	assert := assert.New(t)
+
+	orgVSockDevicePath := VSockDevicePath
+	orgVHostVSockDevicePath := VHostVSockDevicePath
+	defer func() {
+		VSockDevicePath = orgVSockDevicePath
+		VHostVSockDevicePath = orgVHostVSockDevicePath
+	}()
+
+	VSockDevicePath = "/abc/xyz/123"
+	VHostVSockDevicePath = "/abc/xyz/123"
+	assert.False(SupportsVsocks())
+
+	vSockDeviceFile, err := ioutil.TempFile("", "vsock")
+	assert.NoError(err)
+	defer os.Remove(vSockDeviceFile.Name())
+	defer vSockDeviceFile.Close()
+	VSockDevicePath = vSockDeviceFile.Name()
+
+	assert.False(SupportsVsocks())
+
+	vHostVSockFile, err := ioutil.TempFile("", "vhost-vsock")
+	assert.NoError(err)
+	defer os.Remove(vHostVSockFile.Name())
+	defer vHostVSockFile.Close()
+	VHostVSockDevicePath = vHostVSockFile.Name()
+
+	assert.True(SupportsVsocks())
+}


### PR DESCRIPTION
This PR completes the support to use vsock and no proxy configuration.

In order to create add VSOCK support we added:

- coldplug support for VSOCK socket device.
- Implemented a way to find a context ID based in a random search.
 A random  number  is generated between 3 and max `uint32` (4'294,967,295)
and uses it as context ID. The range is large enough to have a low collision probability. Using `ioctl` checks if the context ID is free, else find the immediate next free context ID.

- When the hypervisor option `use_vsock` is true the runtime will check for vsock support . If vsock is supported, not proxy will be used and the shims will connect to the VM using VSOCKS. This flag is true by default, so will use VSOCK when possible.

- The `kata-env` subcommand now shows information about if VSOCK will be used or not. 

fixes #383

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
Signed-off-by: Julio Montes <julio.montes@intel.com>


