### PR TITLE
versions: Update the commit for qemu-lite

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -64,7 +64,7 @@ assets:
       description: "lightweight VMM that uses KVM"
       url: "https://github.com/kata-containers/qemu"
       branch: "qemu-lite-2.11.0"
-      commit: "6ba2bfbee9a80bfd03605c5eb2ca743c8b68389e"
+      commit: "a39e0b3e828ff6fb4457865ef7a021f1e7320c27"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
The commit for qemu needs to be updated to the tip
of the qemu-lite-2.11.0 branch. The qemu packages for
1.12.0 also contain the latest commit.

Fixes #582

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>