### PR TITLE
Ensure containerID and sandboxID fields logged as early as possible

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -53,11 +53,16 @@ EXAMPLE:
 }
 
 func delete(containerID string, force bool) error {
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
+
+	containerID = status.ID
 
 	kataLog = kataLog.WithFields(logrus.Fields{
 		"container": containerID,
@@ -65,8 +70,6 @@ func delete(containerID string, force bool) error {
 	})
 
 	setExternalLoggers(kataLog)
-
-	containerID = status.ID
 
 	containerType, err := oci.GetContainerType(status.Annotations)
 	if err != nil {

--- a/cli/events.go
+++ b/cli/events.go
@@ -141,6 +141,9 @@ information is displayed once every 5 seconds.`,
 			return fmt.Errorf("container id cannot be empty")
 		}
 
+		kataLog = kataLog.WithField("container", containerID)
+		setExternalLoggers(kataLog)
+
 		duration := context.Duration("interval")
 		if duration <= 0 {
 			return fmt.Errorf("duration interval must be greater than 0")
@@ -150,6 +153,8 @@ information is displayed once every 5 seconds.`,
 		if err != nil {
 			return err
 		}
+
+		containerID = status.ID
 
 		kataLog = kataLog.WithFields(logrus.Fields{
 			"container": containerID,

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -16,7 +16,6 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -184,16 +183,16 @@ func generateExecParams(context *cli.Context, specProcess *oci.CompatOCIProcess)
 
 func execute(context *cli.Context) error {
 	containerID := context.Args().First()
+
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return err
 	}
 
-	kataLog = kataLog.WithFields(logrus.Fields{
-		"container": containerID,
-		"sandbox":   sandboxID,
-	})
-
+	kataLog = kataLog.WithField("sandbox", sandboxID)
 	setExternalLoggers(kataLog)
 
 	// Retrieve OCI spec configuration.
@@ -208,6 +207,10 @@ func execute(context *cli.Context) error {
 	}
 
 	params.cID = status.ID
+	containerID = params.cID
+
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
 
 	// container MUST be ready or running.
 	if status.State.State != vc.StateReady &&

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -91,8 +91,12 @@ var signals = map[string]syscall.Signal{
 }
 
 func kill(containerID, signal string, all bool) error {
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(containerID)
+
 	if err != nil {
 		return err
 	}

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -42,6 +42,9 @@ Where "<container-id>" is the container name to be resumed.`,
 }
 
 func toggleContainerPause(containerID string, pause bool) (err error) {
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -48,6 +48,9 @@ func ps(containerID, format string, args []string) error {
 		return fmt.Errorf("Missing container ID")
 	}
 
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {

--- a/cli/start.go
+++ b/cli/start.go
@@ -41,11 +41,16 @@ var startCLICommand = cli.Command{
 }
 
 func start(containerID string) (vc.VCSandbox, error) {
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(kataLog)
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(containerID)
 	if err != nil {
 		return nil, err
 	}
+
+	containerID = status.ID
 
 	kataLog = kataLog.WithFields(logrus.Fields{
 		"container": containerID,
@@ -53,8 +58,6 @@ func start(containerID string) (vc.VCSandbox, error) {
 	})
 
 	setExternalLoggers(kataLog)
-
-	containerID = status.ID
 
 	containerType, err := oci.GetContainerType(status.Annotations)
 	if err != nil {

--- a/cli/update.go
+++ b/cli/update.go
@@ -132,6 +132,10 @@ other options are ignored.
 		}
 
 		containerID := context.Args().First()
+
+		kataLog = kataLog.WithField("container", containerID)
+		setExternalLoggers(kataLog)
+
 		status, sandboxID, err := getExistingContainerInfo(containerID)
 		if err != nil {
 			return err
@@ -143,6 +147,8 @@ other options are ignored.
 			"container": containerID,
 			"sandbox":   sandboxID,
 		})
+
+		setExternalLoggers(kataLog)
 
 		// container MUST be running
 		if status.State.State != vc.StateRunning {

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -19,11 +19,12 @@ func init() {
 	runtime.LockOSThread()
 }
 
-var virtLog *logrus.Entry
+var virtLog = logrus.WithField("source", "virtcontainers")
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger *logrus.Entry) {
-	virtLog = logger.WithField("source", "virtcontainers")
+	fields := virtLog.Data
+	virtLog = logger.WithFields(fields)
 
 	deviceApi.SetLogger(virtLog)
 }

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -19,11 +19,12 @@ func init() {
 	runtime.LockOSThread()
 }
 
-var virtLog = logrus.FieldLogger(logrus.New())
+var virtLog *logrus.Entry
 
 // SetLogger sets the logger for virtcontainers package.
-func SetLogger(logger logrus.FieldLogger) {
+func SetLogger(logger *logrus.Entry) {
 	virtLog = logger.WithField("source", "virtcontainers")
+
 	deviceApi.SetLogger(virtLog)
 }
 

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -23,12 +23,7 @@ var virtLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for virtcontainers package.
 func SetLogger(logger logrus.FieldLogger) {
-	fields := logrus.Fields{
-		"source": "virtcontainers",
-		"arch":   runtime.GOARCH,
-	}
-
-	virtLog = logger.WithFields(fields)
+	virtLog = logger.WithField("source", "virtcontainers")
 	deviceApi.SetLogger(virtLog)
 }
 

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -264,9 +264,8 @@ func (c *Container) ID() string {
 // Logger returns a logrus logger appropriate for logging Container messages
 func (c *Container) Logger() *logrus.Entry {
 	return virtLog.WithFields(logrus.Fields{
-		"subsystem":    "container",
-		"container-id": c.id,
-		"sandbox-id":   c.sandboxID,
+		"subsystem": "container",
+		"sandbox":   c.sandboxID,
 	})
 }
 

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -12,10 +12,10 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 )
 
-var devLogger = logrus.FieldLogger(logrus.New())
+var devLogger *logrus.Entry
 
 // SetLogger sets the logger for device api package.
-func SetLogger(logger logrus.FieldLogger) {
+func SetLogger(logger *logrus.Entry) {
 	devLogger = logger
 }
 

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -12,16 +12,17 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 )
 
-var devLogger *logrus.Entry
+var devLogger = logrus.WithField("subsystem", "device")
 
 // SetLogger sets the logger for device api package.
 func SetLogger(logger *logrus.Entry) {
-	devLogger = logger
+	fields := devLogger.Data
+	devLogger = logger.WithFields(fields)
 }
 
 // DeviceLogger returns logger for device management
 func DeviceLogger() *logrus.Entry {
-	return devLogger.WithField("subsystem", "device")
+	return devLogger
 }
 
 // DeviceReceiver is an interface used for accepting devices

--- a/virtcontainers/hack/virtc/main.go
+++ b/virtcontainers/hack/virtc/main.go
@@ -19,7 +19,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
-var virtcLog = logrus.New()
+var virtcLog *logrus.Entry
 
 var listFormat = "%s\t%s\t%s\t%s\n"
 var statusFormat = "%s\t%s\n"
@@ -915,14 +915,14 @@ func main() {
 			if err != nil {
 				return err
 			}
-			virtcLog.Out = f
+			virtcLog.Logger.Out = f
 		}
 
 		switch context.GlobalString("log-format") {
 		case "text":
 			// retain logrus's default.
 		case "json":
-			virtcLog.Formatter = new(logrus.JSONFormatter)
+			virtcLog.Logger.Formatter = new(logrus.JSONFormatter)
 		default:
 			return fmt.Errorf("unknown log-format %q", context.GlobalString("log-format"))
 		}

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -22,7 +22,7 @@ type VCImpl struct {
 }
 
 // SetLogger implements the VC function of the same name.
-func (impl *VCImpl) SetLogger(logger logrus.FieldLogger) {
+func (impl *VCImpl) SetLogger(logger *logrus.Entry) {
 	SetLogger(logger)
 }
 

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -15,7 +15,7 @@ import (
 
 // VC is the Virtcontainers interface
 type VC interface {
-	SetLogger(logger logrus.FieldLogger)
+	SetLogger(logger *logrus.Entry)
 	SetFactory(Factory)
 
 	CreateSandbox(sandboxConfig SandboxConfig) (VCSandbox, error)

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -469,7 +469,7 @@ func (k *kataAgent) startProxy(sandbox *Sandbox) error {
 
 	proxyParams := proxyParams{
 		agentURL: agentURL,
-		logger:   k.Logger().WithField("sandbox-id", sandbox.id),
+		logger:   k.Logger().WithField("sandbox", sandbox.id),
 	}
 
 	// Start the proxy here
@@ -494,9 +494,9 @@ func (k *kataAgent) startProxy(sandbox *Sandbox) error {
 	}
 
 	k.Logger().WithFields(logrus.Fields{
-		"sandbox-id": sandbox.id,
-		"proxy-pid":  pid,
-		"proxy-url":  uri,
+		"sandbox":   sandbox.id,
+		"proxy-pid": pid,
+		"proxy-url": uri,
 	}).Info("proxy started")
 
 	return nil

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -489,7 +489,7 @@ func (n *NetworkNamespace) UnmarshalJSON(b []byte) error {
 			}
 
 			endpoints = append(endpoints, &endpoint)
-			virtLog.Infof("Physical endpoint unmarshalled [%v]", endpoint)
+			networkLogger().Infof("Physical endpoint unmarshalled [%v]", endpoint)
 
 		case VirtualEndpointType:
 			var endpoint VirtualEndpoint
@@ -499,7 +499,7 @@ func (n *NetworkNamespace) UnmarshalJSON(b []byte) error {
 			}
 
 			endpoints = append(endpoints, &endpoint)
-			virtLog.Infof("Virtual endpoint unmarshalled [%v]", endpoint)
+			networkLogger().Infof("Virtual endpoint unmarshalled [%v]", endpoint)
 
 		case VhostUserEndpointType:
 			var endpoint VhostUserEndpoint
@@ -509,10 +509,10 @@ func (n *NetworkNamespace) UnmarshalJSON(b []byte) error {
 			}
 
 			endpoints = append(endpoints, &endpoint)
-			virtLog.Infof("VhostUser endpoint unmarshalled [%v]", endpoint)
+			networkLogger().Infof("VhostUser endpoint unmarshalled [%v]", endpoint)
 
 		default:
-			virtLog.Errorf("Unknown endpoint type received %s\n", e.Type)
+			networkLogger().Errorf("Unknown endpoint type received %s\n", e.Type)
 		}
 	}
 
@@ -1010,7 +1010,7 @@ func untapNetworkPair(netPair NetworkInterfacePair) error {
 	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
 	if err != nil {
 		// The veth pair is not totally managed by virtcontainers
-		virtLog.Warnf("Could not get veth interface %s: %s", netPair.VirtIface.Name, err)
+		networkLogger().Warnf("Could not get veth interface %s: %s", netPair.VirtIface.Name, err)
 	} else {
 		if err := netHandle.LinkSetDown(vethLink); err != nil {
 			return fmt.Errorf("Could not disable veth %s: %s", netPair.VirtIface.Name, err)
@@ -1062,7 +1062,7 @@ func unBridgeNetworkPair(netPair NetworkInterfacePair) error {
 	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
 	if err != nil {
 		// The veth pair is not totally managed by virtcontainers
-		virtLog.WithError(err).Warn("Could not get veth interface")
+		networkLogger().WithError(err).Warn("Could not get veth interface")
 	} else {
 		if err := netHandle.LinkSetDown(vethLink); err != nil {
 			return fmt.Errorf("Could not disable veth %s: %s", netPair.VirtIface.Name, err)

--- a/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -124,7 +124,10 @@ var hyperLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for hyperstart package.
 func SetLogger(logger logrus.FieldLogger) {
-	hyperLog = logger.WithField("source", "virtcontainers/hyperstart")
+	hyperLog = logger.WithFields(logrus.Fields{
+		"source":    "virtcontainers",
+		"subsystem": "hyperstart",
+	})
 }
 
 // NewHyperstart returns a new hyperstart structure.

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -132,7 +132,10 @@ var ociLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for oci package.
 func SetLogger(logger logrus.FieldLogger) {
-	ociLog = logger.WithField("source", "virtcontainers/oci")
+	ociLog = logger.WithFields(logrus.Fields{
+		"source":    "virtcontainers",
+		"subsystem": "oci",
+	})
 }
 
 func cmdEnvs(spec CompatOCISpec, envs []vc.EnvVar) []vc.EnvVar {

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -131,7 +131,7 @@ func (config *RuntimeConfig) AddKernelParam(p vc.Param) error {
 var ociLog = logrus.FieldLogger(logrus.New())
 
 // SetLogger sets the logger for oci package.
-func SetLogger(logger logrus.FieldLogger) {
+func SetLogger(logger *logrus.Entry) {
 	ociLog = logger.WithFields(logrus.Fields{
 		"source":    "virtcontainers",
 		"subsystem": "oci",

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -128,14 +128,15 @@ func (config *RuntimeConfig) AddKernelParam(p vc.Param) error {
 	return config.HypervisorConfig.AddKernelParam(p)
 }
 
-var ociLog = logrus.FieldLogger(logrus.New())
+var ociLog = logrus.WithFields(logrus.Fields{
+	"source":    "virtcontainers",
+	"subsystem": "oci",
+})
 
 // SetLogger sets the logger for oci package.
 func SetLogger(logger *logrus.Entry) {
-	ociLog = logger.WithFields(logrus.Fields{
-		"source":    "virtcontainers",
-		"subsystem": "oci",
-	})
+	fields := ociLog.Data
+	ociLog = logger.WithFields(fields)
 }
 
 func cmdEnvs(spec CompatOCISpec, envs []vc.EnvVar) []vc.EnvVar {

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -29,7 +29,7 @@ import (
 const mockErrorPrefix = "vcmock forced failure"
 
 // SetLogger implements the VC function of the same name.
-func (m *VCMock) SetLogger(logger logrus.FieldLogger) {
+func (m *VCMock) SetLogger(logger *logrus.Entry) {
 	if m.SetLoggerFunc != nil {
 		m.SetLoggerFunc(logger)
 	}

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -98,7 +98,7 @@ func TestVCMockSetLogger(t *testing.T) {
 	m := &VCMock{}
 	assert.Nil(m.SetLoggerFunc)
 
-	logger := logrus.New()
+	logger := logrus.NewEntry(logrus.New())
 
 	assert.Equal(loggerTriggered, 0)
 	m.SetLogger(logger)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -483,8 +483,8 @@ func (s *Sandbox) ID() string {
 // Logger returns a logrus logger appropriate for logging Sandbox messages
 func (s *Sandbox) Logger() *logrus.Entry {
 	return virtLog.WithFields(logrus.Fields{
-		"subsystem":  "sandbox",
-		"sandbox-id": s.id,
+		"subsystem": "sandbox",
+		"sandbox":   s.id,
 	})
 }
 
@@ -827,7 +827,7 @@ func (s *Sandbox) storeSandbox() error {
 
 // fetchSandbox fetches a sandbox config from a sandbox ID and returns a sandbox.
 func fetchSandbox(sandboxID string) (sandbox *Sandbox, err error) {
-	virtLog.WithField("sandbox-id", sandboxID).Info("fetch sandbox")
+	virtLog.Info("fetch sandbox")
 	if sandboxID == "" {
 		return nil, errNeedSandboxID
 	}

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -66,11 +66,11 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
-	logger := logrus.New()
-	logger.Level = logrus.ErrorLevel
+	logger := logrus.NewEntry(logrus.New())
+	logger.Logger.Level = logrus.ErrorLevel
 	for _, arg := range flag.Args() {
 		if arg == "debug-logs" {
-			logger.Level = logrus.DebugLevel
+			logger.Logger.Level = logrus.DebugLevel
 		}
 	}
 	SetLogger(logger)


### PR DESCRIPTION
Improve containerID and sandboxID logging by:

- Ensuring that `setExternalLoggers()` saves any previously-set log fields
  (this required a `SetLogger()` API change).

- Calling `setExternalLoggers()` as early as possible, then again once new fields become available.

  This is necessary to ensure that all virtcontainers functions atleast have access to the containerID for logging purposes.

PR also performs various log cleanup.

Fixes #519.
    
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>