### PR TITLE
Stable 1.2.1 candidate

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -322,7 +322,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 
 	if image != "" && initrd != "" {
 		return vc.HypervisorConfig{},
-			errors.New("cannot specify an image and an initrd in configuration file")
+			errors.New("having both an image and an initrd defined in the configuration file is not supported")
 	}
 
 	firmware, err := h.firmware()

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -24,7 +24,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.13"
+const formatVersion = "1.0.14"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -64,6 +64,7 @@ type RuntimeInfo struct {
 	Version RuntimeVersionInfo
 	Config  RuntimeConfigInfo
 	Debug   bool
+	Path    string
 }
 
 // RuntimeVersionInfo stores details of the runtime version
@@ -154,9 +155,12 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 		Path: configFile,
 	}
 
+	runtimePath, _ := os.Executable()
+
 	return RuntimeInfo{
 		Version: runtimeVersion,
 		Config:  runtimeConfig,
+		Path:    runtimePath,
 	}
 }
 

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -16,6 +16,7 @@ import (
 	"github.com/BurntSushi/toml"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	vcUtils "github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
@@ -24,7 +25,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.14"
+const formatVersion = "1.0.15"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -119,6 +120,7 @@ type HostInfo struct {
 	Distro             DistroInfo
 	CPU                CPUInfo
 	VMContainerCapable bool
+	SupportVSocks      bool
 }
 
 // EnvInfo collects all information that will be displayed by the
@@ -212,6 +214,7 @@ func getHostInfo() (HostInfo, error) {
 		Distro:             hostDistro,
 		CPU:                hostCPU,
 		VMContainerCapable: hostVMContainerCapable,
+		SupportVSocks:      vcUtils.SupportsVsocks(),
 	}
 
 	return host, nil

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -255,6 +255,8 @@ func getExpectedKernel(config oci.RuntimeConfig) KernelInfo {
 }
 
 func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
+	runtimePath, _ := os.Executable()
+
 	return RuntimeInfo{
 		Version: RuntimeVersionInfo{
 			Semver: version,
@@ -264,6 +266,7 @@ func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
 		Config: RuntimeConfigInfo{
 			Path: configFile,
 		},
+		Path: runtimePath,
 	}
 }
 

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	vcUtils "github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 
@@ -179,6 +180,7 @@ func genericGetExpectedHostDetails(tmpdir string) (HostInfo, error) {
 		Distro:             expectedDistro,
 		CPU:                expectedCPU,
 		VMContainerCapable: false,
+		SupportVSocks:      vcUtils.SupportsVsocks(),
 	}
 
 	testProcCPUInfo := filepath.Join(tmpdir, "cpuinfo")

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -287,6 +287,7 @@ func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
 		ID:         id,
 		SocketPath: endpoint.SocketPath,
 		MacAddress: endpoint.HardAddr,
+		Type:       config.VhostUserNet,
 	}
 
 	return h.addDevice(d, vhostuserDev)

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"bufio"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -591,6 +592,107 @@ func newNetwork(networkType NetworkModel) network {
 	}
 }
 
+const procMountInfoFile = "/proc/self/mountinfo"
+
+// getNetNsFromBindMount returns the network namespace for the bind-mounted path
+func getNetNsFromBindMount(nsPath string, procMountFile string) (string, error) {
+	netNsMountType := "nsfs"
+
+	// Resolve all symlinks in the path as the mountinfo file contains
+	// resolved paths.
+	nsPath, err := filepath.EvalSymlinks(nsPath)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(procMountFile)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		// Scan the mountinfo file to search for the network namespace path
+		// This file contains mounts in the eg format:
+		// "711 26 0:3 net:[4026532009] /run/docker/netns/default rw shared:535 - nsfs nsfs rw"
+		//
+		// Reference: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+
+		// We are interested in the first 9 fields of this file,
+		// to check for the correct mount type.
+		fields := strings.Split(text, " ")
+		if len(fields) < 9 {
+			continue
+		}
+
+		// We check here if the mount type is a network namespace mount type, namely "nsfs"
+		mountTypeFieldIdx := 8
+		if fields[mountTypeFieldIdx] != netNsMountType {
+			continue
+		}
+
+		// This is the mount point/destination for the mount
+		mntDestIdx := 4
+		if fields[mntDestIdx] != nsPath {
+			continue
+		}
+
+		// This is the root/source of the mount
+		return fields[3], nil
+	}
+
+	return "", nil
+}
+
+// hostNetworkingRequested checks if the network namespace requested is the
+// same as the current process.
+func hostNetworkingRequested(configNetNs string) (bool, error) {
+	var evalNS, nsPath, currentNsPath string
+	var err error
+
+	// Net namespace provided as "/proc/pid/ns/net" or "/proc/<pid>/task/<tid>/ns/net"
+	if strings.HasPrefix(configNetNs, "/proc") && strings.HasSuffix(configNetNs, "/ns/net") {
+		if _, err := os.Stat(configNetNs); err != nil {
+			return false, err
+		}
+
+		// Here we are trying to resolve the path but it fails because
+		// namespaces links don't really exist. For this reason, the
+		// call to EvalSymlinks will fail when it will try to stat the
+		// resolved path found. As we only care about the path, we can
+		// retrieve it from the PathError structure.
+		if _, err = filepath.EvalSymlinks(configNetNs); err != nil {
+			nsPath = err.(*os.PathError).Path
+		} else {
+			return false, fmt.Errorf("Net namespace path %s is not a symlink", configNetNs)
+		}
+
+		_, evalNS = filepath.Split(nsPath)
+
+	} else {
+		// Bind-mounted path provided
+		evalNS, _ = getNetNsFromBindMount(configNetNs, procMountInfoFile)
+	}
+
+	currentNS := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+	if _, err = filepath.EvalSymlinks(currentNS); err != nil {
+		currentNsPath = err.(*os.PathError).Path
+	} else {
+		return false, fmt.Errorf("Unexpected: Current network namespace path is not a symlink")
+	}
+
+	_, evalCurrentNS := filepath.Split(currentNsPath)
+
+	if evalNS == evalCurrentNS {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func initNetworkCommon(config NetworkConfig) (string, bool, error) {
 	if !config.InterworkingModel.IsValid() || config.InterworkingModel == NetXConnectDefaultModel {
 		config.InterworkingModel = DefaultNetInterworkingModel
@@ -603,6 +705,15 @@ func initNetworkCommon(config NetworkConfig) (string, bool, error) {
 		}
 
 		return path, true, nil
+	}
+
+	isHostNs, err := hostNetworkingRequested(config.NetNSPath)
+	if err != nil {
+		return "", false, err
+	}
+
+	if isHostNs {
+		return "", false, fmt.Errorf("Host networking requested, not supported by runtime")
 	}
 
 	return config.NetNSPath, false, nil

--- a/virtcontainers/pkg/cni/OWNERS
+++ b/virtcontainers/pkg/cni/OWNERS
@@ -1,3 +1,4 @@
+#SPDX-License-Identifier: Apache-2.0
 reviewers:
 - virtcontainers-maintainers
 

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -24,7 +24,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off,nvdimm"
 
 const defaultPCBridgeBus = "pci.0"
 


### PR DESCRIPTION
Walked through all patches on master from HEAD (8bbd9b5) to 1.2.0 , and cherrypicked the relevant ones.  Analysis is as follows:
```
1.2.1 | * ee1ea36 network: fix vhost-user net creation

1.2.1 | * | 161e3a7 vc: Remove unused variable NumInterfaces

1.2.1 | * | 88d79f3 cli: kata-env: show if vsocks are supported

NO * |   26f3107 Merge pull request #287 from caoruidong/hotplug
 | * | 7beb309 test: add UTs for network hotplug
 | * | 72df219 cli: add network commands
 | * | 1a17200 virtcontainers: add sandbox hotplug network API
 | * | 6666426 vendor: update govmm and agent changes

NO * | |   b473dc4 Merge pull request #579 from lifupan/master
 | * | | 4850579 CI: bump the CI travis's go to 1.10

1.2.1 | * | | 8b69c75 cli: kata-env: add runtime path to output

NO * | |   cd514b6 Merge pull request #568 from amshinde/remove-unused-cni-code
 | * | | 474111c tests: Add a cleanup for the CNM tests
 | * | | 0d7b476 network: Remove unused cni vendored code
 | * | | 99fa758 network: Remove unused CNI code

NO * | | |   e0c179d Merge pull request #550 from WeiZhang555/add-device-before-container-create
| * | | 6e6be98 devices: add interface "sandbox.AddDevice"

NO * | | |   83008d4 Merge pull request #583 from amshinde/update-qemu-commit
 | * | | f6bfb85 versions: Update the commit for qemu-lite

NO * | |   dd2acd2 Merge pull request #565 from jodh-intel/support-opentracing
 | * | 3a1bbd0 (jodh/support-opentracing) tracing: Add initial opentracing support
 | * | 0ede467 tests: Add cli.Context helper functions
 | * | 41d1c14 tests: Move assert closer to function call

1.2.1 | * | bee8d66 cli: Make message of using initrd OR rootfs clearer


NO * |   800369d Merge pull request #574 from jodh-intel/update-dep-lock-file-format
 | * | d9fa73c (jodh/update-dep-lock-file-format) vendor: Update dep lock file for new format

1.2.1 | * | 2f3f375 network: Error out when host-networking is requested

1.2.1 | * | | ef3a7e8 virtcontainers: ppc64le: Add nvdimm to defaultQemuMachineOption

NO * | |   e863e55 Merge pull request #559 from sboeuf/enable_virt_machine_type
 | * | ef74bc5 virtcontainers: qemu: x86: Support "virt" machine type
```