### PR TITLE
virtcontainers: qemu: Don't shutdown QMP from hotplug

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -835,12 +835,6 @@ func (q *qemu) hotplugMacvtap(drive VirtualEndpoint) error {
 }
 
 func (q *qemu) hotplugNetDevice(drive VirtualEndpoint, op operation) error {
-	defer func(qemu *qemu) {
-		if q.qmpMonitorCh.qmp != nil {
-			q.qmpMonitorCh.qmp.Shutdown()
-		}
-	}(q)
-
 	err := q.qmpSetup()
 	if err != nil {
 		return err


### PR DESCRIPTION
The QMP shutdown is taken care of by the sandbox release, through a
call to hypervisor.disconnect(). By shutting down the QMP at the qemu
level directly, we are creating some unrecoverable errors by trying to
close an already closed channel.

This patch simply removes the faulty code, following the same design
other hotplug functions are designed.

Fixes #627

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>