### PR TITLE
versions: Update golang to 1.10.4

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -138,9 +138,12 @@ externals:
 
   cri-containerd:
     description: |
-      Containerd Plugin for Kubernetes Container Runtime Interface
+      Containerd Plugin for Kubernetes Container Runtime Interface.
+
+      Note that the current version is required for golang 1.10.2
+      (see https://github.com/containerd/cri/pull/941).
     url: "https://github.com/containerd/cri"
-    version: "v1.0.5"
+    version: "8b0d53c09c41d9fbc3b3896548ecf011518e3c42"
     meta:
       containerd-version: "1.1.3"
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -186,9 +186,10 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.9.7"
+    issue: "https://github.com/golang/go/issues/20676"
+    version: "1.10.4"
     meta:
-      newest-version: "1.10"
+      newest-version: "1.11"
 
 specs:
   description: "Details of important specifications"

--- a/virtcontainers/monitor.go
+++ b/virtcontainers/monitor.go
@@ -18,9 +18,9 @@ type monitor struct {
 	sandbox       *Sandbox
 	checkInterval time.Duration
 	watchers      []chan error
+	wg            sync.WaitGroup
 	running       bool
 	stopCh        chan bool
-	wg            sync.WaitGroup
 }
 
 func newMonitor(s *Sandbox) *monitor {

--- a/virtcontainers/pkg/mock/cc_proxy_mock.go
+++ b/virtcontainers/pkg/mock/cc_proxy_mock.go
@@ -25,7 +25,6 @@ type CCProxyMock struct {
 	sync.Mutex
 
 	t              *testing.T
-	wg             sync.WaitGroup
 	connectionPath string
 
 	// proxy socket
@@ -43,6 +42,8 @@ type CCProxyMock struct {
 	Signal           chan ShimSignal
 	ShimDisconnected chan bool
 	StdinReceived    chan bool
+
+	wg sync.WaitGroup
 
 	stopped bool
 }


### PR DESCRIPTION
Move to golang version 1.10.4 -- the oldest stable golang release at the
time of writing -- since golang 1.10+ is needed to make namespace
handling safe.

See:

- https://github.com/golang/go/issues/20676
- https://github.com/golang/go/commit/2595fe7fb6f272f9204ca3ef0b0c55e66fb8d90f

Also bumped `languages.golang.meta.newest-version` to golang version
1.11, which is the newest stable release at the time of writing.

Fixes #148.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>