### PR TITLE
kata-env: Fix amd64 VM container capable check

### DIFF
--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -492,3 +492,32 @@ func TestKvmIsUsable(t *testing.T) {
 func TestGetCPUDetails(t *testing.T) {
 	genericTestGetCPUDetails(t)
 }
+
+func TestSetCPUtype(t *testing.T) {
+	assert := assert.New(t)
+
+	savedArchRequiredCPUFlags := archRequiredCPUFlags
+	savedArchRequiredCPUAttribs := archRequiredCPUAttribs
+	savedArchRequiredKernelModules := archRequiredKernelModules
+
+	defer func() {
+		archRequiredCPUFlags = savedArchRequiredCPUFlags
+		archRequiredCPUAttribs = savedArchRequiredCPUAttribs
+		archRequiredKernelModules = savedArchRequiredKernelModules
+	}()
+
+	archRequiredCPUFlags = map[string]string{}
+	archRequiredCPUAttribs = map[string]string{}
+	archRequiredKernelModules = map[string]kernelModule{}
+
+	setCPUtype()
+
+	assert.NotEmpty(archRequiredCPUFlags)
+	assert.NotEmpty(archRequiredCPUAttribs)
+	assert.NotEmpty(archRequiredKernelModules)
+
+	assert.Equal(archRequiredCPUFlags["vmx"], "Virtualization support")
+
+	_, ok := archRequiredKernelModules["kvm"]
+	assert.True(ok)
+}

--- a/cli/kata-check_arm64_test.go
+++ b/cli/kata-check_arm64_test.go
@@ -199,3 +199,7 @@ foo     : bar
 		}
 	}
 }
+
+func TestSetCPUtype(t *testing.T) {
+	testSetCPUTypeGeneric(t)
+}

--- a/cli/kata-check_generic_test.go
+++ b/cli/kata-check_generic_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// +build arm64 ppc64le
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testSetCPUTypeGeneric(t *testing.T) {
+	assert := assert.New(t)
+
+	savedArchRequiredCPUFlags := archRequiredCPUFlags
+	savedArchRequiredCPUAttribs := archRequiredCPUAttribs
+	savedArchRequiredKernelModules := archRequiredKernelModules
+
+	defer func() {
+		archRequiredCPUFlags = savedArchRequiredCPUFlags
+		archRequiredCPUAttribs = savedArchRequiredCPUAttribs
+		archRequiredKernelModules = savedArchRequiredKernelModules
+	}()
+
+	assert.Empty(archRequiredCPUFlags)
+	assert.Empty(archRequiredCPUAttribs)
+	assert.NotEmpty(archRequiredKernelModules)
+
+	setCPUtype()
+
+	assert.Equal(archRequiredCPUFlags, savedArchRequiredCPUFlags)
+	assert.Equal(archRequiredCPUAttribs, savedArchRequiredCPUAttribs)
+	assert.Equal(archRequiredKernelModules, savedArchRequiredKernelModules)
+}

--- a/cli/kata-check_ppc64le_test.go
+++ b/cli/kata-check_ppc64le_test.go
@@ -211,3 +211,7 @@ func TestKvmIsUsable(t *testing.T) {
 func TestGetCPUDetails(t *testing.T) {
 	genericTestGetCPUDetails(t)
 }
+
+func TestSetCPUtype(t *testing.T) {
+	testSetCPUTypeGeneric(t)
+}

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -294,6 +294,8 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 }
 
 func getEnvInfo(configFile string, config oci.RuntimeConfig) (env EnvInfo, err error) {
+	setCPUtype()
+
 	meta := getMetaInfo()
 
 	runtime := getRuntimeInfo(configFile, config)

--- a/cli/kata-env_arm64_test.go
+++ b/cli/kata-env_arm64_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	goruntime "runtime"
+	"testing"
 )
 
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
@@ -91,4 +92,8 @@ VERSION_ID="%s"
 	}
 
 	return expectedHostDetails, nil
+}
+
+func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
+	testEnvGetEnvInfoSetsCPUTypeGeneric(t)
 }

--- a/cli/kata-env_generic_test.go
+++ b/cli/kata-env_generic_test.go
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// +build arm64 ppc64le
+
 package main
 
 import (
@@ -13,11 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
-	return genericGetExpectedHostDetails(tmpdir)
-}
-
-func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
+func testEnvGetEnvInfoSetsCPUTypeGeneric(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir("", "")
@@ -34,9 +32,9 @@ func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
 		archRequiredKernelModules = savedArchRequiredKernelModules
 	}()
 
-	archRequiredCPUFlags = map[string]string{}
-	archRequiredCPUAttribs = map[string]string{}
-	archRequiredKernelModules = map[string]kernelModule{}
+	assert.Empty(archRequiredCPUFlags)
+	assert.Empty(archRequiredCPUAttribs)
+	assert.NotEmpty(archRequiredKernelModules)
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
@@ -49,12 +47,7 @@ func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
 
 	assert.Equal(expectedEnv, env)
 
-	assert.NotEmpty(archRequiredCPUFlags)
-	assert.NotEmpty(archRequiredCPUAttribs)
-	assert.NotEmpty(archRequiredKernelModules)
-
-	assert.Equal(archRequiredCPUFlags["vmx"], "Virtualization support")
-
-	_, ok := archRequiredKernelModules["kvm"]
-	assert.True(ok)
+	assert.Equal(archRequiredCPUFlags, savedArchRequiredCPUFlags)
+	assert.Equal(archRequiredCPUAttribs, savedArchRequiredCPUAttribs)
+	assert.Equal(archRequiredKernelModules, savedArchRequiredKernelModules)
 }

--- a/cli/kata-env_ppc64le_test.go
+++ b/cli/kata-env_ppc64le_test.go
@@ -5,6 +5,12 @@
 
 package main
 
+import "testing"
+
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	return genericGetExpectedHostDetails(tmpdir)
+}
+
+func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
+	testEnvGetEnvInfoSetsCPUTypeGeneric(t)
 }


### PR DESCRIPTION
Fix nasty bug which resulted in `kata-env` showing
`VMContainerCapable = true` even on amd64 systems without virtualisation
support (thankfully `kata-check` still showed the correct results).

Added arch-specific tests to avoid any possibility of regression.

Fixes #660.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>