### PR TITLE
qemu: refactor maximum vcpus supported in aarch64

### DIFF
--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -107,8 +107,22 @@ func getGuestGICVersion() (version string) {
 	return "host"
 }
 
+//In qemu, maximum number of vCPUs depends on the GIC version, or on how
+//many redistributors we can fit into the memory map.
+//related codes are under github.com/qemu/qemu/hw/arm/virt.c(Line 135 and 1306 in stable-2.11)
+//for now, qemu only supports v2 and v3, we treat v4 as v3 based on
+//backward compatibility.
+var gicList = map[uint32]uint32{
+	uint32(2): uint32(8),
+	uint32(3): uint32(123),
+	uint32(4): uint32(123),
+}
+
 // MaxQemuVCPUs returns the maximum number of vCPUs supported
 func MaxQemuVCPUs() uint32 {
+	if hostGICVersion != 0 {
+		return gicList[hostGICVersion]
+	}
 	return uint32(runtime.NumCPU())
 }
 

--- a/virtcontainers/qemu_arm64_test.go
+++ b/virtcontainers/qemu_arm64_test.go
@@ -7,6 +7,10 @@ package virtcontainers
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	govmmQemu "github.com/intel/govmm/qemu"
@@ -49,4 +53,53 @@ func TestQemuArm64MemoryTopology(t *testing.T) {
 
 	m := arm64.memoryTopology(mem, hostMem)
 	assert.Equal(expectedMemory, m)
+}
+
+func TestMaxQemuVCPUs(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		contents       string
+		expectedResult uint32
+	}
+
+	data := []testData{
+		{"", uint32(runtime.NumCPU())},
+		{"  1:          0          0     GICv2  25 Level     vgic \n", uint32(8)},
+		{"  1:          0          0     GICv3  25 Level     vgic \n", uint32(123)},
+		{"  1:          0          0     GICv4  25 Level     vgic \n", uint32(123)},
+	}
+
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	savedGicProfile := gicProfile
+
+	testGicProfile := filepath.Join(tmpdir, "interrupts")
+
+	// override
+	gicProfile = testGicProfile
+
+	defer func() {
+		gicProfile = savedGicProfile
+	}()
+
+	savedHostGICVersion := hostGICVersion
+
+	defer func() {
+		hostGICVersion = savedHostGICVersion
+	}()
+
+	for _, d := range data {
+		err := ioutil.WriteFile(gicProfile, []byte(d.contents), os.FileMode(0640))
+		assert.NoError(err)
+
+		hostGICVersion = getHostGICVersion()
+		vCPUs := MaxQemuVCPUs()
+
+		assert.Equal(d.expectedResult, vCPUs)
+	}
 }


### PR DESCRIPTION
on aarch64, we support different gic interrupt controllers.
The maximum number of vCPUs depends on the GIC version, or on how many redistributors we can fit into the memory map.

Fixes: #584

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <Wei.Chen@arm.com>