### PR TITLE
virtcontainers: revert apply devices constraints

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -669,6 +669,7 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	// By now only CPU constraints are supported
 	// Issue: https://github.com/kata-containers/runtime/issues/158
 	// Issue: https://github.com/kata-containers/runtime/issues/204
+	grpcSpec.Linux.Resources.Devices = nil
 	grpcSpec.Linux.Resources.Pids = nil
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -450,7 +450,7 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	// check nil fields
 	assert.Nil(g.Hooks)
 	assert.Nil(g.Linux.Seccomp)
-	assert.NotNil(g.Linux.Resources.Devices)
+	assert.Nil(g.Linux.Resources.Devices)
 	assert.NotNil(g.Linux.Resources.Memory)
 	assert.Nil(g.Linux.Resources.Pids)
 	assert.Nil(g.Linux.Resources.BlockIO)


### PR DESCRIPTION
Due to issue https://github.com/kata-containers/runtime/issues/677
commit 137769a694136ef744fcb22ba389910fe1c1d951 must be reverted

This reverts commit 137769a694136ef744fcb22ba389910fe1c1d951.

fixes #685

Signed-off-by: Julio Montes <julio.montes@intel.com>