### PR TITLE
versions: update containerd version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -140,9 +140,9 @@ externals:
     description: |
       Containerd Plugin for Kubernetes Container Runtime Interface
     url: "https://github.com/containerd/cri"
-    version: "v1.0.0"
+    version: "v1.0.5"
     meta:
-      containerd-version: "1.1.0"
+      containerd-version: "1.1.3"
 
   docker:
     description: "Moby project container manager"


### PR DESCRIPTION
Update the version that is used to test Kata.

```yaml
  cri-containerd:
    version: "v1.0.5"
    meta:
      containerd-version: "1.1.3"
```

Fixes: #748