### PR TITLE
vc: Remove unused variable NumInterfaces

### DIFF
--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -152,9 +152,7 @@ func newTestSandboxConfigHyperstartAgentCNMNetwork() SandboxConfig {
 		PostStopHooks:  []Hook{},
 	}
 
-	netConfig := NetworkConfig{
-		NumInterfaces: len(hooks.PreStartHooks),
-	}
+	netConfig := NetworkConfig{}
 
 	sandboxConfig := SandboxConfig{
 		ID:    testSandboxID,
@@ -1980,9 +1978,7 @@ func createNewSandboxConfig(hType HypervisorType, aType AgentType, aConfig inter
 		HypervisorPath: "/usr/bin/qemu-system-x86_64",
 	}
 
-	netConfig := NetworkConfig{
-		NumInterfaces: 1,
-	}
+	netConfig := NetworkConfig{}
 
 	return SandboxConfig{
 		ID:               testSandboxID,

--- a/virtcontainers/documentation/api/1.0/api.md
+++ b/virtcontainers/documentation/api/1.0/api.md
@@ -276,7 +276,6 @@ const (
 // NetworkConfig is the network configuration related to a network.
 type NetworkConfig struct {
 	NetNSPath         string
-	NumInterfaces     int
 	InterworkingModel NetInterworkingModel
 }
 ```

--- a/virtcontainers/hack/virtc/main.go
+++ b/virtcontainers/hack/virtc/main.go
@@ -176,9 +176,7 @@ func buildSandboxConfig(context *cli.Context) (vc.SandboxConfig, error) {
 		return vc.SandboxConfig{}, err
 	}
 
-	netConfig := vc.NetworkConfig{
-		NumInterfaces: 1,
-	}
+	netConfig := vc.NetworkConfig{}
 
 	switch *agentType {
 	case vc.HyperstartAgent:

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -142,7 +142,6 @@ type NetworkInterfacePair struct {
 // NetworkConfig is the network configuration related to a network.
 type NetworkConfig struct {
 	NetNSPath         string
-	NumInterfaces     int
 	InterworkingModel NetInterworkingModel
 }
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -357,9 +357,6 @@ func networkConfig(ocispec CompatOCISpec, config RuntimeConfig) (vc.NetworkConfi
 			continue
 		}
 
-		// Bug: This is not the interface count
-		// It is just an indication that you need networking
-		netConf.NumInterfaces = 1
 		if n.Path != "" {
 			netConf.NetNSPath = n.Path
 		}

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -211,9 +211,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 		DeviceInfos: expectedDeviceInfo,
 	}
 
-	expectedNetworkConfig := vc.NetworkConfig{
-		NumInterfaces: 1,
-	}
+	expectedNetworkConfig := vc.NetworkConfig{}
 
 	expectedSandboxConfig := vc.SandboxConfig{
 		ID:       containerID,


### PR DESCRIPTION
Remove unsed variable, the variable is set just in one place, and
never is used again.

Fixes: #603