### PR TITLE
network: fix vhost-user net creation

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -286,6 +286,7 @@ func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
 		ID:         id,
 		SocketPath: endpoint.SocketPath,
 		MacAddress: endpoint.HardAddr,
+		Type:       config.VhostUserNet,
 	}
 
 	return h.addDevice(d, vhostuserDev)


### PR DESCRIPTION
When creating a device structure to be added to the hypervisor, make
sure that the device includes the vhost-user type.  In particular,
for network devices, specific it is VhostUserNet

Fixes: #601

Signed-off-by: Eric Ernst <eric.ernst@intel.com>