### PR TITLE
cli: Error out if initrd/rootfs not define in config file

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -327,6 +327,11 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 			errors.New("having both an image and an initrd defined in the configuration file is not supported")
 	}
 
+	if image == "" && initrd == "" {
+		return vc.HypervisorConfig{},
+			errors.New("either image or initrd must be defined in the configuration file")
+	}
+
 	firmware, err := h.firmware()
 	if err != nil {
 		return vc.HypervisorConfig{}, err

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -626,7 +626,7 @@ func TestMinimalRuntimeConfigWithVsock(t *testing.T) {
 	defaultHypervisorPath = hypervisorPath
 	defaultKernelPath = kernelPath
 
-	for _, file := range []string{proxyPath, shimPath, hypervisorPath, kernelPath} {
+	for _, file := range []string{proxyPath, shimPath, hypervisorPath, kernelPath, imagePath} {
 		err = writeFile(file, "foo", testFileMode)
 		if err != nil {
 			t.Fatal(err)
@@ -638,6 +638,7 @@ func TestMinimalRuntimeConfigWithVsock(t *testing.T) {
 	# Runtime configuration file
 	[hypervisor.qemu]
 	use_vsock = true
+	image = "` + imagePath + `"
 
 	[proxy.kata]
 	path = "` + proxyPath + `"


### PR DESCRIPTION
If neither initrd nor rootfs path is mentioned in
the configuration.toml file, then error out stating
the same

Fixes: #587

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com