### PR TITLE
kernel: Remove initcall_debug boot option

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -85,7 +85,6 @@ var qemuMinorVersion int
 // agnostic list of kernel parameters
 var defaultKernelParameters = []Param{
 	{"panic", "1"},
-	{"initcall_debug", ""},
 }
 
 type operation int

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -52,7 +52,7 @@ func testQemuKernelParameters(t *testing.T, kernelParams []Param, expected strin
 }
 
 func TestQemuKernelParameters(t *testing.T) {
-	expectedOut := fmt.Sprintf("panic=1 initcall_debug nr_cpus=%d foo=foo bar=bar", MaxQemuVCPUs())
+	expectedOut := fmt.Sprintf("panic=1 nr_cpus=%d foo=foo bar=bar", MaxQemuVCPUs())
 	params := []Param{
 		{
 			Key:   "foo",


### PR DESCRIPTION
Remove the `initcall_debug` boot option from the kernel command-line as
we don't need it any more and it generates a ton of boot messages that
may well be impacting performance.

Fixes #526.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>