### PR TITLE
devices: add interface "sandbox.AddDevice"

### DIFF
--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -62,6 +62,7 @@ type Device interface {
 // device management object.
 type DeviceManager interface {
 	NewDevice(config.DeviceInfo) (Device, error)
+	RemoveDevice(string) error
 	AttachDevice(string, DeviceReceiver) error
 	DetachDevice(string, DeviceReceiver) error
 	IsDeviceAttached(string) bool

--- a/virtcontainers/device/manager/manager.go
+++ b/virtcontainers/device/manager/manager.go
@@ -93,7 +93,7 @@ func (dm *deviceManager) createDevice(devInfo config.DeviceInfo) (api.Device, er
 	}
 }
 
-// NewDevice creates bundles of devices based on array of DeviceInfo
+// NewDevice creates a device based on specified DeviceInfo
 func (dm *deviceManager) NewDevice(devInfo config.DeviceInfo) (api.Device, error) {
 	dm.Lock()
 	defer dm.Unlock()
@@ -102,6 +102,17 @@ func (dm *deviceManager) NewDevice(devInfo config.DeviceInfo) (api.Device, error
 		dm.devices[dev.DeviceID()] = dev
 	}
 	return dev, err
+}
+
+// RemoveDevice deletes the device from list based on specified device id
+func (dm *deviceManager) RemoveDevice(id string) error {
+	dm.Lock()
+	defer dm.Unlock()
+	if _, ok := dm.devices[id]; !ok {
+		return ErrDeviceNotExist
+	}
+	delete(dm.devices, id)
+	return nil
 }
 
 func (dm *deviceManager) newDeviceID() (string, error) {

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -12,6 +12,8 @@ package virtcontainers
 import (
 	"syscall"
 
+	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -140,4 +142,9 @@ func (impl *VCImpl) PauseContainer(sandboxID, containerID string) error {
 // ResumeContainer implements the VC function of the same name.
 func (impl *VCImpl) ResumeContainer(sandboxID, containerID string) error {
 	return ResumeContainer(sandboxID, containerID)
+}
+
+// AddDevice will add a device to sandbox
+func (impl *VCImpl) AddDevice(sandboxID string, info config.DeviceInfo) (api.Device, error) {
+	return AddDevice(sandboxID, info)
 }

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"syscall"
 
+	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -41,6 +43,8 @@ type VC interface {
 	UpdateContainer(sandboxID, containerID string, resources specs.LinuxResources) error
 	PauseContainer(sandboxID, containerID string) error
 	ResumeContainer(sandboxID, containerID string) error
+
+	AddDevice(sandboxID string, info config.DeviceInfo) (api.Device, error)
 }
 
 // VCSandbox is the Sandbox interface
@@ -70,6 +74,8 @@ type VCSandbox interface {
 	SignalProcess(containerID, processID string, signal syscall.Signal, all bool) error
 	WinsizeProcess(containerID, processID string, height, width uint32) error
 	IOStream(containerID, processID string) (io.WriteCloser, io.Reader, io.Reader, error)
+
+	AddDevice(info config.DeviceInfo) (api.Device, error)
 }
 
 // VCContainer is the Container interface

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -238,4 +240,13 @@ func (m *VCMock) ResumeContainer(sandboxID, containerID string) error {
 	}
 
 	return fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
+}
+
+// AddDevice implements the VC function of the same name.
+func (m *VCMock) AddDevice(sandboxID string, info config.DeviceInfo) (api.Device, error) {
+	if m.AddDeviceFunc != nil {
+		return m.AddDeviceFunc(sandboxID, info)
+	}
+
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -137,4 +139,9 @@ func (s *Sandbox) WinsizeProcess(containerID, processID string, height, width ui
 // IOStream implements the VCSandbox function of the same name.
 func (s *Sandbox) IOStream(containerID, processID string) (io.WriteCloser, io.Reader, io.Reader, error) {
 	return nil, nil, nil, nil
+}
+
+// AddDevice adds a device to sandbox
+func (s *Sandbox) AddDevice(info config.DeviceInfo) (api.Device, error) {
+	return nil, nil
 }

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -61,4 +63,6 @@ type VCMock struct {
 	UpdateContainerFunc      func(sandboxID, containerID string, resources specs.LinuxResources) error
 	PauseContainerFunc       func(sandboxID, containerID string) error
 	ResumeContainerFunc      func(sandboxID, containerID string) error
+
+	AddDeviceFunc func(sandboxID string, info config.DeviceInfo) (api.Device, error)
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1546,3 +1546,25 @@ func (s *Sandbox) AppendDevice(device api.Device) error {
 	}
 	return fmt.Errorf("unsupported device type")
 }
+
+// AddDevice will add a device to sandbox
+func (s *Sandbox) AddDevice(info config.DeviceInfo) (api.Device, error) {
+	if s.devManager == nil {
+		return nil, fmt.Errorf("device manager isn't initialized")
+	}
+
+	b, err := s.devManager.NewDevice(info)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.devManager.AttachDevice(b.DeviceID(), s); err != nil {
+		return nil, err
+	}
+
+	if err := s.storeSandboxDevices(); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}


### PR DESCRIPTION
Fixes #50

Add new interface sandbox.AddDevice, then for Frakti use case, a device
can be attached to sandbox before container is created.

Signed-off-by: Wei Zhang <zhangwei555@huawei.com>