### PR TITLE
factory: add SetLogger API

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	vf "github.com/kata-containers/runtime/virtcontainers/factory"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -146,6 +147,7 @@ func init() {
 	kataLog = logrus.WithFields(logrus.Fields{
 		"name":   name,
 		"source": "runtime",
+		"arch":   arch,
 		"pid":    os.Getpid(),
 	})
 
@@ -193,6 +195,9 @@ func setupSignalHandler() {
 func setExternalLoggers(logger *logrus.Entry) {
 	// Set virtcontainers logger.
 	vci.SetLogger(logger)
+
+	// Set vm factory logger.
+	vf.SetLogger(logger)
 
 	// Set the OCI package logger.
 	oci.SetLogger(logger)

--- a/virtcontainers/factory/factory.go
+++ b/virtcontainers/factory/factory.go
@@ -67,6 +67,15 @@ func NewFactory(config Config, fetchOnly bool) (vc.Factory, error) {
 	return &factory{b}, nil
 }
 
+// SetLogger sets the logger for the factory.
+func SetLogger(logger logrus.FieldLogger) {
+	fields := logrus.Fields{
+		"source": "virtcontainers",
+	}
+
+	factoryLogger = logger.WithFields(fields)
+}
+
 func (f *factory) log() *logrus.Entry {
 	return factoryLogger.WithField("subsystem", "factory")
 }

--- a/virtcontainers/factory/factory_test.go
+++ b/virtcontainers/factory/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
@@ -64,6 +65,27 @@ func TestNewFactory(t *testing.T) {
 	assert.Nil(err)
 	_, err = NewFactory(config, true)
 	assert.Error(err)
+}
+
+func TestFactorySetLogger(t *testing.T) {
+	assert := assert.New(t)
+
+	testLog := logrus.WithFields(logrus.Fields{"testfield": "foobar"})
+	testLog.Level = logrus.DebugLevel
+	SetLogger(testLog)
+
+	var config Config
+	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
+		KernelPath: "foo",
+		ImagePath:  "bar",
+	}
+	vf, err := NewFactory(config, false)
+	assert.Nil(err)
+
+	f, ok := vf.(*factory)
+	assert.True(ok)
+
+	assert.Equal(f.log().Logger.Level, testLog.Logger.Level)
 }
 
 func TestVMConfigValid(t *testing.T) {


### PR DESCRIPTION
So that we actually use the same logger as other packages when being
invoked by CLI.

Fixes: #520