### PR TITLE
qemu: query migrate status

### DIFF
--- a/virtcontainers/factory/template/template.go
+++ b/virtcontainers/factory/template/template.go
@@ -25,7 +25,6 @@ type template struct {
 
 var templateProxyType = vc.KataBuiltInProxyType
 var templateWaitForAgent = 2 * time.Second
-var templateWaitForMigration = 1 * time.Second
 
 // Fetch finds and returns a pre-built template factory.
 // TODO: save template metadata and fetch from storage.
@@ -144,9 +143,6 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	if err = vm.Save(); err != nil {
 		return err
 	}
-
-	// qemu QMP does not wait for migration to finish...
-	time.Sleep(templateWaitForMigration)
 
 	return nil
 }

--- a/virtcontainers/factory/template/template_test.go
+++ b/virtcontainers/factory/template/template_test.go
@@ -20,7 +20,6 @@ import (
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
-	templateWaitForMigration = 1 * time.Microsecond
 	templateWaitForAgent = 1 * time.Microsecond
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")


### PR DESCRIPTION
This makes `saveSandbox` wait for migration completion, then we can remove the arbitrary sleep waiting for migration completion when creating a tempalte vm.

The govmm patch will be revendored once it is merged.