### PR TITLE
virtcontainers: hotplug communication channel

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -230,6 +230,9 @@ type agent interface {
 	// reseedRNG will reseed the guest random number generator
 	reseedRNG(data []byte) error
 
+	// waitForAgentReady waits until the agent is ready
+	waitForAgentReady(sandbox *Sandbox) error
+
 	// updateInterface will tell the agent to update a nic for an existed Sandbox.
 	updateInterface(inf *grpc.Interface) (*grpc.Interface, error)
 

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -178,6 +178,10 @@ func newTestSandboxConfigKataAgent() SandboxConfig {
 		HypervisorConfig: hypervisorConfig,
 
 		AgentType: KataContainersAgent,
+		AgentConfig: KataAgentConfig{
+			LongLiveConn: false,
+			UseVSock:     false,
+		},
 
 		Annotations: sandboxAnnotations,
 	}

--- a/virtcontainers/factory.go
+++ b/virtcontainers/factory.go
@@ -14,4 +14,7 @@ type Factory interface {
 
 	// CloseFactory closes and cleans up the factory.
 	CloseFactory(ctx context.Context)
+
+	// InitializeVM initializes the VM.
+	InitializeVM(ctx context.Context, vm *VM, sandbox *Sandbox) error
 }

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -987,3 +987,8 @@ func (h *hyper) setProxy(sandbox *Sandbox, proxy proxy, pid int, url string) err
 
 	return nil
 }
+
+func (h *hyper) waitForAgentReady(sandbox *Sandbox) error {
+	// hyperstart-agent does not support wait for agent ready
+	return nil
+}

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -207,6 +207,14 @@ func TestHyperReseedAPI(t *testing.T) {
 	assert.Nil(err)
 }
 
+func TestHyperWaitForAgentReady(t *testing.T) {
+	assert := assert.New(t)
+
+	h := &hyper{}
+	err := h.waitForAgentReady(nil)
+	assert.Nil(err)
+}
+
 func TestHyperUpdateInterface(t *testing.T) {
 	assert := assert.New(t)
 

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -197,3 +197,8 @@ func (n *noopAgent) getAgentURL() (string, error) {
 func (n *noopAgent) setProxy(sandbox *Sandbox, proxy proxy, pid int, url string) error {
 	return nil
 }
+
+// waitForAgentReady is the Noop agent implementation. It does nothing.
+func (n *noopAgent) waitForAgentReady(sandbox *Sandbox) error {
+	return nil
+}

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -222,6 +222,14 @@ func TestNoopAgentReseedRNG(t *testing.T) {
 	}
 }
 
+func TestNoopAgentWaitForAgentReady(t *testing.T) {
+	n := &noopAgent{}
+	err := n.waitForAgentReady(nil)
+	if err != nil {
+		t.Fatal("waitForAgentReady failed")
+	}
+}
+
 func TestNoopAgentUpdateInterface(t *testing.T) {
 	n := &noopAgent{}
 	_, err := n.updateInterface(nil)

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -907,6 +907,9 @@ func (q *qemu) hotplugDevice(devInfo interface{}, devType deviceType, op operati
 	case serialPortDev:
 		socket := devInfo.(Socket)
 		return nil, q.hotplugSocket(socket, op)
+	case vSockPCIDev:
+		vsock := devInfo.(kataVSOCK)
+		return nil, q.hotplugVSockPCI(vsock, op)
 	default:
 		return nil, fmt.Errorf("cannot hotplug device: unsupported device type '%v'", devType)
 	}
@@ -1267,6 +1270,38 @@ func (q *qemu) hotplugSocket(socket Socket, op operation) error {
 		return errors.New("Remove socket device is not supported")
 	default:
 		return fmt.Errorf("Unknown socket operation: %d", op)
+	}
+
+	return nil
+}
+
+func (q *qemu) hotplugVSockPCI(vsock kataVSOCK, op operation) error {
+	if err := q.qmpSetup(); err != nil {
+		return err
+	}
+
+	switch op {
+	case addDevice:
+		vhostfdname := fmt.Sprintf("vhostfd-%d", vsock.contextID)
+		if err := q.qmpMonitorCh.qmp.ExecuteGetFD(q.qmpMonitorCh.ctx, vhostfdname, vsock.vhostFd); err != nil {
+			return err
+		}
+
+		id := fmt.Sprintf("vsock-%d", vsock.contextID)
+		addr, bridge, err := q.addDeviceToBridge(id)
+		if err != nil {
+			return err
+		}
+
+		disableModern := q.arch.runningNested()
+		guestCID := fmt.Sprintf("%d", vsock.contextID)
+		if err := q.qmpMonitorCh.qmp.ExecutePCIVSockAdd(q.qmpMonitorCh.ctx, id, guestCID, vhostfdname, addr, bridge.ID, disableModern); err != nil {
+			return err
+		}
+	case removeDevice:
+		return errors.New("Remove vsock PCI is not supported")
+	default:
+		return fmt.Errorf("Unknown vsock operation: %d", op)
 	}
 
 	return nil

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -24,6 +24,9 @@ type qemuArch interface {
 	// disableNestingChecks nesting checks will be ignored
 	disableNestingChecks()
 
+	// runningNested returns true if QEMU is running in a nested environment, otherwise false
+	runningNested() bool
+
 	// enableVhostNet vhost will be enabled
 	enableVhostNet()
 
@@ -181,6 +184,10 @@ func (q *qemuArchBase) enableNestingChecks() {
 
 func (q *qemuArchBase) disableNestingChecks() {
 	q.nestedRun = false
+}
+
+func (q *qemuArchBase) runningNested() bool {
+	return q.nestedRun
 }
 
 func (q *qemuArchBase) enableVhostNet() {

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -431,3 +431,11 @@ func TestQemuArchBaseAppendSCSIController(t *testing.T) {
 	_, ioThread = qemuArchBase.appendSCSIController(devices, true)
 	assert.NotNil(ioThread)
 }
+
+func TestQemuArchBaseRunningNested(t *testing.T) {
+	assert := assert.New(t)
+	q := &qemuArchBase{nestedRun: true}
+	assert.True(q.runningNested())
+	q.nestedRun = false
+	assert.False(q.runningNested())
+}

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -128,7 +128,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	// 2. setup agent
 	agent := newAgent(config.AgentType)
 	vmSharePath := buildVMSharePath(id)
-	err = agent.configure(hypervisor, id, vmSharePath, isProxyBuiltIn(config.ProxyType), config.AgentConfig)
+	err = agent.configure(hypervisor, id, vmSharePath, isProxyBuiltIn(config.ProxyType), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -162,15 +162,10 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	if err = agent.setProxy(nil, proxy, pid, url); err != nil {
 		return nil, err
 	}
-
 	// 5. check agent aliveness
 	// VMs booted from template are paused, do not check
 	if !config.HypervisorConfig.BootFromTemplate {
 		virtLog.WithField("vm", id).Info("check agent status")
-		err = agent.check()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return &VM{
@@ -333,6 +328,9 @@ func (v *VM) assignSandbox(s *Sandbox) error {
 	}
 
 	s.hypervisor = v.hypervisor
+
+	// Use sanbox's agent since it points to the right communication channel.
+	v.agent = s.agent
 
 	return nil
 }


### PR DESCRIPTION
Do not cold plug communication channel (unix socket or vsock)
instead hot plug it after launching QEMU.
VM templating requires this feature.
    
fixes #532

Signed-off-by: Julio Montes <julio.montes@intel.com>