### PR TITLE
factory: start proxy before assign vm to a sandbox

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -145,6 +145,12 @@ type agent interface {
 	// start the proxy
 	startProxy(sandbox *Sandbox) error
 
+	// set to use an existing proxy
+	setProxy(sandbox *Sandbox, proxy proxy, pid int, url string) error
+
+	// get agent url
+	getAgentURL() (string, error)
+
 	// createSandbox will tell the agent to perform necessary setup for a Sandbox.
 	createSandbox(sandbox *Sandbox) error
 

--- a/virtcontainers/cc_proxy.go
+++ b/virtcontainers/cc_proxy.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"fmt"
 	"os/exec"
 )
 
@@ -14,8 +15,12 @@ type ccProxy struct {
 
 // start is the proxy start implementation for ccProxy.
 func (p *ccProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
-	config, err := newProxyConfig(sandbox.config)
-	if err != nil {
+	if sandbox.config == nil {
+		return -1, "", fmt.Errorf("Sandbox config cannot be nil")
+	}
+
+	config := sandbox.config.ProxyConfig
+	if err := validateProxyConfig(config); err != nil {
 		return -1, "", err
 	}
 

--- a/virtcontainers/cc_proxy.go
+++ b/virtcontainers/cc_proxy.go
@@ -5,33 +5,27 @@
 
 package virtcontainers
 
-import (
-	"fmt"
-	"os/exec"
-)
+import "os/exec"
 
 type ccProxy struct {
 }
 
 // start is the proxy start implementation for ccProxy.
-func (p *ccProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
-	if sandbox.config == nil {
-		return -1, "", fmt.Errorf("Sandbox config cannot be nil")
-	}
-
-	config := sandbox.config.ProxyConfig
-	if err := validateProxyConfig(config); err != nil {
+func (p *ccProxy) start(params proxyParams) (int, string, error) {
+	if err := validateProxyParams(params); err != nil {
 		return -1, "", err
 	}
 
+	params.logger.Info("Starting cc proxy")
+
 	// construct the socket path the proxy instance will use
-	proxyURL, err := defaultProxyURL(sandbox, SocketTypeUNIX)
+	proxyURL, err := defaultProxyURL(params.id, SocketTypeUNIX)
 	if err != nil {
 		return -1, "", err
 	}
 
-	args := []string{config.Path, "-uri", proxyURL}
-	if config.Debug {
+	args := []string{params.path, "-uri", proxyURL}
+	if params.debug {
 		args = append(args, "-log", "debug")
 	}
 
@@ -43,7 +37,7 @@ func (p *ccProxy) start(sandbox *Sandbox, params proxyParams) (int, string, erro
 	return cmd.Process.Pid, proxyURL, nil
 }
 
-func (p *ccProxy) stop(sandbox *Sandbox, pid int) error {
+func (p *ccProxy) stop(pid int) error {
 	return nil
 }
 

--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -7,10 +7,22 @@ package virtcontainers
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCCProxyStart(t *testing.T) {
 	proxy := &ccProxy{}
 
 	testProxyStart(t, nil, proxy)
+}
+
+func TestCCProxy(t *testing.T) {
+	proxy := &ccProxy{}
+	assert := assert.New(t)
+
+	err := proxy.stop(0)
+	assert.Nil(err)
+
+	assert.False(proxy.consoleWatched())
 }

--- a/virtcontainers/cc_proxy_test.go
+++ b/virtcontainers/cc_proxy_test.go
@@ -12,5 +12,5 @@ import (
 func TestCCProxyStart(t *testing.T) {
 	proxy := &ccProxy{}
 
-	testProxyStart(t, nil, proxy, CCProxyType)
+	testProxyStart(t, nil, proxy)
 }

--- a/virtcontainers/factory/base/base.go
+++ b/virtcontainers/factory/base/base.go
@@ -21,7 +21,7 @@ type FactoryBase interface {
 	Config() vc.VMConfig
 
 	// GetBaseVM returns a paused VM created by the base factory.
-	GetBaseVM(ctx context.Context) (*vc.VM, error)
+	GetBaseVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error)
 
 	// CloseFactory closes the base factory.
 	CloseFactory(ctx context.Context)

--- a/virtcontainers/factory/cache/cache.go
+++ b/virtcontainers/factory/cache/cache.go
@@ -37,7 +37,7 @@ func New(ctx context.Context, count uint, b base.FactoryBase) base.FactoryBase {
 		c.wg.Add(1)
 		go func() {
 			for {
-				vm, err := b.GetBaseVM(ctx)
+				vm, err := b.GetBaseVM(ctx, c.Config())
 				if err != nil {
 					c.wg.Done()
 					c.CloseFactory(ctx)
@@ -63,7 +63,7 @@ func (c *cache) Config() vc.VMConfig {
 }
 
 // GetBaseVM returns a base VM from cache factory's base factory.
-func (c *cache) GetBaseVM(ctx context.Context) (*vc.VM, error) {
+func (c *cache) GetBaseVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error) {
 	vm, ok := <-c.cacheCh
 	if ok {
 		return vm, nil

--- a/virtcontainers/factory/cache/cache_test.go
+++ b/virtcontainers/factory/cache/cache_test.go
@@ -27,6 +27,7 @@ func TestTemplateFactory(t *testing.T) {
 	vmConfig := vc.VMConfig{
 		HypervisorType:   vc.MockHypervisor,
 		AgentType:        vc.NoopAgentType,
+		ProxyType:        vc.NoopProxyType,
 		HypervisorConfig: hyperConfig,
 	}
 
@@ -39,7 +40,7 @@ func TestTemplateFactory(t *testing.T) {
 	assert.Equal(f.Config(), vmConfig)
 
 	// GetBaseVM
-	_, err := f.GetBaseVM(ctx)
+	_, err := f.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 
 	// CloseFactory

--- a/virtcontainers/factory/direct/direct.go
+++ b/virtcontainers/factory/direct/direct.go
@@ -28,8 +28,8 @@ func (d *direct) Config() vc.VMConfig {
 }
 
 // GetBaseVM create a new VM directly.
-func (d *direct) GetBaseVM(ctx context.Context) (*vc.VM, error) {
-	vm, err := vc.NewVM(ctx, d.config)
+func (d *direct) GetBaseVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error) {
+	vm, err := vc.NewVM(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/virtcontainers/factory/direct/direct_test.go
+++ b/virtcontainers/factory/direct/direct_test.go
@@ -26,6 +26,7 @@ func TestTemplateFactory(t *testing.T) {
 	vmConfig := vc.VMConfig{
 		HypervisorType:   vc.MockHypervisor,
 		AgentType:        vc.NoopAgentType,
+		ProxyType:        vc.NoopProxyType,
 		HypervisorConfig: hyperConfig,
 	}
 
@@ -38,7 +39,7 @@ func TestTemplateFactory(t *testing.T) {
 	assert.Equal(f.Config(), vmConfig)
 
 	// GetBaseVM
-	_, err := f.GetBaseVM(ctx)
+	_, err := f.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 
 	// CloseFactory

--- a/virtcontainers/factory/factory_test.go
+++ b/virtcontainers/factory/factory_test.go
@@ -98,8 +98,6 @@ func TestVMConfigValid(t *testing.T) {
 
 	config := vc.VMConfig{
 		HypervisorType: vc.MockHypervisor,
-		AgentType:      vc.NoopAgentType,
-		ProxyType:      vc.NoopProxyType,
 		HypervisorConfig: vc.HypervisorConfig{
 			KernelPath: testDir,
 			ImagePath:  testDir,
@@ -109,6 +107,14 @@ func TestVMConfigValid(t *testing.T) {
 	f := factory{}
 
 	err := f.validateNewVMConfig(config)
+	assert.NotNil(err)
+
+	config.AgentType = vc.NoopAgentType
+	err = f.validateNewVMConfig(config)
+	assert.NotNil(err)
+
+	config.ProxyType = vc.NoopProxyType
+	err = f.validateNewVMConfig(config)
 	assert.Nil(err)
 }
 
@@ -167,6 +173,9 @@ func TestFactoryGetVM(t *testing.T) {
 		AgentType:        vc.NoopAgentType,
 		ProxyType:        vc.NoopProxyType,
 	}
+
+	err := vmConfig.Valid()
+	assert.Nil(err)
 
 	ctx := context.Background()
 

--- a/virtcontainers/factory/factory_test.go
+++ b/virtcontainers/factory/factory_test.go
@@ -94,23 +94,21 @@ func TestFactorySetLogger(t *testing.T) {
 func TestVMConfigValid(t *testing.T) {
 	assert := assert.New(t)
 
-	config := Config{}
-
-	err := config.validate()
-	assert.Error(err)
-
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
 
-	config.VMConfig = vc.VMConfig{
+	config := vc.VMConfig{
 		HypervisorType: vc.MockHypervisor,
 		AgentType:      vc.NoopAgentType,
+		ProxyType:      vc.NoopProxyType,
 		HypervisorConfig: vc.HypervisorConfig{
 			KernelPath: testDir,
 			ImagePath:  testDir,
 		},
 	}
 
-	err = config.validate()
+	f := factory{}
+
+	err := f.validateNewVMConfig(config)
 	assert.Nil(err)
 }
 
@@ -165,8 +163,9 @@ func TestFactoryGetVM(t *testing.T) {
 	}
 	vmConfig := vc.VMConfig{
 		HypervisorType:   vc.MockHypervisor,
-		AgentType:        vc.NoopAgentType,
 		HypervisorConfig: hyperConfig,
+		AgentType:        vc.NoopAgentType,
+		ProxyType:        vc.NoopProxyType,
 	}
 
 	ctx := context.Background()

--- a/virtcontainers/factory/template/template.go
+++ b/virtcontainers/factory/template/template.go
@@ -23,6 +23,10 @@ type template struct {
 	config    vc.VMConfig
 }
 
+var templateProxyType = vc.KataBuiltInProxyType
+var templateWaitForAgent = 2 * time.Second
+var templateWaitForMigration = 1 * time.Second
+
 // Fetch finds and returns a pre-built template factory.
 // TODO: save template metadata and fetch from storage.
 func Fetch(config vc.VMConfig) (base.FactoryBase, error) {
@@ -63,8 +67,8 @@ func (t *template) Config() vc.VMConfig {
 }
 
 // GetBaseVM creates a new paused VM from the template VM.
-func (t *template) GetBaseVM(ctx context.Context) (*vc.VM, error) {
-	return t.createFromTemplateVM(ctx)
+func (t *template) GetBaseVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error) {
+	return t.createFromTemplateVM(ctx, config)
 }
 
 // CloseFactory cleans up the template VM.
@@ -100,6 +104,8 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
 	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	// template vm uses builtin proxy
+	config.ProxyType = templateProxyType
 
 	vm, err := vc.NewVM(ctx, config)
 	if err != nil {
@@ -107,28 +113,41 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	}
 	defer vm.Stop()
 
-	err = vm.Pause()
-	if err != nil {
+	if err = vm.Disconnect(); err != nil {
 		return err
 	}
 
-	err = vm.Save()
-	if err != nil {
+	// Sleep a bit to let the agent grpc server clean up
+	// When we close connection to the agent, it needs sometime to cleanup
+	// and restart listening on the communication( serial or vsock) port.
+	// That time can be saved if we sleep a bit to wait for the agent to
+	// come around and start listening again. The sleep is only done when
+	// creating new vm templates and saves time for every new vm that are
+	// created from template, so it worth the invest.
+	time.Sleep(templateWaitForAgent)
+
+	if err = vm.Pause(); err != nil {
+		return err
+	}
+
+	if err = vm.Save(); err != nil {
 		return err
 	}
 
 	// qemu QMP does not wait for migration to finish...
-	time.Sleep(1 * time.Second)
+	time.Sleep(templateWaitForMigration)
 
 	return nil
 }
 
-func (t *template) createFromTemplateVM(ctx context.Context) (*vc.VM, error) {
+func (t *template) createFromTemplateVM(ctx context.Context, c vc.VMConfig) (*vc.VM, error) {
 	config := t.config
 	config.HypervisorConfig.BootToBeTemplate = false
 	config.HypervisorConfig.BootFromTemplate = true
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
 	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	config.ProxyType = c.ProxyType
+	config.ProxyConfig = c.ProxyConfig
 
 	return vc.NewVM(ctx, config)
 }

--- a/virtcontainers/factory/template/template_test.go
+++ b/virtcontainers/factory/template/template_test.go
@@ -35,6 +35,9 @@ func TestTemplateFactory(t *testing.T) {
 		ProxyType:        vc.NoopProxyType,
 	}
 
+	err := vmConfig.Valid()
+	assert.Nil(err)
+
 	ctx := context.Background()
 
 	// New
@@ -44,7 +47,7 @@ func TestTemplateFactory(t *testing.T) {
 	assert.Equal(f.Config(), vmConfig)
 
 	// GetBaseVM
-	_, err := f.GetBaseVM(ctx, vmConfig)
+	_, err = f.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 
 	// Fetch
@@ -52,6 +55,8 @@ func TestTemplateFactory(t *testing.T) {
 		statePath: testDir,
 		config:    vmConfig,
 	}
+
+	assert.Equal(tt.Config(), vmConfig)
 
 	err = tt.checkTemplateVM()
 	assert.Error(err)
@@ -69,11 +74,17 @@ func TestTemplateFactory(t *testing.T) {
 	err = tt.createTemplateVM(ctx)
 	assert.Error(err)
 
+	templateProxyType = vc.NoopProxyType
+	_, err = tt.GetBaseVM(ctx, vmConfig)
+	assert.Nil(err)
+
 	_, err = f.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 
-	templateProxyType = vc.NoopProxyType
 	err = tt.createTemplateVM(ctx)
+	assert.Nil(err)
+
+	_, err = tt.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 
 	_, err = f.GetBaseVM(ctx, vmConfig)

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -390,7 +390,11 @@ func (h *hyper) startProxy(sandbox *Sandbox) error {
 	}
 
 	// Start the proxy here
-	pid, uri, err := h.proxy.start(sandbox, proxyParams{})
+	pid, uri, err := h.proxy.start(proxyParams{
+		id:     sandbox.id,
+		path:   sandbox.config.ProxyConfig.Path,
+		logger: h.Logger(),
+	})
 	if err != nil {
 		return err
 	}
@@ -461,7 +465,7 @@ func (h *hyper) stopSandbox(sandbox *Sandbox) error {
 		return err
 	}
 
-	return h.proxy.stop(sandbox, h.state.ProxyPid)
+	return h.proxy.stop(h.state.ProxyPid)
 }
 
 // handleBlockVolumes handles volumes that are block device files, by

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -238,3 +238,26 @@ func TestHyperListRoutes(t *testing.T) {
 	_, err := h.listRoutes()
 	assert.Nil(err)
 }
+
+func TestHyperSetProxy(t *testing.T) {
+	assert := assert.New(t)
+
+	h := &hyper{}
+	p := &ccProxy{}
+	s := &Sandbox{storage: &filesystem{}}
+
+	err := h.setProxy(s, p, 0, "")
+	assert.Error(err)
+
+	err = h.setProxy(s, p, 0, "foobar")
+	assert.Error(err)
+}
+
+func TestHyperGetAgentUrl(t *testing.T) {
+	assert := assert.New(t)
+	h := &hyper{}
+
+	url, err := h.getAgentURL()
+	assert.Nil(err)
+	assert.Empty(url)
+}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -795,3 +795,35 @@ func TestAgentNetworkOperation(t *testing.T) {
 	_, err = k.listRoutes()
 	assert.Nil(err)
 }
+
+func TestKataAgentSetProxy(t *testing.T) {
+	assert := assert.New(t)
+
+	k := &kataAgent{}
+	p := &kataBuiltInProxy{}
+	s := &Sandbox{storage: &filesystem{}}
+
+	err := k.setProxy(s, p, 0, "")
+	assert.Error(err)
+
+	err = k.setProxy(s, p, 0, "foobar")
+	assert.Error(err)
+}
+
+func TestKataGetAgentUrl(t *testing.T) {
+	assert := assert.New(t)
+
+	k := &kataAgent{}
+	err := k.generateVMSocket("foobar", KataAgentConfig{})
+	assert.Nil(err)
+	url, err := k.getAgentURL()
+	assert.Nil(err)
+	assert.NotEmpty(url)
+
+	err = k.generateVMSocket("foobar", KataAgentConfig{UseVSock: true})
+	assert.Nil(err)
+	url, err = k.getAgentURL()
+	assert.Nil(err)
+	assert.NotEmpty(url)
+
+}

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var buildinProxyConsoleProto = consoleProtoUnix
+
 // This is a kata builtin proxy implementation of the proxy interface. Kata proxy
 // functionality is implemented inside the virtcontainers library.
 type kataBuiltInProxy struct {
@@ -53,7 +55,7 @@ func (p *kataBuiltInProxy) start(params proxyParams) (int, string, error) {
 	params.logger.Info("Starting builtin kata proxy")
 
 	p.sandboxID = params.id
-	err := p.watchConsole(consoleProtoUnix, params.consoleURL, params.logger)
+	err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
 	if err != nil {
 		p.sandboxID = ""
 		return -1, "", err

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -26,22 +26,36 @@ func (p *kataBuiltInProxy) consoleWatched() bool {
 	return p.conn != nil
 }
 
+func (p *kataBuiltInProxy) validateParams(params proxyParams) error {
+	if len(params.id) == 0 || len(params.agentURL) == 0 || len(params.consoleURL) == 0 {
+		return fmt.Errorf("Invalid proxy parameters %+v", params)
+	}
+
+	if params.logger == nil {
+		return fmt.Errorf("Invalid proxy parameter: proxy logger is not set")
+	}
+
+	return nil
+}
+
 // start is the proxy start implementation for kata builtin proxy.
 // It starts the console watcher for the guest.
 // It returns agentURL to let agent connect directly.
-func (p *kataBuiltInProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
-	if p.consoleWatched() {
-		return -1, "", fmt.Errorf("kata builtin proxy running for sandbox %s", p.sandboxID)
-	}
-
-	p.sandboxID = sandbox.id
-	console, err := sandbox.hypervisor.getSandboxConsole(sandbox.id)
-	if err != nil {
+func (p *kataBuiltInProxy) start(params proxyParams) (int, string, error) {
+	if err := p.validateParams(params); err != nil {
 		return -1, "", err
 	}
 
-	err = p.watchConsole(consoleProtoUnix, console, params.logger)
+	if p.consoleWatched() {
+		return -1, "", fmt.Errorf("kata builtin proxy running for sandbox %s", params.id)
+	}
+
+	params.logger.Info("Starting builtin kata proxy")
+
+	p.sandboxID = params.id
+	err := p.watchConsole(consoleProtoUnix, params.consoleURL, params.logger)
 	if err != nil {
+		p.sandboxID = ""
 		return -1, "", err
 	}
 
@@ -49,7 +63,7 @@ func (p *kataBuiltInProxy) start(sandbox *Sandbox, params proxyParams) (int, str
 }
 
 // stop is the proxy stop implementation for kata builtin proxy.
-func (p *kataBuiltInProxy) stop(sandbox *Sandbox, pid int) error {
+func (p *kataBuiltInProxy) stop(pid int) error {
 	if p.conn != nil {
 		p.conn.Close()
 		p.conn = nil

--- a/virtcontainers/kata_builtin_proxy_test.go
+++ b/virtcontainers/kata_builtin_proxy_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKataBuiltinProxy(t *testing.T) {
+	assert := assert.New(t)
+
+	p := kataBuiltInProxy{}
+
+	params := proxyParams{}
+
+	err := p.validateParams(params)
+	assert.NotNil(err)
+
+	params.id = "foobarproxy"
+	err = p.validateParams(params)
+	assert.NotNil(err)
+
+	params.agentURL = "foobaragent"
+	err = p.validateParams(params)
+	assert.NotNil(err)
+
+	params.consoleURL = "foobarconsole"
+	err = p.validateParams(params)
+	assert.NotNil(err)
+
+	params.logger = logrus.WithField("proxy", params.id)
+	err = p.validateParams(params)
+	assert.Nil(err)
+
+	buildinProxyConsoleProto = "foobarproto"
+	_, _, err = p.start(params)
+	assert.NotNil(err)
+	assert.Empty(p.sandboxID)
+
+	err = p.stop(0)
+	assert.Nil(err)
+
+	assert.False(p.consoleWatched())
+}

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -25,6 +25,10 @@ func (p *kataProxy) consoleWatched() bool {
 // start is kataProxy start implementation for proxy interface.
 func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
 	sandbox.Logger().Info("Starting regular Kata proxy rather than built-in")
+	if sandbox.config == nil {
+		return -1, "", fmt.Errorf("Sandbox config cannot be nil")
+	}
+
 	if sandbox.agent == nil {
 		return -1, "", fmt.Errorf("No agent")
 	}
@@ -33,8 +37,8 @@ func (p *kataProxy) start(sandbox *Sandbox, params proxyParams) (int, string, er
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
 
-	config, err := newProxyConfig(sandbox.config)
-	if err != nil {
+	config := sandbox.config.ProxyConfig
+	if err := validateProxyConfig(config); err != nil {
 		return -1, "", err
 	}
 

--- a/virtcontainers/kata_proxy_test.go
+++ b/virtcontainers/kata_proxy_test.go
@@ -13,5 +13,5 @@ func TestKataProxyStart(t *testing.T) {
 	agent := &kataAgent{}
 	proxy := &kataProxy{}
 
-	testProxyStart(t, agent, proxy, KataProxyType)
+	testProxyStart(t, agent, proxy)
 }

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -23,8 +23,13 @@ type noProxy struct {
 }
 
 // start is noProxy start implementation for proxy interface.
-func (p *noProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
-	sandbox.Logger().Info("No proxy started because of no-proxy implementation")
+func (p *noProxy) start(params proxyParams) (int, string, error) {
+	if params.logger == nil {
+		return -1, "", fmt.Errorf("proxy logger is not set")
+	}
+
+	params.logger.Info("No proxy started because of no-proxy implementation")
+
 	if params.agentURL == "" {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")
 	}
@@ -33,7 +38,7 @@ func (p *noProxy) start(sandbox *Sandbox, params proxyParams) (int, string, erro
 }
 
 // stop is noProxy stop implementation for proxy interface.
-func (p *noProxy) stop(sandbox *Sandbox, pid int) error {
+func (p *noProxy) stop(pid int) error {
 	return nil
 }
 

--- a/virtcontainers/no_proxy_test.go
+++ b/virtcontainers/no_proxy_test.go
@@ -7,33 +7,30 @@ package virtcontainers
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNoProxyStart(t *testing.T) {
 	p := &noProxy{}
+	assert := assert.New(t)
 
 	agentURL := "agentURL"
+	_, _, err := p.start(proxyParams{
+		agentURL: agentURL,
+	})
+	assert.NotNil(err)
+
 	pid, vmURL, err := p.start(proxyParams{
 		agentURL: agentURL,
 		logger:   testDefaultLogger,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(err)
+	assert.Equal(vmURL, agentURL)
+	assert.Equal(pid, 0)
 
-	if vmURL != agentURL {
-		t.Fatalf("Got URL %q, expecting %q", vmURL, agentURL)
-	}
+	err = p.stop(0)
+	assert.Nil(err)
 
-	if pid != 0 {
-		t.Fatal("Failure since returned PID should be 0")
-	}
-}
-
-func TestNoProxyStop(t *testing.T) {
-	p := &noProxy{}
-
-	if err := p.stop(0); err != nil {
-		t.Fatal(err)
-	}
+	assert.False(p.consoleWatched())
 }

--- a/virtcontainers/no_proxy_test.go
+++ b/virtcontainers/no_proxy_test.go
@@ -10,14 +10,13 @@ import (
 )
 
 func TestNoProxyStart(t *testing.T) {
-	sandbox := &Sandbox{
-		agent: newAgent(NoopAgentType),
-	}
-
 	p := &noProxy{}
 
 	agentURL := "agentURL"
-	pid, vmURL, err := p.start(sandbox, proxyParams{agentURL: agentURL})
+	pid, vmURL, err := p.start(proxyParams{
+		agentURL: agentURL,
+		logger:   testDefaultLogger,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +33,7 @@ func TestNoProxyStart(t *testing.T) {
 func TestNoProxyStop(t *testing.T) {
 	p := &noProxy{}
 
-	if err := p.stop(&Sandbox{}, 0); err != nil {
+	if err := p.stop(0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -187,3 +187,13 @@ func (n *noopAgent) getSharePath(id string) string {
 func (n *noopAgent) reseedRNG(data []byte) error {
 	return nil
 }
+
+// getAgentURL is the Noop agent url getter. It returns nothing.
+func (n *noopAgent) getAgentURL() (string, error) {
+	return "", nil
+}
+
+// setProxy is the Noop agent proxy setter. It does nothing.
+func (n *noopAgent) setProxy(sandbox *Sandbox, proxy proxy, pid int, url string) error {
+	return nil
+}

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -9,6 +9,8 @@ package virtcontainers
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testCreateNoopContainer() (*Sandbox, *Container, error) {
@@ -250,4 +252,23 @@ func TestNoopAgentListRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatal("listRoutes failed")
 	}
+}
+
+func TestNoopAgentRSetProxy(t *testing.T) {
+	n := &noopAgent{}
+	p := &noopProxy{}
+	s := &Sandbox{}
+	err := n.setProxy(s, p, 0, "")
+	if err != nil {
+		t.Fatal("set proxy failed")
+	}
+}
+
+func TestNoopGetAgentUrl(t *testing.T) {
+	assert := assert.New(t)
+	n := &noopAgent{}
+
+	url, err := n.getAgentURL()
+	assert.Nil(err)
+	assert.Empty(url)
 }

--- a/virtcontainers/noop_proxy.go
+++ b/virtcontainers/noop_proxy.go
@@ -13,13 +13,13 @@ var noopProxyURL = "noopProxyURL"
 
 // register is the proxy start implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) start(sandbox *Sandbox, params proxyParams) (int, string, error) {
+func (p *noopProxy) start(params proxyParams) (int, string, error) {
 	return 0, noopProxyURL, nil
 }
 
 // stop is the proxy stop implementation for testing purpose.
 // It does nothing.
-func (p *noopProxy) stop(sandbox *Sandbox, pid int) error {
+func (p *noopProxy) stop(pid int) error {
 	return nil
 }
 

--- a/virtcontainers/noop_proxy_test.go
+++ b/virtcontainers/noop_proxy_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 HyperHQ Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoopProxy(t *testing.T) {
+	n := &noopProxy{}
+	assert := assert.New(t)
+
+	_, url, err := n.start(proxyParams{})
+	assert.Nil(err)
+	assert.Equal(url, noopProxyURL)
+
+	err = n.stop(0)
+	assert.Nil(err)
+
+	assert.False(n.consoleWatched())
+}

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -119,28 +119,12 @@ func newProxy(pType ProxyType) (proxy, error) {
 	}
 }
 
-// newProxyConfig returns a proxy config from a generic SandboxConfig handler,
-// after it properly checked the configuration was valid.
-func newProxyConfig(sandboxConfig *SandboxConfig) (ProxyConfig, error) {
-	if sandboxConfig == nil {
-		return ProxyConfig{}, fmt.Errorf("Sandbox config cannot be nil")
+func validateProxyConfig(proxyConfig ProxyConfig) error {
+	if len(proxyConfig.Path) == 0 {
+		return fmt.Errorf("Proxy path cannot be empty")
 	}
 
-	var config ProxyConfig
-	switch sandboxConfig.ProxyType {
-	case KataProxyType:
-		fallthrough
-	case CCProxyType:
-		config = sandboxConfig.ProxyConfig
-	default:
-		return ProxyConfig{}, fmt.Errorf("unknown proxy type %v", sandboxConfig.ProxyType)
-	}
-
-	if config.Path == "" {
-		return ProxyConfig{}, fmt.Errorf("Proxy path cannot be empty")
-	}
-
-	return config, nil
+	return nil
 }
 
 func defaultProxyURL(sandbox *Sandbox, socketType string) (string, error) {

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -22,8 +22,12 @@ type ProxyConfig struct {
 // proxyParams is the structure providing specific parameters needed
 // for the execution of the proxy binary.
 type proxyParams struct {
-	agentURL string
-	logger   *logrus.Entry
+	id         string
+	path       string
+	agentURL   string
+	consoleURL string
+	logger     *logrus.Entry
+	debug      bool
 }
 
 // ProxyType describes a proxy type.
@@ -119,6 +123,18 @@ func newProxy(pType ProxyType) (proxy, error) {
 	}
 }
 
+func validateProxyParams(p proxyParams) error {
+	if len(p.path) == 0 || len(p.id) == 0 || len(p.agentURL) == 0 || len(p.consoleURL) == 0 {
+		return fmt.Errorf("Invalid proxy parameters %+v", p)
+	}
+
+	if p.logger == nil {
+		return fmt.Errorf("Invalid proxy parameter: proxy logger is not set")
+	}
+
+	return nil
+}
+
 func validateProxyConfig(proxyConfig ProxyConfig) error {
 	if len(proxyConfig.Path) == 0 {
 		return fmt.Errorf("Proxy path cannot be empty")
@@ -127,10 +143,10 @@ func validateProxyConfig(proxyConfig ProxyConfig) error {
 	return nil
 }
 
-func defaultProxyURL(sandbox *Sandbox, socketType string) (string, error) {
+func defaultProxyURL(id, socketType string) (string, error) {
 	switch socketType {
 	case SocketTypeUNIX:
-		socketPath := filepath.Join(runStoragePath, sandbox.id, "proxy.sock")
+		socketPath := filepath.Join(runStoragePath, id, "proxy.sock")
 		return fmt.Sprintf("unix://%s", socketPath), nil
 	case SocketTypeVSOCK:
 		// TODO Build the VSOCK default URL
@@ -146,13 +162,13 @@ func isProxyBuiltIn(pType ProxyType) bool {
 
 // proxy is the virtcontainers proxy interface.
 type proxy interface {
-	// start launches a proxy instance for the specified sandbox, returning
+	// start launches a proxy instance with specified parameters, returning
 	// the PID of the process and the URL used to connect to it.
-	start(sandbox *Sandbox, params proxyParams) (int, string, error)
+	start(params proxyParams) (int, string, error)
 
 	// stop terminates a proxy instance after all communications with the
 	// agent inside the VM have been properly stopped.
-	stop(sandbox *Sandbox, pid int) error
+	stop(pid int) error
 
 	//check if the proxy has watched the vm console.
 	consoleWatched() bool

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
 
@@ -132,9 +131,9 @@ func newProxyConfig(sandboxConfig *SandboxConfig) (ProxyConfig, error) {
 	case KataProxyType:
 		fallthrough
 	case CCProxyType:
-		if err := mapstructure.Decode(sandboxConfig.ProxyConfig, &config); err != nil {
-			return ProxyConfig{}, err
-		}
+		config = sandboxConfig.ProxyConfig
+	default:
+		return ProxyConfig{}, fmt.Errorf("unknown proxy type %v", sandboxConfig.ProxyType)
 	}
 
 	if config.Path == "" {

--- a/virtcontainers/proxy_test.go
+++ b/virtcontainers/proxy_test.go
@@ -154,15 +154,15 @@ func TestNewProxyFromUnknownProxyType(t *testing.T) {
 	}
 }
 
-func testNewProxyConfigFromSandboxConfig(t *testing.T, sandboxConfig SandboxConfig, expected ProxyConfig) {
-	result, err := newProxyConfig(&sandboxConfig)
-	if err != nil {
+func testNewProxyFromSandboxConfig(t *testing.T, sandboxConfig SandboxConfig) {
+	if _, err := newProxy(sandboxConfig.ProxyType); err != nil {
 		t.Fatal(err)
 	}
 
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("Got %+v\nExpecting %+v", result, expected)
+	if err := validateProxyConfig(sandboxConfig.ProxyConfig); err != nil {
+		t.Fatal(err)
 	}
+
 }
 
 var testProxyPath = "proxy-path"
@@ -177,7 +177,7 @@ func TestNewProxyConfigFromCCProxySandboxConfig(t *testing.T) {
 		ProxyConfig: proxyConfig,
 	}
 
-	testNewProxyConfigFromSandboxConfig(t, sandboxConfig, proxyConfig)
+	testNewProxyFromSandboxConfig(t, sandboxConfig)
 }
 
 func TestNewProxyConfigFromKataProxySandboxConfig(t *testing.T) {
@@ -190,22 +190,11 @@ func TestNewProxyConfigFromKataProxySandboxConfig(t *testing.T) {
 		ProxyConfig: proxyConfig,
 	}
 
-	testNewProxyConfigFromSandboxConfig(t, sandboxConfig, proxyConfig)
-}
-
-func TestNewProxyConfigNilSandboxConfigFailure(t *testing.T) {
-	if _, err := newProxyConfig(nil); err == nil {
-		t.Fatal("Should fail because SandboxConfig provided is nil")
-	}
+	testNewProxyFromSandboxConfig(t, sandboxConfig)
 }
 
 func TestNewProxyConfigNoPathFailure(t *testing.T) {
-	sandboxConfig := &SandboxConfig{
-		ProxyType:   CCProxyType,
-		ProxyConfig: ProxyConfig{},
-	}
-
-	if _, err := newProxyConfig(sandboxConfig); err == nil {
+	if err := validateProxyConfig(ProxyConfig{}); err == nil {
 		t.Fatal("Should fail because ProxyConfig has no Path")
 	}
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1104,6 +1104,8 @@ func (s *Sandbox) startVM() error {
 				HypervisorConfig: s.config.HypervisorConfig,
 				AgentType:        s.config.AgentType,
 				AgentConfig:      s.config.AgentConfig,
+				ProxyType:        s.config.ProxyType,
+				ProxyConfig:      s.config.ProxyConfig,
 			})
 			if err != nil {
 				return err
@@ -1593,9 +1595,9 @@ func (s *Sandbox) HotplugAddDevice(device api.Device, devType config.DeviceType)
 			if _, err := s.hypervisor.hotplugAddDevice(dev, vfioDev); err != nil {
 				s.Logger().
 					WithFields(logrus.Fields{
-						"sandboxid":       s.id,
-						"vfio device ID":  dev.ID,
-						"vfio device BDF": dev.BDF,
+						"sandbox":         s.id,
+						"vfio-device-ID":  dev.ID,
+						"vfio-device-BDF": dev.BDF,
 					}).WithError(err).Error("failed to hotplug VFIO device")
 				return err
 			}
@@ -1630,9 +1632,9 @@ func (s *Sandbox) HotplugRemoveDevice(device api.Device, devType config.DeviceTy
 			if _, err := s.hypervisor.hotplugRemoveDevice(dev, vfioDev); err != nil {
 				s.Logger().WithError(err).
 					WithFields(logrus.Fields{
-						"sandboxid":       s.id,
-						"vfio device ID":  dev.ID,
-						"vfio device BDF": dev.BDF,
+						"sandbox":         s.id,
+						"vfio-device-ID":  dev.ID,
+						"vfio-device-BDF": dev.BDF,
 					}).Error("failed to hot unplug VFIO device")
 				return err
 			}

--- a/virtcontainers/vm_test.go
+++ b/virtcontainers/vm_test.go
@@ -20,6 +20,7 @@ func TestNewVM(t *testing.T) {
 	config := VMConfig{
 		HypervisorType: MockHypervisor,
 		AgentType:      NoopAgentType,
+		ProxyType:      NoopProxyType,
 	}
 	hyperConfig := HypervisorConfig{
 		KernelPath: testDir,

--- a/virtcontainers/vm_test.go
+++ b/virtcontainers/vm_test.go
@@ -44,6 +44,8 @@ func TestNewVM(t *testing.T) {
 	assert.Nil(err)
 	err = vm.Start()
 	assert.Nil(err)
+	err = vm.Disconnect()
+	assert.Nil(err)
 	err = vm.Save()
 	assert.Nil(err)
 	err = vm.Stop()
@@ -85,5 +87,26 @@ func TestVMConfigValid(t *testing.T) {
 		InitrdPath: testDir,
 	}
 	err = config.Valid()
+	assert.Nil(err)
+}
+
+func TestSetupProxy(t *testing.T) {
+	assert := assert.New(t)
+
+	config := VMConfig{
+		HypervisorType: MockHypervisor,
+		AgentType:      NoopAgentType,
+	}
+
+	hypervisor := &mockHypervisor{}
+	agent := &noopAgent{}
+
+	// wrong proxy type
+	config.ProxyType = "invalidProxyType"
+	_, _, _, err := setupProxy(hypervisor, agent, config, "foobar")
+	assert.NotNil(err)
+
+	config.ProxyType = NoopProxyType
+	_, _, _, err = setupProxy(hypervisor, agent, config, "foobar")
 	assert.Nil(err)
 }


### PR DESCRIPTION
Right now proxy is always started **after** we assign the guest vm to a sandbox. But then we will have to wait again for the proxy to start up. We can move the creation of proxy to vm factory so that new vms are created with configured proxy type, and then wait for both proxy and vm/agent in parallel. This will save about 300ms startup time for vm factory.