### PR TITLE
kata-env: Fix display of debug options

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -530,6 +530,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	}
 
 	if tomlConf.Runtime.Debug {
+		config.Debug = true
 		debug = true
 		crashOnError = true
 	} else {

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -24,6 +24,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	hypervisorDebug = false
+	proxyDebug      = false
+	runtimeDebug    = false
+	shimDebug       = false
+)
+
 type testRuntimeConfig struct {
 	RuntimeConfig     oci.RuntimeConfig
 	RuntimeConfigFile string
@@ -50,17 +57,20 @@ func makeRuntimeConfigFileData(hypervisor, hypervisorPath, kernelPath, imagePath
 	disable_block_device_use =  ` + strconv.FormatBool(disableBlock) + `
 	enable_iothreads =  ` + strconv.FormatBool(enableIOThreads) + `
 	msize_9p = ` + strconv.FormatUint(uint64(defaultMsize9p), 10) + `
+	enable_debug = ` + strconv.FormatBool(hypervisorDebug) + `
 
 	[proxy.kata]
+	enable_debug = ` + strconv.FormatBool(proxyDebug) + `
 	path = "` + proxyPath + `"
 
 	[shim.kata]
 	path = "` + shimPath + `"
+	enable_debug = ` + strconv.FormatBool(shimDebug) + `
 
 	[agent.kata]
 
         [runtime]
-	`
+	enable_debug = ` + strconv.FormatBool(runtimeDebug)
 }
 
 func createConfig(configPath string, fileData string) error {

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -160,6 +160,7 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 	runtimePath, _ := os.Executable()
 
 	return RuntimeInfo{
+		Debug:   config.Debug,
 		Version: runtimeVersion,
 		Config:  runtimeConfig,
 		Path:    runtimePath,
@@ -284,6 +285,7 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 	}
 
 	return HypervisorInfo{
+		Debug:             config.HypervisorConfig.Debug,
 		MachineType:       config.HypervisorConfig.HypervisorMachineType,
 		Version:           version,
 		Path:              hypervisorPath,

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -146,6 +146,7 @@ func getExpectedShimDetails(config oci.RuntimeConfig) (ShimInfo, error) {
 		Type:    string(config.ShimType),
 		Version: testShimVersion,
 		Path:    shimPath,
+		Debug:   shimConfig.Debug,
 	}, nil
 }
 
@@ -240,6 +241,7 @@ func getExpectedHypervisor(config oci.RuntimeConfig) HypervisorInfo {
 		MachineType:       config.HypervisorConfig.HypervisorMachineType,
 		BlockDeviceDriver: config.HypervisorConfig.BlockDeviceDriver,
 		Msize9p:           config.HypervisorConfig.Msize9p,
+		Debug:             config.HypervisorConfig.Debug,
 	}
 }
 
@@ -256,7 +258,7 @@ func getExpectedKernel(config oci.RuntimeConfig) KernelInfo {
 	}
 }
 
-func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
+func getExpectedRuntimeDetails(config oci.RuntimeConfig, configFile string) RuntimeInfo {
 	runtimePath, _ := os.Executable()
 
 	return RuntimeInfo{
@@ -268,14 +270,15 @@ func getExpectedRuntimeDetails(configFile string) RuntimeInfo {
 		Config: RuntimeConfigInfo{
 			Path: configFile,
 		},
-		Path: runtimePath,
+		Path:  runtimePath,
+		Debug: config.Debug,
 	}
 }
 
 func getExpectedSettings(config oci.RuntimeConfig, tmpdir, configFile string) (EnvInfo, error) {
 	meta := getExpectedMetaInfo()
 
-	runtime := getExpectedRuntimeDetails(configFile)
+	runtime := getExpectedRuntimeDetails(config, configFile)
 
 	proxy, err := getExpectedProxyDetails(config)
 	if err != nil {
@@ -404,16 +407,25 @@ func TestEnvGetEnvInfo(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	configFile, config, err := makeRuntimeConfig(tmpdir)
-	assert.NoError(t, err)
+	// Run test twice to ensure the individual component debug options are
+	// tested.
+	for _, debug := range []bool{false, true} {
+		hypervisorDebug = debug
+		proxyDebug = debug
+		runtimeDebug = debug
+		shimDebug = debug
 
-	expectedEnv, err := getExpectedSettings(config, tmpdir, configFile)
-	assert.NoError(t, err)
+		configFile, config, err := makeRuntimeConfig(tmpdir)
+		assert.NoError(t, err)
 
-	env, err := getEnvInfo(configFile, config)
-	assert.NoError(t, err)
+		expectedEnv, err := getExpectedSettings(config, tmpdir, configFile)
+		assert.NoError(t, err)
 
-	assert.Equal(t, expectedEnv, env)
+		env, err := getEnvInfo(configFile, config)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedEnv, env)
+	}
 }
 
 func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
@@ -542,7 +554,7 @@ func TestEnvGetRuntimeInfo(t *testing.T) {
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
 
-	expectedRuntime := getExpectedRuntimeDetails(configFile)
+	expectedRuntime := getExpectedRuntimeDetails(config, configFile)
 
 	runtime := getRuntimeInfo(configFile, config)
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -104,8 +104,6 @@ type RuntimeConfig struct {
 	HypervisorType   vc.HypervisorType
 	HypervisorConfig vc.HypervisorConfig
 
-	FactoryConfig FactoryConfig
-
 	AgentType   vc.AgentType
 	AgentConfig interface{}
 
@@ -120,6 +118,8 @@ type RuntimeConfig struct {
 	//Determines how the VM should be connected to the
 	//the container network interface
 	InterNetworkModel vc.NetInterworkingModel
+	FactoryConfig     FactoryConfig
+	Debug             bool
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing


### PR DESCRIPTION
The runtime and hypervisor `Debug` options were always showing as
`false` (although all debug options in `configuration.toml` were
correctly honoured).

Note: Also moved location of `FactoryConfig` in `RuntimeConfig` as the
`malign` linter was complaining:

```
virtcontainers/pkg/oci/utils.go:102:20:warning: struct of size 408 could be 400 (maligned)
```

Original-master-commit: https://github.com/kata-containers/runtime/commits/23a35c84c92e6ce73366edc575ae875ba4d77473

Fixes #724.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>