### PR TITLE
virtcontainers: ppc64le: Add nvdimm to defaultQemuMachineOption

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -24,7 +24,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off,nvdimm"
 
 const defaultPCBridgeBus = "pci.0"
 


### PR DESCRIPTION
nvdimm is fundamental to get rootfs approach
working for Kata Containers on ppc64le. It should
be added to the default qemu machine option list.

Fixes: #561

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com