### PR TITLE
cli: kata-env: add runtime path to output

### DIFF
--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -23,7 +23,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.12"
+const formatVersion = "1.0.13"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -63,6 +63,7 @@ type RuntimeInfo struct {
 	Version RuntimeVersionInfo
 	Config  RuntimeConfigInfo
 	Debug   bool
+	Path    string
 }
 
 // RuntimeVersionInfo stores details of the runtime version
@@ -152,9 +153,12 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 		Path: configFile,
 	}
 
+	runtimePath, _ := os.Executable()
+
 	return RuntimeInfo{
 		Version: runtimeVersion,
 		Config:  runtimeConfig,
+		Path:    runtimePath,
 	}
 }
 

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -255,6 +255,8 @@ func getExpectedKernel(config oci.RuntimeConfig) KernelInfo {
 }
 
 func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
+	runtimePath, _ := os.Executable()
+
 	return RuntimeInfo{
 		Version: RuntimeVersionInfo{
 			Semver: version,
@@ -264,6 +266,7 @@ func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
 		Config: RuntimeConfigInfo{
 			Path: configFile,
 		},
+		Path: runtimePath,
 	}
 }
 


### PR DESCRIPTION
`kata-env` did not include the path to the runtime exe itself.
Add that into the Runtime section.

Fixes: #577

Signed-off-by: Graham Whaley <graham.whaley@intel.com>