### PR TITLE
versions: Bump golang from 1.8.3 to 1.9.7

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -183,7 +183,7 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.8.3"
+    version: "1.9.7"
     meta:
       newest-version: "1.10"
 


### PR DESCRIPTION
golang version 1.8.3 is old and the runtime cannot even be built with
it now it seems.

Since it is no longer considered a stable version [1], move to the
oldest official stable version (version 1.9.7).

Fixes #642.

[1] - https://golang.org/dl/

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>