### PR TITLE
virtcontainers: qemu: x86: Support "virt" machine type

### DIFF
--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -67,6 +67,10 @@ var supportedQemuMachines = []govmmQemu.Machine{
 		Type:    QemuQ35,
 		Options: defaultQemuMachineOptions,
 	},
+	{
+		Type:    QemuVirt,
+		Options: defaultQemuMachineOptions,
+	},
 }
 
 // MaxQemuVCPUs returns the maximum number of vCPUs supported

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -131,10 +131,10 @@ const (
 	// QemuQ35 is the QEMU Q35 machine type for amd64
 	QemuQ35 = "q35"
 
-	// QemuVirt is the QEMU virt machine type for aarch64
+	// QemuVirt is the QEMU virt machine type for aarch64 or amd64
 	QemuVirt = "virt"
 
-	// QemuPseries is a QEMU virt machine type for for ppc64le
+	// QemuPseries is a QEMU virt machine type for ppc64le
 	QemuPseries = "pseries"
 )
 


### PR DESCRIPTION
In order to start playing with the "virt" machine type for Kata,
we need this new machine type to be part of the list of supported
machines for qemu on x86 architecture.

Fixes #558

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>