### PR TITLE
govmm: modify govmm to be compatible with qemu 2.8

### DIFF
--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -653,7 +653,7 @@ func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string)
 		},
 	}
 
-	if q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 9) {
+	if q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 8) {
 		blockdevArgs["node-name"] = blockdevID
 		args = blockdevArgs
 	} else {
@@ -734,7 +734,12 @@ func (q *QMP) ExecuteBlockdevDel(ctx context.Context, blockdevID string) error {
 		return q.executeCommand(ctx, "blockdev-del", args, nil)
 	}
 
-	args["id"] = blockdevID
+	if q.version.Major == 2 && q.version.Minor == 8 {
+		args["node-name"] = blockdevID
+	} else {
+		args["id"] = blockdevID
+	}
+
 	return q.executeCommand(ctx, "x-blockdev-del", args, nil)
 }
 


### PR DESCRIPTION
govmm has `ExecuteBlockdevAdd()` function and `ExecuteBlockdevDel()` function
doesn't compatible with qemu 2.8,because `blockdev-add` and `x-blockdev-del` usages
are different between qemu 2.7 and qemu 2.8

Follow the qemu 2.7 and qemu 2.8 qmp-commands.txt documents to modify `ExecuteBlockdevAdd()`
function and `ExecuteBlockdevDel()` function to be compatible with qemu 2.8

Signed-off-by: flyflypeng <jiangpengfei9@huawei.com>