### PR TITLE
virtcontainers: fix the issue of missing starting builtin proxy

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -247,7 +247,6 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 
 	if builtin {
 		k.proxyBuiltIn = true
-		k.state.URL, _ = k.agentURL()
 	}
 
 	// Adding the shared volume.

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -649,6 +649,7 @@ func TestAgentConfigure(t *testing.T) {
 
 	err = k.configure(h, id, dir, true, c)
 	assert.Nil(err)
+	assert.Empty(k.state.URL)
 
 	err = k.configure(h, id, dir, false, c)
 	assert.Nil(err)


### PR DESCRIPTION
It shouldn't set kataAgent.state.URL in its configure() method
for builtin kata proxy, otherwise the following check of whether
is it nil in startProxy() will return directly and failed to
start builtin proxy which will log the qemu's console.

Fixes: #756

Signed-off-by: fupan <lifupan@gmail.com>