### PR TITLE
travis: Add variable needed to run static checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ go_import_path: github.com/kata-containers/runtime
 go:
   - "1.10.x"
 
+env:
+  - target_branch=$TRAVIS_BRANCH
+
 before_script:
   - ".ci/static-checks.sh"
 


### PR DESCRIPTION
Now that we support multiple branches, we changed how
static-checks.sh compares branches. We now need a
variable called $target_branch to make the correct
comparison when testing a PR.

Fixes: #663.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>