### PR TITLE
cli: fix build

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -601,7 +601,7 @@ func checkHypervisorConfig(config vc.HypervisorConfig) error {
 		},
 	}
 
-	memSizeMB := int64(config.DefaultMemSz)
+	memSizeMB := int64(config.MemorySize)
 
 	if memSizeMB == 0 {
 		return errors.New("VM memory cannot be zero")

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -476,7 +476,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	imagePath := path.Join(dir, "image.img")
 	initrdPath := path.Join(dir, "initrd.img")
 
-	hypervisorPath := path.Join(dir, "hypervisor")
+	hypervisorPath = path.Join(dir, "hypervisor")
 	kernelPath := path.Join(dir, "kernel")
 
 	savedDefaultImagePath := defaultImagePath
@@ -1389,9 +1389,9 @@ func TestCheckHypervisorConfig(t *testing.T) {
 		kataLog.Logger.Out = logBuf
 
 		config := vc.HypervisorConfig{
-			ImagePath:    d.imagePath,
-			InitrdPath:   d.initrdPath,
-			DefaultMemSz: d.memBytes,
+			ImagePath:  d.imagePath,
+			InitrdPath: d.initrdPath,
+			MemorySize: d.memBytes,
 		}
 
 		err := checkHypervisorConfig(config)


### PR DESCRIPTION
Sadly CI failed to catch the broken line due to the fact that it is introduced by a different
PR that passed w/o the naming PR.
```
./config.go:604:27: config.DefaultMemSz undefined (type virtcontainers.HypervisorConfig has no field or method DefaultMemSz)
Makefile:331: recipe for target '/golang/src/github.com/kata-containers/runtime/kata-runtime' failed
make: *** [/golang/src/github.com/kata-containers/runtime/kata-runtime] Error 2
```
Fixes: #709