### PR TITLE
cli: add systemd-cgroup option

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -83,6 +83,7 @@ var createCLICommand = cli.Command{
 			console,
 			context.String("pid-file"),
 			true,
+			context.Bool("systemd-cgroup"),
 			runtimeConfig,
 		)
 	},
@@ -91,7 +92,7 @@ var createCLICommand = cli.Command{
 // Use a variable to allow tests to modify its value
 var getKernelParamsFunc = getKernelParams
 
-func create(ctx context.Context, containerID, bundlePath, console, pidFilePath string, detach bool,
+func create(ctx context.Context, containerID, bundlePath, console, pidFilePath string, detach, systemdCgroup bool,
 	runtimeConfig oci.RuntimeConfig) error {
 	var err error
 
@@ -146,7 +147,7 @@ func create(ctx context.Context, containerID, bundlePath, console, pidFilePath s
 	var process vc.Process
 	switch containerType {
 	case vc.PodSandbox:
-		process, err = createSandbox(ctx, ociSpec, runtimeConfig, containerID, bundlePath, console, disableOutput)
+		process, err = createSandbox(ctx, ociSpec, runtimeConfig, containerID, bundlePath, console, disableOutput, systemdCgroup)
 		if err != nil {
 			return err
 		}
@@ -252,7 +253,7 @@ func setKernelParams(containerID string, runtimeConfig *oci.RuntimeConfig) error
 }
 
 func createSandbox(ctx context.Context, ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
-	containerID, bundlePath, console string, disableOutput bool) (vc.Process, error) {
+	containerID, bundlePath, console string, disableOutput, systemdCgroup bool) (vc.Process, error) {
 	span, ctx := trace(ctx, "createSandbox")
 	defer span.Finish()
 
@@ -261,7 +262,7 @@ func createSandbox(ctx context.Context, ociSpec oci.CompatOCISpec, runtimeConfig
 		return vc.Process{}, err
 	}
 
-	sandboxConfig, err := oci.SandboxConfig(ociSpec, runtimeConfig, bundlePath, containerID, console, disableOutput)
+	sandboxConfig, err := oci.SandboxConfig(ociSpec, runtimeConfig, bundlePath, containerID, console, disableOutput, systemdCgroup)
 	if err != nil {
 		return vc.Process{}, err
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -105,6 +105,10 @@ var runtimeFlags = []cli.Flag{
 		Name:  showConfigPathsOption,
 		Usage: "show config file paths that will be checked for (in order)",
 	},
+	cli.BoolFlag{
+		Name:  "systemd-cgroup",
+		Usage: "enable systemd cgroup support, expects cgroupsPath to be of form \"slice:prefix:name\" for e.g. \"system.slice:runc:434234\"",
+	},
 }
 
 // runtimeCommands is the list of supported command-line (sub-)

--- a/cli/run.go
+++ b/cli/run.go
@@ -75,11 +75,12 @@ var runCLICommand = cli.Command{
 			context.String("console-socket"),
 			context.String("pid-file"),
 			context.Bool("detach"),
+			context.Bool("systemd-cgroup"),
 			runtimeConfig)
 	},
 }
 
-func run(ctx context.Context, containerID, bundle, console, consoleSocket, pidFile string, detach bool,
+func run(ctx context.Context, containerID, bundle, console, consoleSocket, pidFile string, detach, systemdCgroup bool,
 	runtimeConfig oci.RuntimeConfig) error {
 	span, ctx := trace(ctx, "run")
 	defer span.Finish()
@@ -89,7 +90,7 @@ func run(ctx context.Context, containerID, bundle, console, consoleSocket, pidFi
 		return err
 	}
 
-	if err := create(ctx, containerID, bundle, consolePath, pidFile, detach, runtimeConfig); err != nil {
+	if err := create(ctx, containerID, bundle, consolePath, pidFile, detach, systemdCgroup, runtimeConfig); err != nil {
 		return err
 	}
 

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -421,6 +421,7 @@ func TestAppendDevices(t *testing.T) {
 
 func TestConstraintGRPCSpec(t *testing.T) {
 	assert := assert.New(t)
+	expectedCgroupPath := "/foo/bar"
 
 	g := &pb.Spec{
 		Hooks: &pb.Hooks{},
@@ -448,10 +449,11 @@ func TestConstraintGRPCSpec(t *testing.T) {
 				HugepageLimits: []pb.LinuxHugepageLimit{},
 				Network:        &pb.LinuxNetwork{},
 			},
+			CgroupsPath: "system.slice:foo:bar",
 		},
 	}
 
-	constraintGRPCSpec(g)
+	constraintGRPCSpec(g, true)
 
 	// check nil fields
 	assert.Nil(g.Hooks)
@@ -470,6 +472,9 @@ func TestConstraintGRPCSpec(t *testing.T) {
 
 	// check mounts
 	assert.Len(g.Mounts, 1)
+
+	// check cgroup path
+	assert.Equal(expectedCgroupPath, g.Linux.CgroupsPath)
 }
 
 func TestHandleShm(t *testing.T) {

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -453,7 +453,7 @@ func addAssetAnnotations(ocispec CompatOCISpec, config *vc.SandboxConfig) {
 
 // SandboxConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers sandbox configuration structure.
-func SandboxConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string, detach bool) (vc.SandboxConfig, error) {
+func SandboxConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid, console string, detach, systemdCgroup bool) (vc.SandboxConfig, error) {
 	containerConfig, err := ContainerConfig(ocispec, bundlePath, cid, console, detach)
 	if err != nil {
 		return vc.SandboxConfig{}, err
@@ -507,6 +507,8 @@ func SandboxConfig(ocispec CompatOCISpec, runtime RuntimeConfig, bundlePath, cid
 		},
 
 		ShmSize: shmSize,
+
+		SystemdCgroup: systemdCgroup,
 	}
 
 	addAssetAnnotations(ocispec, &sandboxConfig)

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -231,6 +231,8 @@ func TestMinimalSandboxConfig(t *testing.T) {
 			vcAnnotations.ConfigJSONKey: string(ociSpecJSON),
 			vcAnnotations.BundlePathKey: tempBundlePath,
 		},
+
+		SystemdCgroup: true,
 	}
 
 	ociSpec, err := ParseConfigJSON(tempBundlePath)
@@ -238,7 +240,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 		t.Fatalf("Could not parse config.json: %v", err)
 	}
 
-	sandboxConfig, err := SandboxConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false)
+	sandboxConfig, err := SandboxConfig(ociSpec, runtimeConfig, tempBundlePath, containerID, consolePath, false, true)
 	if err != nil {
 		t.Fatalf("Could not create Sandbox configuration %v", err)
 	}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -352,6 +352,9 @@ type SandboxConfig struct {
 	// Stateful keeps sandbox resources in memory across APIs. Users will be responsible
 	// for calling Release() to release the memory resources.
 	Stateful bool
+
+	// SystemdCgroup enables systemd cgroup support
+	SystemdCgroup bool
 }
 
 func (s *Sandbox) trace(name string) (opentracing.Span, context.Context) {


### PR DESCRIPTION
Add support for cgroup driver systemd.
systemd cgroup is not applied in the VM since in some cases like initrd images
there is no systemd running and nobody can update a systemd cgroup using
systemctl.

fixes #596

Signed-off-by: Julio Montes <julio.montes@intel.com>