### PR TITLE
virtcontainers: apply devices constraints

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -666,10 +666,9 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	// here: https://github.com/kata-containers/agent/issues/104
 	grpcSpec.Linux.Seccomp = nil
 
-	// By now only CPU constraints are supported
+	// By now only CPU, Memory and Devices constraints are supported
 	// Issue: https://github.com/kata-containers/runtime/issues/158
 	// Issue: https://github.com/kata-containers/runtime/issues/204
-	grpcSpec.Linux.Resources.Devices = nil
 	grpcSpec.Linux.Resources.Pids = nil
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -450,7 +450,7 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	// check nil fields
 	assert.Nil(g.Hooks)
 	assert.Nil(g.Linux.Seccomp)
-	assert.Nil(g.Linux.Resources.Devices)
+	assert.NotNil(g.Linux.Resources.Devices)
 	assert.NotNil(g.Linux.Resources.Memory)
 	assert.Nil(g.Linux.Resources.Pids)
 	assert.Nil(g.Linux.Resources.BlockIO)


### PR DESCRIPTION
Apply devices constraints to the container in the virtual machine

Depends-on: github.com/kata-containers/agent#352

fixes #656

Signed-off-by: Julio Montes <julio.montes@intel.com>