### PR TITLE
builtin-proxy: print guest console output to logger

### DIFF
--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -82,7 +82,10 @@ func (p *kataBuiltInProxy) watchConsole(proto, console string, logger *logrus.En
 	go func() {
 		scanner = bufio.NewScanner(conn)
 		for scanner.Scan() {
-			fmt.Printf("[SB-%s] vmconsole: %s\n", p.sandboxID, scanner.Text())
+			logger.WithFields(logrus.Fields{
+				"sandbox":   p.sandboxID,
+				"vmconsole": scanner.Text(),
+			}).Debug("reading guest console")
 		}
 
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
So daemons such as containerd shimv2 can still see it.

Fixes: #647