### PR TITLE
build: add restriction Golang >= 1.10

### DIFF
--- a/cli/oci.go
+++ b/cli/oci.go
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// +build go1.10
+
 package main
 
 import (


### PR DESCRIPTION
Fixes #148

Add build tag to restrict minimum golang version to 1.10, in case we run into
Netns mix problem again and again.

Signed-off-by: Wei Zhang <zhangwei555@huawei.com>