### PR TITLE
qemu: create vm directory before launching qemu

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -416,21 +416,6 @@ func (q *qemu) createSandbox() error {
 		return fmt.Errorf("UUID should not be empty")
 	}
 
-	monitorSockPath, err := q.qmpSocketPath(q.id)
-	if err != nil {
-		return err
-	}
-
-	q.qmpMonitorCh = qmpChannel{
-		ctx:  context.Background(),
-		path: monitorSockPath,
-	}
-
-	err = os.MkdirAll(filepath.Dir(monitorSockPath), dirMode)
-	if err != nil {
-		return err
-	}
-
 	qmpSockets, err := q.createQmpSocket()
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now we create it in `createsandbox` and it would
create the vm dir unnecessarily for fetchsandbox() and
it ends up leaving an empty vm dir behind even after
DeleteSandbox.

Fixes: #547