### PR TITLE
cli: add configuration option to enable/disable vhost_net

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,11 +123,11 @@
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
-  digest = "1:7434a85a1d6c2bf64f322087ec7a7f84ab9e971179bef7b95deabaf0e3f7c126"
+  digest = "1:2b062c3645f86b71bdb0487b4d69746704695fc09158fe4638c213d38c6cc5dc"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "e2c716433e444017507e3587ce071868fd164380"
+  revision = "032705ba6aae05a9bf41e296cf89c8529cffb822"
 
 [[projects]]
   digest = "1:01c37fcb6e2a1fe1321a97faaef74c66ac531ea292ca3f929b7189cc400b1d47"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "e2c716433e444017507e3587ce071868fd164380"
+  revision = "032705ba6aae05a9bf41e296cf89c8529cffb822"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/cli/config.go
+++ b/cli/config.go
@@ -94,6 +94,7 @@ type hypervisor struct {
 	EnableIOThreads       bool   `toml:"enable_iothreads"`
 	UseVSock              bool   `toml:"use_vsock"`
 	HotplugVFIOOnRootBus  bool   `toml:"hotplug_vfio_on_root_bus"`
+	DisableVhostNet       bool   `toml:"disable_vhost_net"`
 }
 
 type proxy struct {
@@ -375,6 +376,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		Msize9p:               h.msize9p(),
 		UseVSock:              useVSock,
 		HotplugVFIOOnRootBus:  h.HotplugVFIOOnRootBus,
+		DisableVhostNet:       h.DisableVhostNet,
 	}, nil
 }
 

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -147,6 +147,10 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # Default false
 #hotplug_vfio_on_root_bus = true
 
+# If host doesn't support vhost_net, set to true. Thus we won't create vhost fds for nics.
+# Default false
+#disable_vhost_net = true
+
 [factory]
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and

--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -812,13 +812,15 @@ func (q *QMP) ExecuteNetdevChardevAdd(ctx context.Context, netdevType, netdevID,
 // Must be valid QMP identifier.
 func (q *QMP) ExecuteNetdevAddByFds(ctx context.Context, netdevType, netdevID string, fdNames, vhostFdNames []string) error {
 	fdNameStr := strings.Join(fdNames, ":")
-	vhostFdNameStr := strings.Join(vhostFdNames, ":")
 	args := map[string]interface{}{
-		"type":     netdevType,
-		"id":       netdevID,
-		"fds":      fdNameStr,
-		"vhost":    "on",
-		"vhostfds": vhostFdNameStr,
+		"type": netdevType,
+		"id":   netdevID,
+		"fds":  fdNameStr,
+	}
+	if len(vhostFdNames) > 0 {
+		vhostFdNameStr := strings.Join(vhostFdNames, ":")
+		args["vhost"] = "on"
+		args["vhostfds"] = vhostFdNameStr
 	}
 
 	return q.executeCommand(ctx, "netdev_add", args, nil)

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -240,6 +240,9 @@ type HypervisorConfig struct {
 	// DevicesStatePath is the VM device state file path. Used when either BootToBeTemplate or
 	// BootFromTemplate is true.
 	DevicesStatePath string
+
+	// DisableVhostNet is used to indicate if host supports vhost_net
+	DisableVhostNet bool
 }
 
 func (conf *HypervisorConfig) checkTemplateConfig() error {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -249,6 +249,13 @@ func (q *qemu) init(ctx context.Context, id string, hypervisorConfig *Hypervisor
 		q.arch.disableNestingChecks()
 	}
 
+	if !q.config.DisableVhostNet {
+		q.arch.enableVhostNet()
+	} else {
+		q.Logger().Debug("Disable vhost_net")
+		q.arch.disableVhostNet()
+	}
+
 	return nil
 }
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -24,6 +24,12 @@ type qemuArch interface {
 	// disableNestingChecks nesting checks will be ignored
 	disableNestingChecks()
 
+	// enableVhostNet vhost will be enabled
+	enableVhostNet()
+
+	// disableVhostNet vhost will be disabled
+	disableVhostNet()
+
 	// machine returns the machine type
 	machine() (govmmQemu.Machine, error)
 
@@ -92,6 +98,7 @@ type qemuArch interface {
 type qemuArchBase struct {
 	machineType           string
 	nestedRun             bool
+	vhost                 bool
 	networkIndex          int
 	qemuPaths             map[string]string
 	supportedQemuMachines []govmmQemu.Machine
@@ -174,6 +181,14 @@ func (q *qemuArchBase) enableNestingChecks() {
 
 func (q *qemuArchBase) disableNestingChecks() {
 	q.nestedRun = false
+}
+
+func (q *qemuArchBase) enableVhostNet() {
+	q.vhost = true
+}
+
+func (q *qemuArchBase) disableVhostNet() {
+	q.vhost = false
 }
 
 func (q *qemuArchBase) machine() (govmmQemu.Machine, error) {
@@ -437,7 +452,7 @@ func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoi
 				MACAddress:    ep.NetPair.TAPIface.HardAddr,
 				DownScript:    "no",
 				Script:        "no",
-				VHost:         true,
+				VHost:         q.vhost,
 				DisableModern: q.nestedRun,
 				FDs:           ep.NetPair.VMFds,
 				VhostFDs:      ep.NetPair.VhostFds,


### PR DESCRIPTION
Add `disable_vhost_net` option to enable or disable the use of
    vhost_net. Vhost_net can improve network performance.

Fixes: #169

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>