### PR TITLE
virtcontainers: network: Add VFIO hotplug support

### DIFF
--- a/virtcontainers/physical_endpoint_test.go
+++ b/virtcontainers/physical_endpoint_test.go
@@ -26,7 +26,7 @@ func TestPhysicalEndpoint_HotAttach(t *testing.T) {
 	h := &mockHypervisor{}
 
 	err := v.HotAttach(h)
-	assert.Error(err)
+	assert.NoError(err)
 }
 
 func TestPhysicalEndpoint_HotDetach(t *testing.T) {


### PR DESCRIPTION
In order to support full network hotplug, it's mandatory that we can
support the hotplug of a VFIO device for the network interface.

Fixes #619

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>