### PR TITLE
network: Add support for macvlan and macvtap driver

### DIFF
--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -230,8 +230,11 @@ func TestCreateVirtualNetworkEndpoint(t *testing.T) {
 	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-4"
 
+	// the resulting mac address will be random - so lets overwrite it
+	result.NetPair.VirtIface.HardAddr = macAddr.String()
+
 	if reflect.DeepEqual(result, expected) == false {
-		t.Fatal()
+		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
 	}
 }
 
@@ -262,8 +265,11 @@ func TestCreateVirtualNetworkEndpointChooseIfaceName(t *testing.T) {
 	// the resulting ID will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-4"
 
+	// the resulting mac address will be random - so lets overwrite it
+	result.NetPair.VirtIface.HardAddr = macAddr.String()
+
 	if reflect.DeepEqual(result, expected) == false {
-		t.Fatal()
+		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
 	}
 }
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -441,20 +441,21 @@ func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType 
 
 func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device {
 	switch ep := endpoint.(type) {
-	case *VirtualEndpoint:
+	case *VirtualEndpoint, *BridgedMacvlanEndpoint:
+		netPair := ep.NetworkPair()
 		devices = append(devices,
 			govmmQemu.NetDevice{
-				Type:          networkModelToQemuType(ep.NetPair.NetInterworkingModel),
+				Type:          networkModelToQemuType(netPair.NetInterworkingModel),
 				Driver:        govmmQemu.VirtioNetPCI,
 				ID:            fmt.Sprintf("network-%d", q.networkIndex),
-				IFName:        ep.NetPair.TAPIface.Name,
-				MACAddress:    ep.NetPair.TAPIface.HardAddr,
+				IFName:        netPair.TAPIface.Name,
+				MACAddress:    netPair.TAPIface.HardAddr,
 				DownScript:    "no",
 				Script:        "no",
 				VHost:         q.vhost,
 				DisableModern: q.nestedRun,
-				FDs:           ep.NetPair.VMFds,
-				VhostFDs:      ep.NetPair.VhostFds,
+				FDs:           netPair.VMFds,
+				VhostFDs:      netPair.VhostFds,
 			},
 		)
 		q.networkIndex++

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -459,6 +459,24 @@ func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoi
 			},
 		)
 		q.networkIndex++
+	case *MacvtapEndpoint:
+		devices = append(devices,
+			govmmQemu.NetDevice{
+				Type:          govmmQemu.MACVTAP,
+				Driver:        govmmQemu.VirtioNetPCI,
+				ID:            fmt.Sprintf("network-%d", q.networkIndex),
+				IFName:        ep.Name(),
+				MACAddress:    ep.HardwareAddr(),
+				DownScript:    "no",
+				Script:        "no",
+				VHost:         q.vhost,
+				DisableModern: q.nestedRun,
+				FDs:           ep.VMFds,
+				VhostFDs:      ep.VhostFds,
+			},
+		)
+		q.networkIndex++
+
 	}
 
 	return devices


### PR DESCRIPTION
Add support for macvlan driver by bridging it with a macvtap or
tap+bridge and moving the mac and ip address from the
macvlan to the bridged interface.

Fixes #162

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>