### PR TITLE
Set the queue size for Multiqueue virtio-net as the number of vCPUs on the guest.

### DIFF
--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -560,4 +560,5 @@ type hypervisor interface {
 	getSandboxConsole(sandboxID string) (string, error)
 	disconnect()
 	capabilities() capabilities
+	hypervisorConfig() HypervisorConfig
 }

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -24,6 +24,10 @@ func (m *mockHypervisor) capabilities() capabilities {
 	return capabilities{}
 }
 
+func (m *mockHypervisor) hypervisorConfig() HypervisorConfig {
+	return HypervisorConfig{}
+}
+
 func (m *mockHypervisor) createSandbox() error {
 	return nil
 }

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -848,7 +848,7 @@ func (q *qemu) hotplugNetDevice(drive VirtualEndpoint, op operation) error {
 	if op == addDevice {
 		switch drive.NetPair.NetInterworkingModel {
 		case NetXConnectBridgedModel:
-			if err := q.qmpMonitorCh.qmp.ExecuteNetdevAdd(q.qmpMonitorCh.ctx, "tap", drive.NetPair.Name, drive.NetPair.TAPIface.Name, "no", "no", defaultQueues); err != nil {
+			if err := q.qmpMonitorCh.qmp.ExecuteNetdevAdd(q.qmpMonitorCh.ctx, "tap", drive.NetPair.Name, drive.NetPair.TAPIface.Name, "no", "no", int(q.config.NumVCPUs)); err != nil {
 				return err
 			}
 		case NetXConnectMacVtapModel:
@@ -863,7 +863,7 @@ func (q *qemu) hotplugNetDevice(drive VirtualEndpoint, op operation) error {
 			return err
 		}
 		drive.PCIAddr = fmt.Sprintf("%02x/%s", bridge.Addr, addr)
-		if err = q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, drive.NetPair.Name, devID, drive.NetPair.TAPIface.HardAddr, addr, bridge.ID, defaultQueues); err != nil {
+		if err = q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, drive.NetPair.Name, devID, drive.NetPair.TAPIface.HardAddr, addr, bridge.ID, int(q.config.NumVCPUs)); err != nil {
 			return err
 		}
 	} else {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -160,6 +160,10 @@ func (q *qemu) capabilities() capabilities {
 	return q.arch.capabilities()
 }
 
+func (q *qemu) hypervisorConfig() HypervisorConfig {
+	return q.config
+}
+
 // get the QEMU binary path
 func (q *qemu) qemuPath() (string, error) {
 	p, err := q.config.HypervisorAssetPath()


### PR DESCRIPTION
Instead of using a default queue size of 8 for Multiqueue virtio-net,
use the number of vCPUs on the guest as the queue size.
This is the recommended approach for setting up the queue size.
This also shown better performance results.
