### PR TITLE
agent: Increase timeout for check request.

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1229,8 +1229,12 @@ func (k *kataAgent) disconnect() error {
 	return nil
 }
 
+// check grpc server is serving
 func (k *kataAgent) check() error {
 	_, err := k.sendReq(&grpc.CheckRequest{})
+	if err != nil {
+		err = fmt.Errorf("Failed to check if grpc server is working: %s", err)
+	}
 	return err
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -34,6 +34,7 @@ import (
 )
 
 var (
+	checkRequestTimeout   = 30 * time.Second
 	defaultKataSocketName = "kata.sock"
 	defaultKataChannel    = "agent.channel.0"
 	defaultKataDeviceID   = "channel0"
@@ -1278,7 +1279,7 @@ type reqFunc func(context.Context, interface{}, ...golangGrpc.CallOption) (inter
 func (k *kataAgent) installReqFunc(c *kataclient.AgentClient) {
 	k.reqHandlers = make(map[string]reqFunc)
 	k.reqHandlers["grpc.CheckRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, checkRequestTimeout)
 		defer cancel()
 		return k.client.Check(ctx, req.(*grpc.CheckRequest), opts...)
 	}


### PR DESCRIPTION
In slow systems when run  multiples containers in parallel.  The start-up time
takes longer and when we do the initial gprc server check, we got a time-out
because is not ready.

This PR adds a better error message when this happens and increase the time-out
to 10 seconds.

Notice that this fix the CI but  we still need to find the route cause why
is taking longer and try to reduce this delay.