### PR TITLE
vendor: update govmm to be compatible with qemu 2.8 to stabel 1.2 branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,25 +2,32 @@
 
 
 [[projects]]
+  digest = "1:167b6f65a6656de568092189ae791253939f076df60231fdd64588ac703892a1"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:3ac89be767202cf44b33eec1b41b3c6255ec1c79d893304ff621cceada4e53d0"
   name = "github.com/clearcontainers/proxy"
   packages = [
     "api",
-    "client"
+    "client",
   ]
+  pruneopts = "NUT"
   revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
 
 [[projects]]
+  digest = "1:3d1a50e9f27c661df8c5552e7f2f6b9d2a8b641c65aeac7373f8a5c60d9f6856"
   name = "github.com/containerd/cri-containerd"
   packages = ["pkg/annotations"]
+  pruneopts = "NUT"
   revision = "3d382e2f5dabe3bae62ceb9ded56bdee847008ee"
 
 [[projects]]
+  digest = "1:3e0383c8e6689f78621ca3592fe1adfc98c23a8bf354704c514d1e7c36d550d7"
   name = "github.com/containernetworking/cni"
   packages = [
     "libcni",
@@ -28,165 +35,215 @@
     "pkg/types",
     "pkg/types/020",
     "pkg/types/current",
-    "pkg/version"
+    "pkg/version",
   ]
+  pruneopts = "NUT"
   revision = "384d8c0b5288c25b9f1da901c66ea5155e6c567d"
 
 [[projects]]
+  digest = "1:1552ba1ba0d0f3596966cca53601a5f59c257ca7ace87f41708a2480835c5286"
   name = "github.com/containernetworking/plugins"
   packages = ["pkg/ns"]
+  pruneopts = "NUT"
   revision = "7f98c94613021d8b57acfa1a2f0c8d0f6fd7ae5a"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:71b605c175e2e0b312d837749f2e58036efd0919ef291104fdc0c496608ffb28"
   name = "github.com/dlespiau/covertool"
   packages = ["pkg/cover"]
+  pruneopts = "NUT"
   revision = "b0c4c6d0583aae4e3b5d12b6ec47767670548cc4"
 
 [[projects]]
+  digest = "1:4340101f42556a9cb2f7a360a0e95a019bfef6247d92e6c4c46f2433cf86a482"
   name = "github.com/docker/go-units"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
 
 [[projects]]
+  digest = "1:021d6ee454d87208dd1cd731cd702d3521aa8a51ad2072fa7beffbb3d677d8bb"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
 
 [[projects]]
+  digest = "1:0dfc35f448d29c2ff6a29fb3a6643f44175dc2a07925b1add2dea74e1dd6bf8d"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
     "protoc-gen-gogo/descriptor",
     "sortkeys",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
 
 [[projects]]
+  digest = "1:d470faddd8d4b027226f9a5ff9d88962c34bb1699dde2acd7e9bfb70a3703d45"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:63e0b20cfa3fe456480edf93a7995f776afb610e49da8e3da04d8904472a44cc"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
+  digest = "1:052c0d6d677c7a3f12d8f83e0a1ce20a896cc206782b035f380249d23bf1265d"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
-  revision = "6ff20ae2f409df976574d0139b5ec2fa3e314769"
+  pruneopts = "NUT"
+  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
 
 [[projects]]
+  digest = "1:b06e09c4554e80f208a583009e54369d109549501b776ca9fc6d59968c68aa29"
   name = "github.com/kata-containers/agent"
   packages = [
     "protocols/client",
-    "protocols/grpc"
+    "protocols/grpc",
   ]
+  pruneopts = "NUT"
   revision = "eec68398287d9491fe648a8e54fb942cf6b6d934"
 
 [[projects]]
+  digest = "1:04054595e5c5a35d1553a7f3464d18577caf597445d643992998643df56d4afd"
   name = "github.com/kubernetes-incubator/cri-o"
   packages = ["pkg/annotations"]
+  pruneopts = "NUT"
   revision = "3394b3b2d6af0e41d185bb695c6378be5dd4d61d"
 
 [[projects]]
+  digest = "1:0159dcdabe50788e5dcfb469521f8f8dcd362db3ab6b465b99a3d33a90726fc0"
   name = "github.com/mdlayher/vsock"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "738c88d6e4cfd60e8124a5344fa10d205fd828b9"
 
 [[projects]]
+  digest = "1:6a65dcd0d14fc0595ee982afc3c59deb5b769ca374455c80c649d92f8a152930"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[projects]]
+  digest = "1:7876a956f7aa42e9830566efbe4278e2963ae0c723b472a0dba27d5fffd066ab"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer/configs",
     "libcontainer/seccomp",
     "libcontainer/specconv",
-    "libcontainer/utils"
+    "libcontainer/utils",
   ]
+  pruneopts = "NUT"
   revision = "0351df1c5a66838d0c392b4ac4cf9450de844e2d"
 
 [[projects]]
+  digest = "1:57234a321bf1f8f98a8a9a5122a2404cc60d0800516f4ab7a7b2375e4b2d19ea"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
+  pruneopts = "NUT"
   revision = "4e3b9264a330d094b0386c3703c5f379119711e8"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:31a930b9d0192b8d37755cd00b5bbd748ca007087235e6b976f7e4549331a2ce"
   name = "github.com/safchain/ethtool"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "79559b488d8848b53a8e34c330140c3fc37ee246"
 
 [[projects]]
+  digest = "1:15427a47e05c87ec16a93f6dc53d8ce52043215ce3ebb4f4f0de1d774120644f"
   name = "github.com/seccomp/libseccomp-golang"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e3496e3a417d1dc9ecdceca5af2513271fed37a0"
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:432ba4d123dc14d6e3b71ca22051bd1a5aa20a8e466e47edabd9af46405c5cfb"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
-    "hooks/syslog"
+    "hooks/syslog",
   ]
+  pruneopts = "NUT"
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
+  digest = "1:511ea0a9d99e8dc47c836f89d58db6690d16e978284b396c89dda04a72925f56"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[projects]]
+  digest = "1:137331c8068398ffaf600c283e721389a6981d3b27ee84a8510e8c77505a464e"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ac249472b7de27a9e8990819566d9be95ab5b816"
 
 [[projects]]
+  digest = "1:51b28ecbdddc7e0260899b64d8cf13343bb8f66b4b00585b46c775509755095a"
   name = "github.com/vishvananda/netlink"
   packages = [
     ".",
-    "nl"
+    "nl",
   ]
+  pruneopts = "NUT"
   revision = "c2a3de3b38bd00f07290c3c5e12b4dbc04ec8666"
 
 [[projects]]
+  digest = "1:7e1f976c4a3aebfcce0bffc7f0fa16903e9c826f6591e0797a91b5fffa1e2f70"
   name = "github.com/vishvananda/netns"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[projects]]
   branch = "master"
+  digest = "1:38cb27d3525635c34e84e2dbc2207c37d10832776997665bf0ddaeae2c861f1f"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "NUT"
   revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
 
 [[projects]]
+  digest = "1:b20c63a56900e442d5f435613fefc9392cbe8849467510fcc3869dbdad9441bb"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -195,19 +252,23 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
+  digest = "1:2fd19a8bed3f4ba8e3b26620f114efec5f39c7b02635a89a915b1cbaefeab5ff"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "1d2aa6dbdea45adaaebb9905d0666e4537563829"
 
 [[projects]]
+  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -223,18 +284,22 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:cd018653a358d4b743a9d3bee89e825521f2ab2f2ec0770164bf7632d8d73ab7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "NUT"
   revision = "2c5e7ac708aaa719366570dd82bda44541ca2a63"
 
 [[projects]]
+  digest = "1:abbcaa84ed484e328cef0cd0bc0130641edc52b4bc6bfb0090dadfd2c1033b6f"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -257,13 +322,48 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "NUT"
   revision = "5a9f7b402fe85096d2e1d0383435ee1876e863d0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ea1297c4bd6bd805ba2ebf07375ba0fd37e1e55a65df361e484934d690ee829e"
+  input-imports = [
+    "github.com/BurntSushi/toml",
+    "github.com/clearcontainers/proxy/api",
+    "github.com/clearcontainers/proxy/client",
+    "github.com/containerd/cri-containerd/pkg/annotations",
+    "github.com/containernetworking/cni/libcni",
+    "github.com/containernetworking/cni/pkg/types",
+    "github.com/containernetworking/cni/pkg/types/020",
+    "github.com/containernetworking/cni/pkg/types/current",
+    "github.com/containernetworking/plugins/pkg/ns",
+    "github.com/dlespiau/covertool/pkg/cover",
+    "github.com/docker/go-units",
+    "github.com/go-ini/ini",
+    "github.com/gogo/protobuf/proto",
+    "github.com/gogo/protobuf/types",
+    "github.com/intel/govmm/qemu",
+    "github.com/kata-containers/agent/protocols/client",
+    "github.com/kata-containers/agent/protocols/grpc",
+    "github.com/kubernetes-incubator/cri-o/pkg/annotations",
+    "github.com/mitchellh/mapstructure",
+    "github.com/opencontainers/runc/libcontainer/configs",
+    "github.com/opencontainers/runc/libcontainer/specconv",
+    "github.com/opencontainers/runc/libcontainer/utils",
+    "github.com/opencontainers/runtime-spec/specs-go",
+    "github.com/safchain/ethtool",
+    "github.com/sirupsen/logrus",
+    "github.com/sirupsen/logrus/hooks/syslog",
+    "github.com/stretchr/testify/assert",
+    "github.com/urfave/cli",
+    "github.com/vishvananda/netlink",
+    "github.com/vishvananda/netns",
+    "golang.org/x/net/context",
+    "golang.org/x/sys/unix",
+    "google.golang.org/grpc",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "6ff20ae2f409df976574d0139b5ec2fa3e314769"
+  revision = "1a16b5f98f133796f9c5e9b6ae3aa6d786cff9b1"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/image.go
+++ b/vendor/github.com/intel/govmm/qemu/image.go
@@ -45,9 +45,11 @@ func CreateCloudInitISO(ctx context.Context, scratchDir, isoPath string,
 	userDataPath := path.Join(dataDirPath, "user_data")
 
 	defer func() {
+		/* #nosec */
 		_ = os.RemoveAll(configDrivePath)
 	}()
 
+	/* #nosec */
 	err := os.MkdirAll(dataDirPath, 0755)
 	if err != nil {
 		return fmt.Errorf("Unable to create config drive directory %s : %v",

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -63,28 +63,28 @@ const (
 	NVDIMM DeviceDriver = "nvdimm"
 
 	// Virtio9P is the 9pfs device driver.
-	Virtio9P = "virtio-9p-pci"
+	Virtio9P DeviceDriver = "virtio-9p-pci"
 
 	// VirtioNet is the virt-io networking device driver.
-	VirtioNet = "virtio-net"
+	VirtioNet DeviceDriver = "virtio-net"
 
 	// VirtioNetPCI is the virt-io pci networking device driver.
-	VirtioNetPCI = "virtio-net-pci"
+	VirtioNetPCI DeviceDriver = "virtio-net-pci"
 
 	// VirtioSerial is the serial device driver.
-	VirtioSerial = "virtio-serial-pci"
+	VirtioSerial DeviceDriver = "virtio-serial-pci"
 
 	// VirtioBlock is the block device driver.
-	VirtioBlock = "virtio-blk"
+	VirtioBlock DeviceDriver = "virtio-blk"
 
 	// Console is the console device driver.
-	Console = "virtconsole"
+	Console DeviceDriver = "virtconsole"
 
 	// VirtioSerialPort is the serial port device driver.
-	VirtioSerialPort = "virtserialport"
+	VirtioSerialPort DeviceDriver = "virtserialport"
 
 	// VHostVSockPCI is the vhost vsock pci driver.
-	VHostVSockPCI = "vhost-vsock-pci"
+	VHostVSockPCI DeviceDriver = "vhost-vsock-pci"
 )
 
 // ObjectType is a string representing a qemu object type.
@@ -171,10 +171,10 @@ const (
 	Local FSDriver = "local"
 
 	// Handle is the handle qemu filesystem driver.
-	Handle = "handle"
+	Handle FSDriver = "handle"
 
 	// Proxy is the proxy qemu filesystem driver.
-	Proxy = "proxy"
+	Proxy FSDriver = "proxy"
 )
 
 const (
@@ -182,13 +182,13 @@ const (
 	None SecurityModelType = "none"
 
 	// PassThrough uses the same credentials on both the host and guest.
-	PassThrough = "passthrough"
+	PassThrough SecurityModelType = "passthrough"
 
 	// MappedXattr stores some files attributes as extended attributes.
-	MappedXattr = "mapped-xattr"
+	MappedXattr SecurityModelType = "mapped-xattr"
 
 	// MappedFile stores some files attributes in the .virtfs directory.
-	MappedFile = "mapped-file"
+	MappedFile SecurityModelType = "mapped-file"
 )
 
 // FSDevice represents a qemu filesystem configuration.
@@ -259,19 +259,19 @@ const (
 	Pipe CharDeviceBackend = "pipe"
 
 	// Socket creates a 2 way stream socket (TCP or Unix).
-	Socket = "socket"
+	Socket CharDeviceBackend = "socket"
 
 	// CharConsole sends traffic from the guest to QEMU's standard output.
-	CharConsole = "console"
+	CharConsole CharDeviceBackend = "console"
 
 	// Serial sends traffic from the guest to a serial device on the host.
-	Serial = "serial"
+	Serial CharDeviceBackend = "serial"
 
 	// TTY is an alias for Serial.
-	TTY = "tty"
+	TTY CharDeviceBackend = "tty"
 
 	// PTY creates a new pseudo-terminal on the host and connect to it.
-	PTY = "pty"
+	PTY CharDeviceBackend = "pty"
 )
 
 // CharDevice represents a qemu character device.
@@ -348,19 +348,19 @@ const (
 	TAP NetDeviceType = "tap"
 
 	// MACVTAP is a macvtap networking device type.
-	MACVTAP = "macvtap"
+	MACVTAP NetDeviceType = "macvtap"
 
 	// IPVTAP is a ipvtap virtual networking device type.
-	IPVTAP = "ipvtap"
+	IPVTAP NetDeviceType = "ipvtap"
 
 	// VETHTAP is a veth-tap virtual networking device type.
-	VETHTAP = "vethtap"
+	VETHTAP NetDeviceType = "vethtap"
 
 	// VFIO is a direct assigned PCI device or PCI VF
-	VFIO = "VFIO"
+	VFIO NetDeviceType = "VFIO"
 
 	// VHOSTUSER is a vhost-user port (socket)
-	VHOSTUSER = "vhostuser"
+	VHOSTUSER NetDeviceType = "vhostuser"
 )
 
 // QemuNetdevParam converts to the QEMU -netdev parameter notation
@@ -637,7 +637,7 @@ const (
 	NoInterface BlockDeviceInterface = "none"
 
 	// SCSI represents a SCSI block device interface.
-	SCSI = "scsi"
+	SCSI BlockDeviceInterface = "scsi"
 )
 
 const (
@@ -645,7 +645,7 @@ const (
 	Threads BlockDeviceAIO = "threads"
 
 	// Native is the pthread asynchronous I/O implementation.
-	Native = "native"
+	Native BlockDeviceAIO = "native"
 )
 
 const (
@@ -976,7 +976,9 @@ type VSOCKDevice struct {
 const (
 	// MinimalGuestCID is the smallest valid context ID for a guest.
 	MinimalGuestCID uint32 = 3
+)
 
+const (
 	// VhostVSOCKPCI is the VSOCK vhost device type.
 	VhostVSOCKPCI = "vhost-vsock-pci"
 
@@ -1029,7 +1031,7 @@ const (
 	UTC RTCBaseType = "utc"
 
 	// LocalTime is the local base time for qemu RTC.
-	LocalTime = "localtime"
+	LocalTime RTCBaseType = "localtime"
 )
 
 const (
@@ -1037,7 +1039,7 @@ const (
 	Host RTCClock = "host"
 
 	// VM is for using the guest clock as a reference
-	VM = "vm"
+	VM RTCClock = "vm"
 )
 
 const (
@@ -1045,7 +1047,7 @@ const (
 	Slew RTCDriftFix = "slew"
 
 	// NoDriftFix means we don't want/need to fix qemu's RTC drift.
-	NoDriftFix = "none"
+	NoDriftFix RTCDriftFix = "none"
 )
 
 // RTC represents a qemu Real Time Clock configuration.
@@ -1062,16 +1064,12 @@ type RTC struct {
 
 // Valid returns true if the RTC structure is valid and complete.
 func (rtc RTC) Valid() bool {
-	if rtc.Clock != "" {
-		if rtc.Clock != Host && rtc.Clock != VM {
-			return false
-		}
+	if rtc.Clock != Host && rtc.Clock != VM {
+		return false
 	}
 
-	if rtc.DriftFix != "" {
-		if rtc.DriftFix != Slew && rtc.DriftFix != NoDriftFix {
-			return false
-		}
+	if rtc.DriftFix != Slew && rtc.DriftFix != NoDriftFix {
+		return false
 	}
 
 	return true
@@ -1237,7 +1235,7 @@ type Config struct {
 	// Path is the qemu binary path.
 	Path string
 
-	// Ctx is not used at the moment.
+	// Ctx is the context used when launching qemu.
 	Ctx context.Context
 
 	// Name is the qemu guest name
@@ -1634,17 +1632,18 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 		return "", err
 	}
 
-	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams,
+	ctx := config.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return LaunchCustomQemu(ctx, config.Path, config.qemuParams,
 		config.fds, nil, logger)
 }
 
 // LaunchCustomQemu can be used to launch a new qemu instance.
 //
 // The path parameter is used to pass the qemu executable path.
-//
-// The ctx parameter is not currently used but has been added so that the
-// signature of this function will not need to change when launch cancellation
-// is implemented.
 //
 // params is a slice of options to pass to qemu-system-x86_64 and fds is a
 // list of open file descriptors that are to be passed to the spawned qemu
@@ -1669,7 +1668,8 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 		path = "qemu-system-x86_64"
 	}
 
-	cmd := exec.Command(path, params...)
+	/* #nosec */
+	cmd := exec.CommandContext(ctx, path, params...)
 	if len(fds) > 0 {
 		logger.Infof("Adding extra file %v", fds)
 		cmd.ExtraFiles = fds

--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -24,9 +24,12 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"syscall"
 	"time"
 
 	"context"
+	"strings"
 )
 
 // QMPLog is a logging interface used by the qemu package to log various
@@ -118,6 +121,7 @@ type qmpCommand struct {
 	args           map[string]interface{}
 	filter         *qmpEventFilter
 	resultReceived bool
+	oob            []byte
 }
 
 // QMP is a structure that contains the internal state used by startQMPLoop and
@@ -302,7 +306,12 @@ func (q *QMP) writeNextQMPCommand(cmdQueue *list.List) {
 	}
 	q.cfg.Logger.Infof("%s", string(encodedCmd))
 	encodedCmd = append(encodedCmd, '\n')
-	_, err = q.conn.Write(encodedCmd)
+	if unixConn, ok := q.conn.(*net.UnixConn); ok && len(cmd.oob) > 0 {
+		_, _, err = unixConn.WriteMsgUnix(encodedCmd, cmd.oob, nil)
+	} else {
+		_, err = q.conn.Write(encodedCmd)
+	}
+
 	if err != nil {
 		cmd.res <- qmpResult{
 			err: fmt.Errorf("Unable to write command to qmp socket %v", err),
@@ -409,13 +418,14 @@ func (q *QMP) mainLoop() {
 		if q.cfg.EventCh != nil {
 			close(q.cfg.EventCh)
 		}
+		/* #nosec */
 		_ = q.conn.Close()
 		_ = <-fromVMCh
 		failOutstandingCommands(cmdQueue)
 		close(q.disconnectedCh)
 	}()
 
-	version := []byte{}
+	var version []byte
 	var cmdDoneCh <-chan struct{}
 
 DONE:
@@ -485,7 +495,7 @@ func startQMPLoop(conn io.ReadWriteCloser, cfg QMPConfig,
 }
 
 func (q *QMP) executeCommandWithResponse(ctx context.Context, name string, args map[string]interface{},
-	filter *qmpEventFilter) (interface{}, error) {
+	oob []byte, filter *qmpEventFilter) (interface{}, error) {
 	var err error
 	var response interface{}
 	resCh := make(chan qmpResult)
@@ -498,6 +508,7 @@ func (q *QMP) executeCommandWithResponse(ctx context.Context, name string, args 
 		name:   name,
 		args:   args,
 		filter: filter,
+		oob:    oob,
 	}:
 	}
 
@@ -519,7 +530,7 @@ func (q *QMP) executeCommandWithResponse(ctx context.Context, name string, args 
 func (q *QMP) executeCommand(ctx context.Context, name string, args map[string]interface{},
 	filter *qmpEventFilter) error {
 
-	_, err := q.executeCommandWithResponse(ctx, name, args, filter)
+	_, err := q.executeCommandWithResponse(ctx, name, args, nil, filter)
 	return err
 }
 
@@ -550,6 +561,10 @@ func (q *QMP) executeCommand(ctx context.Context, name string, args map[string]i
 // block until they have received a success or failure message from QMP,
 // i.e., {"return": {}} or {"error":{}}, and in some cases certain events
 // are received.
+//
+// QEMU currently requires that the "qmp_capabilties" command is sent before any
+// other command. Therefore you must call qmp.ExecuteQMPCapabilities() before
+// you execute any other command.
 func QMPStart(ctx context.Context, socket string, cfg QMPConfig, disconnectedCh chan struct{}) (*QMP, *QMPVersion, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = qmpNullLogger{}
@@ -642,7 +657,7 @@ func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string)
 		},
 	}
 
-	if q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 9) {
+	if q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 8) {
 		blockdevArgs["node-name"] = blockdevID
 		args = blockdevArgs
 	} else {
@@ -660,7 +675,8 @@ func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string)
 // to a previous call to ExecuteBlockdevAdd.  devID is the id of the device to
 // add.  Both strings must be valid QMP identifiers.  driver is the name of the
 // driver,e.g., virtio-blk-pci, and bus is the name of the bus.  bus is optional.
-func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus string) error {
+// shared denotes if the drive can be shared allowing it to be passed more than once.
+func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus string, shared bool) error {
 	args := map[string]interface{}{
 		"id":     devID,
 		"driver": driver,
@@ -668,6 +684,9 @@ func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, b
 	}
 	if bus != "" {
 		args["bus"] = bus
+	}
+	if shared && (q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 10)) {
+		args["share-rw"] = "on"
 	}
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
@@ -678,8 +697,9 @@ func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, b
 // the device to add.  Both strings must be valid QMP identifiers.  driver is the name of the
 // scsi driver,e.g., scsi-hd, and bus is the name of a SCSI controller bus.
 // scsiID is the SCSI id, lun is logical unit number. scsiID and lun are optional, a negative value
-// for scsiID and lun is ignored.
-func (q *QMP) ExecuteSCSIDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus string, scsiID, lun int) error {
+// for scsiID and lun is ignored. shared denotes if the drive can be shared allowing it
+// to be passed more than once.
+func (q *QMP) ExecuteSCSIDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus string, scsiID, lun int, shared bool) error {
 	// TBD: Add drivers for scsi passthrough like scsi-generic and scsi-block
 	drivers := []string{"scsi-hd", "scsi-cd", "scsi-disk"}
 
@@ -707,6 +727,9 @@ func (q *QMP) ExecuteSCSIDeviceAdd(ctx context.Context, blockdevID, devID, drive
 	if lun >= 0 {
 		args["lun"] = lun
 	}
+	if shared && (q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 10)) {
+		args["share-rw"] = "on"
+	}
 
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
@@ -723,8 +746,104 @@ func (q *QMP) ExecuteBlockdevDel(ctx context.Context, blockdevID string) error {
 		return q.executeCommand(ctx, "blockdev-del", args, nil)
 	}
 
-	args["id"] = blockdevID
+	if q.version.Major == 2 && q.version.Minor == 8 {
+		args["node-name"] = blockdevID
+	} else {
+		args["id"] = blockdevID
+	}
+
 	return q.executeCommand(ctx, "x-blockdev-del", args, nil)
+}
+
+// ExecuteNetdevAdd adds a Net device to a QEMU instance
+// using the netdev_add command. netdevID is the id of the device to add.
+// Must be valid QMP identifier.
+func (q *QMP) ExecuteNetdevAdd(ctx context.Context, netdevType, netdevID, ifname, downscript, script string, queues int) error {
+	args := map[string]interface{}{
+		"type":       netdevType,
+		"id":         netdevID,
+		"ifname":     ifname,
+		"downscript": downscript,
+		"script":     script,
+	}
+	if queues > 1 {
+		args["queues"] = queues
+	}
+
+	return q.executeCommand(ctx, "netdev_add", args, nil)
+}
+
+// ExecuteNetdevChardevAdd adds a Net device to a QEMU instance
+// using the netdev_add command. netdevID is the id of the device to add.
+// Must be valid QMP identifier.
+func (q *QMP) ExecuteNetdevChardevAdd(ctx context.Context, netdevType, netdevID, chardev string, queues int) error {
+	args := map[string]interface{}{
+		"type":    netdevType,
+		"id":      netdevID,
+		"chardev": chardev,
+	}
+	if queues > 1 {
+		args["queues"] = queues
+	}
+
+	return q.executeCommand(ctx, "netdev_add", args, nil)
+}
+
+// ExecuteNetdevAddByFds adds a Net device to a QEMU instance
+// using the netdev_add command by fds and vhostfds. netdevID is the id of the device to add.
+// Must be valid QMP identifier.
+func (q *QMP) ExecuteNetdevAddByFds(ctx context.Context, netdevType, netdevID string, fdNames, vhostFdNames []string) error {
+	fdNameStr := strings.Join(fdNames, ":")
+	vhostFdNameStr := strings.Join(vhostFdNames, ":")
+	args := map[string]interface{}{
+		"type":     netdevType,
+		"id":       netdevID,
+		"fds":      fdNameStr,
+		"vhost":    "on",
+		"vhostfds": vhostFdNameStr,
+	}
+
+	return q.executeCommand(ctx, "netdev_add", args, nil)
+}
+
+// ExecuteNetdevDel deletes a Net device from a QEMU instance
+// using the netdev_del command. netdevID is the id of the device to delete.
+func (q *QMP) ExecuteNetdevDel(ctx context.Context, netdevID string) error {
+	args := map[string]interface{}{
+		"id": netdevID,
+	}
+	return q.executeCommand(ctx, "netdev_del", args, nil)
+}
+
+// ExecuteNetPCIDeviceAdd adds a Net PCI device to a QEMU instance
+// using the device_add command. devID is the id of the device to add.
+// Must be valid QMP identifier. netdevID is the id of nic added by previous netdev_add.
+// queues is the number of queues of a nic.
+func (q *QMP) ExecuteNetPCIDeviceAdd(ctx context.Context, netdevID, devID, macAddr, addr, bus string, queues int) error {
+	args := map[string]interface{}{
+		"id":     devID,
+		"driver": VirtioNetPCI,
+		"netdev": netdevID,
+		"mac":    macAddr,
+		"addr":   addr,
+	}
+
+	if bus != "" {
+		args["bus"] = bus
+	}
+
+	if queues > 0 {
+		// (2N+2 vectors, N for tx queues, N for rx queues, 1 for config, and one for possible control vq)
+		// -device virtio-net-pci,mq=on,vectors=2N+2...
+		// enable mq in guest by 'ethtool -L eth0 combined $queue_num'
+		// Clearlinux automatically sets up the queues properly
+		// The agent implementation should do this to ensure that it is
+		// always set
+		args["mq"] = "on"
+		args["vectors"] = 2*queues + 2
+	}
+
+	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
 // ExecuteDeviceDel deletes guest portion of a QEMU device by sending a
@@ -747,8 +866,9 @@ func (q *QMP) ExecuteDeviceDel(ctx context.Context, devID string) error {
 
 // ExecutePCIDeviceAdd is the PCI version of ExecuteDeviceAdd. This function can be used
 // to hot plug PCI devices on PCI(E) bridges, unlike ExecuteDeviceAdd this function receive the
-// device address on its parent bus. bus is optional.
-func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver, addr, bus string) error {
+// device address on its parent bus. bus is optional. shared denotes if the drive can be shared
+// allowing it to be passed more than once.
+func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver, addr, bus string, shared bool) error {
 	args := map[string]interface{}{
 		"id":     devID,
 		"driver": driver,
@@ -758,6 +878,10 @@ func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver
 	if bus != "" {
 		args["bus"] = bus
 	}
+	if shared && (q.version.Major > 2 || (q.version.Major == 2 && q.version.Minor >= 10)) {
+		args["share-rw"] = "on"
+	}
+
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
@@ -792,6 +916,24 @@ func (q *QMP) ExecutePCIVFIODeviceAdd(ctx context.Context, devID, bdf, addr, bus
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
+// ExecutePCIVFIOMediatedDeviceAdd adds a VFIO mediated device to a QEMU instance using the device_add command.
+// This function can be used to hot plug VFIO mediated devices on PCI(E) bridges, unlike
+// ExecuteVFIODeviceAdd this function receives the bus and the device address on its parent bus.
+// bus is optional. devID is the id of the device to add. Must be valid QMP identifier. sysfsdev is the VFIO
+// mediated device.
+func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsdev, addr, bus string) error {
+	args := map[string]interface{}{
+		"id":       devID,
+		"driver":   "vfio-pci",
+		"sysfsdev": sysfsdev,
+		"addr":     addr,
+	}
+	if bus != "" {
+		args["bus"] = bus
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
 // ExecuteCPUDeviceAdd adds a CPU to a QEMU instance using the device_add command.
 // driver is the CPU model, cpuID must be a unique ID to identify the CPU, socketID is the socket number within
 // node/board the CPU belongs to, coreID is the core number within socket the CPU belongs to, threadID is the
@@ -809,7 +951,7 @@ func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, 
 
 // ExecuteQueryHotpluggableCPUs returns a slice with the list of hotpluggable CPUs
 func (q *QMP) ExecuteQueryHotpluggableCPUs(ctx context.Context) ([]HotpluggableCPU, error) {
-	response, err := q.executeCommandWithResponse(ctx, "query-hotpluggable-cpus", nil, nil)
+	response, err := q.executeCommandWithResponse(ctx, "query-hotpluggable-cpus", nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -883,11 +1025,70 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 }
 
 // ExecutePCIVSockAdd adds a vhost-vsock-pci bus
-func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID string) error {
+func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID, vhostfd, addr, bus string, disableModern bool) error {
 	args := map[string]interface{}{
 		"driver":    VHostVSockPCI,
 		"id":        id,
 		"guest-cid": guestCID,
+		"vhostfd":   vhostfd,
+		"addr":      addr,
 	}
+
+	if bus != "" {
+		args["bus"] = bus
+	}
+
+	if disableModern {
+		args["disable-modern"] = disableModern
+	}
+
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
+// ExecuteGetFD sends a file descriptor via SCM rights and assigns it a name
+func (q *QMP) ExecuteGetFD(ctx context.Context, fdname string, fd *os.File) error {
+	oob := syscall.UnixRights(int(fd.Fd()))
+	args := map[string]interface{}{
+		"fdname": fdname,
+	}
+
+	_, err := q.executeCommandWithResponse(ctx, "getfd", args, oob, nil)
+	return err
+}
+
+// ExecuteCharDevUnixSocketAdd adds a character device using as backend a unix socket,
+// id is an identifier for the device, path specifies the local path of the unix socket,
+// wait is to block waiting for a client to connect, server specifies that the socket is a listening socket.
+func (q *QMP) ExecuteCharDevUnixSocketAdd(ctx context.Context, id, path string, wait, server bool) error {
+	args := map[string]interface{}{
+		"id": id,
+		"backend": map[string]interface{}{
+			"type": "socket",
+			"data": map[string]interface{}{
+				"wait":   wait,
+				"server": server,
+				"addr": map[string]interface{}{
+					"type": "unix",
+					"data": map[string]interface{}{
+						"path": path,
+					},
+				},
+			},
+		},
+	}
+	return q.executeCommand(ctx, "chardev-add", args, nil)
+}
+
+// ExecuteVirtSerialPortAdd adds a virtserialport.
+// id is an identifier for the virtserialport, name is a name for the virtserialport and
+// it will be visible in the VM, chardev is the character device id previously added.
+func (q *QMP) ExecuteVirtSerialPortAdd(ctx context.Context, id, name, chardev string) error {
+	args := map[string]interface{}{
+		"driver":  VirtioSerialPort,
+		"id":      id,
+		"name":    name,
+		"chardev": chardev,
+	}
+
 	return q.executeCommand(ctx, "device_add", args, nil)
 }

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -689,7 +689,7 @@ func (q *qemu) hotplugBlockDevice(drive *config.BlockDrive, op operation) error 
 			// PCI address is in the format bridge-addr/device-addr eg. "03/02"
 			drive.PCIAddr = fmt.Sprintf("%02x", bridge.Addr) + "/" + addr
 
-			if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bridge.ID); err != nil {
+			if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bridge.ID, true); err != nil {
 				return err
 			}
 		} else {
@@ -704,7 +704,7 @@ func (q *qemu) hotplugBlockDevice(drive *config.BlockDrive, op operation) error 
 				return err
 			}
 
-			if err = q.qmpMonitorCh.qmp.ExecuteSCSIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, bus, scsiID, lun); err != nil {
+			if err = q.qmpMonitorCh.qmp.ExecuteSCSIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, bus, scsiID, lun, true); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
backport from commit-id: f841e89 in master branch to stable 1.2 branch

govmm has ExecuteBlockdevAdd() function and ExecuteBlockdevDel() function
doesn't compatible with qemu 2.8,because blockdev-add and x-blockdev-del usages
are different between qemu 2.7 and qemu 2.8

shortlog:

    ce070d1 govmm: modify govmm to be compatible with qemu 2.8
    0286ff9 qemu/qmp: support hotplug a nic whose qdisc is mq
    8515ae4 qmp: Remind users that you must first call ExecuteQMPCapabilities()
    21504d3 qemu/qmp: Add netdev_add with chardev support
    ed34f61 Add some negative test cases for qmp.go
    17cacc7 Add negative test cases for qemu.go
    2706a07 qemu: Use the supplied context.Context for launching
    e46092e qemu: Do not try and generate invalid RTC parameters
    fcaf61d qemu/qmp: add vfio mediated device support
    4461c45 disk: Add --share-rw option for hotplugging disks
    6851999 qemu/qmp: add addr and bus to hotplug vsock devices
    10efa84 qemu/qmp: add function for hotplug network by fds
    80ed88e qemu/qmp: implement function to hotplug serial ports
    ca46f21 qemu/qmp: implement function to hotplug character devices
    03f1a1c qemu/qmp: implement getfd
    84b212f qemu: add vhostfd and disable-modern to vsock hotplug
    12dfa87 qemu/qmp: implement function for hotplug network
    4ca232e qmp_test: Fix Warning and Error level logs
    430e72c qemu,qmp: Enable gas security checker
    ffc06e6 qemu,qmp: Add staticcheck to travis and fix errors

fixes: #637

Signed-off-by: flyflypeng <jiangpengfei9@huawei.com>