### PR TITLE
devices: add per-device VFIO ids

### DIFF
--- a/virtcontainers/device/drivers/vfio.go
+++ b/virtcontainers/device/drivers/vfio.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -64,14 +65,14 @@ func (device *VFIODevice) Attach(devReceiver api.DeviceReceiver) error {
 	}
 
 	// Pass all devices in iommu group
-	for _, deviceFile := range deviceFiles {
+	for i, deviceFile := range deviceFiles {
 		//Get bdf of device eg 0000:00:1c.0
 		deviceBDF, err := getBDF(deviceFile.Name())
 		if err != nil {
 			return err
 		}
 		vfio := &config.VFIODev{
-			ID:  utils.MakeNameID("vfio", device.DeviceInfo.ID, maxDevIDSize),
+			ID:  utils.MakeNameID("vfio", device.DeviceInfo.ID+strconv.Itoa(i), maxDevIDSize),
 			BDF: deviceBDF,
 		}
 		device.vfioDevs = append(device.vfioDevs, vfio)


### PR DESCRIPTION
Adds per-device VFIO ids allowing IOMMU groups with
multiple devices to be passed to qemu.

Fixes #708

Signed-off-by: Edward Guzman <eguzman@nvidia.com>