### PR TITLE
cli: create vm factory if failed to load existing one

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -120,8 +120,13 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 		kataLog.WithField("factory", factoryConfig).Info("load vm factory")
 		f, err := vf.NewFactory(factoryConfig, true)
 		if err != nil {
-			kataLog.WithError(err).Info("load vm factory failed")
-		} else {
+			kataLog.WithError(err).Warn("load vm factory failed, about to create new one")
+			f, err = vf.NewFactory(factoryConfig, false)
+			if err != nil {
+				kataLog.WithError(err).Warn("create vm factory failed")
+			}
+		}
+		if err != nil {
 			vci.SetFactory(f)
 		}
 	}


### PR DESCRIPTION
When vm factory is enabled, create vm factory automatically
during creation.

Fixes: #504
