### PR TITLE
qemu: clear qmp state before wait for qemu process

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -517,6 +517,8 @@ func (q *qemu) waitSandbox(timeout int) error {
 	var ver *govmmQemu.QMPVersion
 	var err error
 
+	// clear any possible old state before trying to connect again.
+	q.qmpShutdown()
 	timeStart := time.Now()
 	for {
 		disconnectCh := make(chan struct{})

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -345,3 +345,18 @@ func TestHotplugUnsupportedDeviceType(t *testing.T) {
 	_, err = q.hotplugRemoveDevice(&memoryDevice{0, 128}, fsDev)
 	assert.Error(err)
 }
+
+func TestQMPSetupShutdown(t *testing.T) {
+	assert := assert.New(t)
+
+	qemuConfig := newQemuConfig()
+	q := &qemu{
+		config: qemuConfig,
+	}
+
+	q.qmpShutdown()
+
+	q.qmpMonitorCh.qmp = &govmmQemu.QMP{}
+	err := q.qmpSetup()
+	assert.Nil(err)
+}


### PR DESCRIPTION
So that if there is any remaining state, we do not let it interfere
with the new one. This should fix the occasional vm factory hang.