### PR TITLE
agent: clean up proxy process if start sandbox failed

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -569,6 +569,12 @@ func (k *kataAgent) startSandbox(sandbox *Sandbox) error {
 		return err
 	}
 
+	defer func() {
+		if err != nil {
+			k.proxy.stop(k.state.ProxyPid)
+		}
+	}()
+
 	hostname := sandbox.config.Hostname
 	if len(hostname) > maxHostnameLen {
 		hostname = hostname[:maxHostnameLen]
@@ -586,10 +592,10 @@ func (k *kataAgent) startSandbox(sandbox *Sandbox) error {
 	if err != nil {
 		return err
 	}
-	if err := k.updateInterfaces(interfaces); err != nil {
+	if err = k.updateInterfaces(interfaces); err != nil {
 		return err
 	}
-	if _, err := k.updateRoutes(routes); err != nil {
+	if _, err = k.updateRoutes(routes); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Otherwise we'll leave kata-proxy process dangling around forever.

Fixes: #759