### PR TITLE
kata-env: Fix display of debug options

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -532,6 +532,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	}
 
 	if tomlConf.Runtime.Debug {
+		config.Debug = true
 		debug = true
 		crashOnError = true
 	} else {

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	hypervisorDebug = false
+	proxyDebug      = false
+	runtimeDebug    = false
+	shimDebug       = false
+)
+
 type testRuntimeConfig struct {
 	RuntimeConfig     oci.RuntimeConfig
 	RuntimeConfigFile string
@@ -52,17 +59,20 @@ func makeRuntimeConfigFileData(hypervisor, hypervisorPath, kernelPath, imagePath
 	enable_iothreads =  ` + strconv.FormatBool(enableIOThreads) + `
 	hotplug_vfio_on_root_bus =  ` + strconv.FormatBool(hotplugVFIOOnRootBus) + `
 	msize_9p = ` + strconv.FormatUint(uint64(defaultMsize9p), 10) + `
+	enable_debug = ` + strconv.FormatBool(hypervisorDebug) + `
 
 	[proxy.kata]
+	enable_debug = ` + strconv.FormatBool(proxyDebug) + `
 	path = "` + proxyPath + `"
 
 	[shim.kata]
 	path = "` + shimPath + `"
+	enable_debug = ` + strconv.FormatBool(shimDebug) + `
 
 	[agent.kata]
 
         [runtime]
-	`
+	enable_debug = ` + strconv.FormatBool(runtimeDebug)
 }
 
 func createConfig(configPath string, fileData string) error {

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -160,6 +160,7 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 	runtimePath, _ := os.Executable()
 
 	return RuntimeInfo{
+		Debug:   config.Debug,
 		Version: runtimeVersion,
 		Config:  runtimeConfig,
 		Path:    runtimePath,
@@ -284,6 +285,7 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 	}
 
 	return HypervisorInfo{
+		Debug:             config.HypervisorConfig.Debug,
 		MachineType:       config.HypervisorConfig.HypervisorMachineType,
 		Version:           version,
 		Path:              hypervisorPath,

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -103,8 +103,6 @@ type RuntimeConfig struct {
 	HypervisorType   vc.HypervisorType
 	HypervisorConfig vc.HypervisorConfig
 
-	FactoryConfig FactoryConfig
-
 	AgentType   vc.AgentType
 	AgentConfig interface{}
 
@@ -119,6 +117,8 @@ type RuntimeConfig struct {
 	//Determines how the VM should be connected to the
 	//the container network interface
 	InterNetworkModel vc.NetInterworkingModel
+	FactoryConfig     FactoryConfig
+	Debug             bool
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing


### PR DESCRIPTION
The runtime and hypervisor `Debug` options were always showing as
`false` (although all debug options in `configuration.toml` were
correctly honoured).

Note: Also moved location of `FactoryConfig` in `RuntimeConfig` as the
`malign` linter was complaining:

```
virtcontainers/pkg/oci/utils.go:102:20:warning struct of size 408 could be 400 (maligned)
```

Fixes #724.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>