### PR TITLE
device: Add GPU device support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -127,7 +127,7 @@
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "032705ba6aae05a9bf41e296cf89c8529cffb822"
+  revision = "9905ae92c5915c07abeb669eaa4d7f7408834b51"
 
 [[projects]]
   digest = "1:672470f31bc4e50f9ba09a1af7ab6035bf8b1452db64dfd79b1a22614bb30710"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "032705ba6aae05a9bf41e296cf89c8529cffb822"
+  revision = "9905ae92c5915c07abeb669eaa4d7f7408834b51"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -946,10 +946,12 @@ func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsd
 		"id":       devID,
 		"driver":   "vfio-pci",
 		"sysfsdev": sysfsdev,
-		"addr":     addr,
 	}
 	if bus != "" {
 		args["bus"] = bus
+	}
+	if addr != "" {
+		args["addr"] = addr
 	}
 	return q.executeCommand(ctx, "device_add", args, nil)
 }

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -109,12 +109,33 @@ type BlockDrive struct {
 	VirtPath string
 }
 
+// VFIODeviceType indicates VFIO device type
+type VFIODeviceType uint32
+
+const (
+	// VFIODeviceErrorType is the error type of VFIO device
+	VFIODeviceErrorType VFIODeviceType = iota
+
+	// VFIODeviceNormalType is a normal VFIO device type
+	VFIODeviceNormalType
+
+	// VFIODeviceMediatedType is a VFIO mediated device type
+	VFIODeviceMediatedType
+)
+
 // VFIODev represents a VFIO drive used for hotplugging
 type VFIODev struct {
 	// ID is used to identify this drive in the hypervisor options.
 	ID string
+
+	// Type of VFIO device
+	Type VFIODeviceType
+
 	// BDF (Bus:Device.Function) of the PCI address
 	BDF string
+
+	// sysfsdev of VFIO mediated device
+	SysfsDev string
 }
 
 // RNGDev represents a random number generator device


### PR DESCRIPTION
Enable GPU device support in kata runtime, including GVT-g and GVT-d.
GVT-g: graphic virtualization technology with mediated pass through
GVT-d: graphic virtualization technology with direct pass through

BDF of device eg "0000:00:1c.0" is used to distinguish GPU device in GVT-d,
while sysfsdev of device eg "f79944e4-5a3d-11e8-99ce-479cbab002e4"is used
in GVT-g.

Signed-off-by: Zhao Xinda <xinda.zhao@intel.com>