### PR TITLE
versions: Update docker-ce to 18.06

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -148,7 +148,7 @@ externals:
     description: "Moby project container manager"
     notes: "Docker Swarm requires an older version of Docker."
     url: "https://github.com/moby/moby"
-    version: "v18.03-ce"
+    version: "v18.06-ce"
     meta:
       swarm-version: "1.12.1"
 


### PR DESCRIPTION
Docker 18.06 was released last week, update our
supported docker to this new version.

Fixes: #510

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>