### PR TITLE
fix container cpu hot add

### DIFF
--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -286,10 +287,13 @@ func TestContainerAddResources(t *testing.T) {
 
 	c := &Container{
 		sandbox: &Sandbox{
-			storage: &filesystem{},
+			storage: &noopResourceStorage{},
 		},
 	}
-	err := c.addResources()
+	err := c.sandbox.storage.createAllResources(context.Background(), c.sandbox)
+	assert.Nil(err)
+
+	err = c.addResources()
 	assert.Nil(err)
 
 	c.config = &ContainerConfig{Annotations: make(map[string]string)}
@@ -310,7 +314,7 @@ func TestContainerAddResources(t *testing.T) {
 			vCPUs: vCPUs,
 		},
 		agent:   &noopAgent{},
-		storage: &filesystem{},
+		storage: &noopResourceStorage{},
 	}
 	err = c.addResources()
 	assert.Nil(err)
@@ -321,7 +325,8 @@ func TestContainerRemoveResources(t *testing.T) {
 
 	c := &Container{
 		sandbox: &Sandbox{
-			storage: &filesystem{},
+			storage: &noopResourceStorage{},
+			config:  &SandboxConfig{},
 		},
 	}
 
@@ -346,7 +351,8 @@ func TestContainerRemoveResources(t *testing.T) {
 		hypervisor: &mockHypervisor{
 			vCPUs: vCPUs,
 		},
-		storage: &filesystem{},
+		storage: &noopResourceStorage{},
+		config:  &SandboxConfig{},
 	}
 
 	err = c.removeResources()

--- a/virtcontainers/noop_resource_storage.go
+++ b/virtcontainers/noop_resource_storage.go
@@ -6,12 +6,14 @@
 package virtcontainers
 
 import (
+	"context"
+
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 )
 
 type noopResourceStorage struct{}
 
-func (n *noopResourceStorage) createAllResources(sandbox *Sandbox) error {
+func (n *noopResourceStorage) createAllResources(ctx context.Context, sandbox *Sandbox) error {
 	return nil
 }
 

--- a/virtcontainers/noop_resource_storage_test.go
+++ b/virtcontainers/noop_resource_storage_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
@@ -15,7 +16,7 @@ import (
 func TestNoopCreateAllResources(t *testing.T) {
 	n := &noopResourceStorage{}
 
-	err := n.createAllResources(nil)
+	err := n.createAllResources(context.Background(), nil)
 	assert.Nil(t, err)
 }
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1722,3 +1722,52 @@ func TestGetNetNs(t *testing.T) {
 	netNs = s.GetNetNs()
 	assert.Equal(t, netNs, expected)
 }
+
+func TestAdjustVCPUCount(t *testing.T) {
+	assert := assert.New(t)
+	s := Sandbox{
+		storage: &noopResourceStorage{},
+		config: &SandboxConfig{
+			HypervisorConfig: HypervisorConfig{
+				DefaultVCPUs: 10,
+			},
+		},
+	}
+
+	s.state.FreeStaticCPU = 10
+
+	num, err := s.adjustVCPUCount(1, true)
+	assert.Nil(err)
+	assert.EqualValues(num, 0)
+	assert.EqualValues(s.state.FreeStaticCPU, 9)
+
+	num, err = s.adjustVCPUCount(1, false)
+	assert.Nil(err)
+	assert.EqualValues(num, 0)
+	assert.EqualValues(s.state.FreeStaticCPU, 10)
+
+	num, err = s.adjustVCPUCount(11, true)
+	assert.Nil(err)
+	assert.EqualValues(num, 1)
+	assert.EqualValues(s.state.FreeStaticCPU, 0)
+
+	num, err = s.adjustVCPUCount(11, true)
+	assert.Nil(err)
+	assert.EqualValues(num, 11)
+	assert.EqualValues(s.state.FreeStaticCPU, 0)
+
+	num, err = s.adjustVCPUCount(1, false)
+	assert.Nil(err)
+	assert.EqualValues(num, 0)
+	assert.EqualValues(s.state.FreeStaticCPU, 1)
+
+	num, err = s.adjustVCPUCount(11, false)
+	assert.Nil(err)
+	assert.EqualValues(num, 2)
+	assert.EqualValues(s.state.FreeStaticCPU, 10)
+
+	num, err = s.adjustVCPUCount(10, false)
+	assert.Nil(err)
+	assert.EqualValues(num, 10)
+	assert.EqualValues(s.state.FreeStaticCPU, 10)
+}


### PR DESCRIPTION
The cpu hotplug calculation should take into account the initial vCPUs
counts otherwise we end up hotplugging more vCPUs than actual need.

Before fix:
```
[macbeth@runtime]$docker run --rm -it --runtime kata --cpu-period "1000" --cpu-quota "1000" busybox
/ # nproc
2
```
After fix:
```
[macbeth@runtime]$docker run --rm -it --runtime kata --cpu-period "1000" --cpu-quota "1000" busybox
/ # nproc
1
```