### PR TITLE
virtcontainers: fix the issue of cleanup the vm's path

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -579,7 +579,7 @@ func (q *qemu) stopSandbox() error {
 		return err
 	}
 
-	err = os.RemoveAll(RunVMStoragePath + q.id)
+	err = os.RemoveAll(filepath.Join(RunVMStoragePath, q.id))
 	if err != nil {
 		q.Logger().WithError(err).Error("Fail to clean up vm directory")
 	}


### PR DESCRIPTION
To use the filepath.Join() instead of the simple
string append method to form the file path, otherwise
it will lose the "/" between the two parts.

Fixes #543.

Signed-off-by: Fupan Li <lifupan@gmail.com>