### PR TITLE
qemu: Add rng virtio device

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,11 +123,11 @@
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
-  digest = "1:052c0d6d677c7a3f12d8f83e0a1ce20a896cc206782b035f380249d23bf1265d"
+  digest = "1:7434a85a1d6c2bf64f322087ec7a7f84ab9e971179bef7b95deabaf0e3f7c126"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
+  revision = "e2c716433e444017507e3587ce071868fd164380"
 
 [[projects]]
   digest = "1:01c37fcb6e2a1fe1321a97faaef74c66ac531ea292ca3f929b7189cc400b1d47"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
+  revision = "e2c716433e444017507e3587ce071868fd164380"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/versions.yaml
+++ b/versions.yaml
@@ -64,7 +64,7 @@ assets:
       description: "lightweight VMM that uses KVM"
       url: "https://github.com/kata-containers/qemu"
       branch: "qemu-lite-2.11.0"
-      commit: "a39e0b3e828ff6fb4457865ef7a021f1e7320c27"
+      commit: "f88622805677163b04498dcba35ceca0183b1318"
 
     qemu:
       description: "VMM that uses KVM"

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -117,6 +117,12 @@ type VFIODev struct {
 	BDF string
 }
 
+// RNGDev represents a random number generator device
+type RNGDev struct {
+	// ID is used to identify the device in the hypervisor options.
+	ID string
+}
+
 // VhostUserDeviceAttrs represents data shared by most vhost-user devices
 type VhostUserDeviceAttrs struct {
 	DevID      string

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -81,6 +81,7 @@ const (
 	qmpExecCatCmd                     = "exec:cat"
 
 	scsiControllerID = "scsi0"
+	rngID            = "rng0"
 )
 
 var qemuMajorVersion int
@@ -488,6 +489,11 @@ func (q *qemu) createSandbox() error {
 	if ioThread != nil {
 		qemuConfig.IOThreads = []govmmQemu.IOThread{*ioThread}
 	}
+	// Add RNG device to hypervisor
+	rngDev := config.RNGDev{
+		ID: rngID,
+	}
+	qemuConfig.Devices = q.arch.appendRNGDevice(qemuConfig.Devices, rngDev)
 
 	q.qemuConfig = qemuConfig
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -82,6 +82,9 @@ type qemuArch interface {
 	// appendVFIODevice appends a VFIO device to devices
 	appendVFIODevice(devices []govmmQemu.Device, vfioDevice config.VFIODev) []govmmQemu.Device
 
+	// appendRNGDevice appends a RNG device to devices
+	appendRNGDevice(devices []govmmQemu.Device, rngDevice config.RNGDev) []govmmQemu.Device
+
 	// handleImagePath handles the Hypervisor Config image path
 	handleImagePath(config HypervisorConfig)
 }
@@ -499,6 +502,16 @@ func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev conf
 	devices = append(devices,
 		govmmQemu.VFIODevice{
 			BDF: vfioDev.BDF,
+		},
+	)
+
+	return devices
+}
+
+func (q *qemuArchBase) appendRNGDevice(devices []govmmQemu.Device, rngDev config.RNGDev) []govmmQemu.Device {
+	devices = append(devices,
+		govmmQemu.RngDevice{
+			ID: rngDev.ID,
 		},
 	)
 


### PR DESCRIPTION
Kata Containers does not provide good entropy. Enable a paravirtual rng device to provide a random number generator source.

Depens on: https://github.com/intel/govmm/pull/45

Fixes: #445 