### PR TITLE
vendor: update govmm to be compatible with qemu 2.8

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -115,11 +115,11 @@
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
-  digest = "1:e35245b8aac4b53c6dd7b161c8c19f038e2ad29a54a03d276a88f3fc2a656c29"
+  digest = "1:052c0d6d677c7a3f12d8f83e0a1ce20a896cc206782b035f380249d23bf1265d"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "d8f80cafe3ee3bba440a9ff8d234817b64a30b07"
+  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
 
 [[projects]]
   digest = "1:55460fbdfca464360cec902b0805126451908aa1a058fe4072b01650ebe768b3"
@@ -405,6 +405,7 @@
     "github.com/opencontainers/runc/libcontainer/utils",
     "github.com/opencontainers/runtime-spec/specs-go",
     "github.com/opentracing/opentracing-go",
+    "github.com/opentracing/opentracing-go/log",
     "github.com/safchain/ethtool",
     "github.com/sirupsen/logrus",
     "github.com/sirupsen/logrus/hooks/syslog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "d8f80cafe3ee3bba440a9ff8d234817b64a30b07"
+  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -859,7 +859,7 @@ func (q *qemu) hotplugNetDevice(drive VirtualEndpoint, op operation) error {
 			return err
 		}
 		drive.PCIAddr = fmt.Sprintf("%02x/%s", bridge.Addr, addr)
-		if err = q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, drive.NetPair.Name, devID, drive.NetPair.TAPIface.HardAddr, addr, bridge.ID); err != nil {
+		if err = q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, drive.NetPair.Name, devID, drive.NetPair.TAPIface.HardAddr, addr, bridge.ID, defaultQueues); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
govmm has ExecuteBlockdevAdd() function and ExecuteBlockdevDel() function
doesn't compatible with qemu 2.8,because blockdev-add and x-blockdev-del usages
are different between qemu 2.7 and qemu 2.8

shortlog:

ce070d1 govmm: modify govmm to be compatible with qemu 2.8
0286ff9 qemu/qmp: support hotplug a nic whose qdisc is mq
8515ae4 qmp: Remind users that you must first call ExecuteQMPCapabilities()
21504d3 qemu/qmp: Add netdev_add with chardev support
ed34f61 Add some negative test cases for qmp.go
17cacc7 Add negative test cases for qemu.go

fixes: #637

Signed-off-by: flyflypeng <jiangpengfei9@huawei.com>