### PR TITLE
CI: bump the CI travis's go to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 go_import_path: github.com/kata-containers/runtime
 
 go:
-  - 1.8
+  - "1.10.x"
 
 before_script:
   - ".ci/static-checks.sh"


### PR DESCRIPTION
Bump the CI travis's go to 1.10 to meet
the building kata shim v2 for containerd.

Fixes: 575

Signed-off-by: fupan <lifupan@gmail.com>