### PR TITLE
codecov: Explicitly disable codecov/patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+coverage:
+  status:
+    patch:
+      default:
+        enabled: no


### PR DESCRIPTION
Because codecov coverage regarding the patch is very inconsistent,
this commit introduces codecov.yml config file in order to disable
this check.

Fixes #511

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>