### PR TITLE
virtcontainers: Apply memory constraints

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -670,7 +670,6 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	// Issue: https://github.com/kata-containers/runtime/issues/158
 	// Issue: https://github.com/kata-containers/runtime/issues/204
 	grpcSpec.Linux.Resources.Devices = nil
-	grpcSpec.Linux.Resources.Memory = nil
 	grpcSpec.Linux.Resources.Pids = nil
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -451,7 +451,7 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	assert.Nil(g.Hooks)
 	assert.Nil(g.Linux.Seccomp)
 	assert.Nil(g.Linux.Resources.Devices)
-	assert.Nil(g.Linux.Resources.Memory)
+	assert.NotNil(g.Linux.Resources.Memory)
 	assert.Nil(g.Linux.Resources.Pids)
 	assert.Nil(g.Linux.Resources.BlockIO)
 	assert.Nil(g.Linux.Resources.HugepageLimits)


### PR DESCRIPTION
Apply all supported memory constraints to the contrainer
inside the virtual machine.

fixes #653

Signed-off-by: Julio Montes <julio.montes@intel.com>