### PR TITLE
[WIP] k8s memory resource hotplug

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1181,6 +1181,19 @@ func (c *Container) addResources() error {
 		return c.sandbox.agent.onlineCPUMem(vcpusAdded)
 	}
 
+	// Container is being created, try to add the memory specified
+	mem := c.config.Resources.Mem
+	if mem != 0 {
+		virtLog.Debugf("hot adding %d B memory", mem)
+		sizeMB := int(mem / 1024 / 1024)
+		// sizeMB needs to be divisible by 2
+		sizeMB = sizeMB + sizeMB%2
+		_, err := c.sandbox.hypervisor.hotplugAddDevice(&memoryDevice{1, sizeMB}, memoryDev)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -1202,6 +1215,18 @@ func (c *Container) removeResources() error {
 	if vCPUs != 0 {
 		virtLog.Debugf("hot removing %d vCPUs", vCPUs)
 		if _, err := c.sandbox.hypervisor.hotplugRemoveDevice(vCPUs, cpuDev); err != nil {
+			return err
+		}
+	}
+
+	mem := c.config.Resources.Mem
+	if mem != 0 {
+		virtLog.Debugf("hot removing %d B memory", mem)
+		sizeMB := int(mem / 1024 / 1024)
+		// sizeMB needs to be divisible by 2
+		sizeMB = sizeMB + sizeMB%2
+		_, err := c.sandbox.hypervisor.hotplugRemoveDevice(&memoryDevice{1, sizeMB}, memoryDev)
+		if err != nil {
 			return err
 		}
 	}

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -605,6 +605,11 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 			resources.VCPUs = uint32(utils.ConstraintsToVCPUs(*ocispec.Linux.Resources.CPU.Quota, *ocispec.Linux.Resources.CPU.Period))
 		}
 	}
+	if ocispec.Linux.Resources.Memory != nil {
+		if ocispec.Linux.Resources.Memory.Limit != nil {
+			resources.Mem = uint32(*ocispec.Linux.Resources.Memory.Limit)
+		}
+	}
 
 	containerConfig := vc.ContainerConfig{
 		ID:             cid,


### PR DESCRIPTION
At present, kata-runtime already supports memory hotplug in hypervisor side，however, the limitation of pod resources in k8s cannot be satisfied.

This pr try to satisfy the usage of k8s. 


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>