### PR TITLE
kata_agent: disable cgroup namespace

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -684,6 +684,7 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec) {
 	var tmpNamespaces []grpc.LinuxNamespace
 	for _, ns := range grpcSpec.Linux.Namespaces {
 		switch ns.Type {
+		case specs.CgroupNamespace:
 		case specs.NetworkNamespace:
 		default:
 			ns.Path = ""


### PR DESCRIPTION
We do not support it yet. If we pass it to the agent, container creation
will fail.

Fixes: #711
