### PR TITLE
config: Detect if VM memory smaller than image

### DIFF
--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -76,7 +76,8 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	}
 
 	for _, file := range filesToCreate {
-		err := createEmptyFile(file)
+		// files must exist and be >0 bytes.
+		err := writeFile(file, "foo", testFileMode)
 		if err != nil {
 			return "", oci.RuntimeConfig{}, err
 		}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 const (
@@ -229,4 +230,16 @@ func writeFile(filePath string, data string, fileMode os.FileMode) error {
 // isEmptyString return if string is empty
 func isEmptyString(b []byte) bool {
 	return len(bytes.Trim(b, "\n")) == 0
+}
+
+// fileSize returns the number of bytes in the specified file
+func fileSize(file string) (int64, error) {
+	st := syscall.Stat_t{}
+
+	err := syscall.Stat(file, &st)
+	if err != nil {
+		return 0, err
+	}
+
+	return st.Size, nil
 }

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -362,3 +362,37 @@ func TestWriteFileErrNoPath(t *testing.T) {
 	err = writeFile(dir, "", 0000)
 	assert.Error(err)
 }
+
+func TestFileSize(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir(testDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file := filepath.Join(dir, "foo")
+
+	// ENOENT
+	_, err = fileSize(file)
+	assert.Error(err)
+
+	err = createEmptyFile(file)
+	assert.NoError(err)
+
+	// zero size
+	size, err := fileSize(file)
+	assert.NoError(err)
+	assert.Equal(size, int64(0))
+
+	msg := "hello"
+	msgLen := len(msg)
+
+	err = writeFile(file, msg, testFileMode)
+	assert.NoError(err)
+
+	size, err = fileSize(file)
+	assert.NoError(err)
+	assert.Equal(size, int64(msgLen))
+}


### PR DESCRIPTION
Add a heuristic to ensure the amount of memory allocated to the
hypervisor is bigger than the size of the image.

This catches simple configuration issues where `default_memory=` is set
to a smaller value than the size of either the `image=` or `initrd=`
files.

If the configured image type is `initrd`, fail but only warn in the
logs for `image` as although it seems a highly unlikely scenario, it is
permitted.

Update tests to ensure that created resources have `>0` bytes.

Fixes #636.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>