### PR TITLE
cli: Agent as init in rootfs images

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -27,6 +27,10 @@ machine_type = "@MACHINETYPE@"
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
+#
+# NOTE: If you want to use systemd or any other init daemon, the `init` parameter
+# should be used here. For example for systemd you have to add following line:
+# init=/lib/systemd/systemd systemd.unit=@PROJECT_TAG@.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket
 kernel_params = "@KERNELPARAMS@"
 
 # Path to the firmware.

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -758,24 +758,9 @@ func TestCreateInvalidKernelParams(t *testing.T) {
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
 
-	savedFunc := katautils.GetKernelParamsFunc
-	defer func() {
-		katautils.GetKernelParamsFunc = savedFunc
-	}()
-
-	katautils.GetKernelParamsFunc = func(needSystemd bool) []vc.Param {
-		return []vc.Param{
-			{
-				Key:   "",
-				Value: "",
-			},
-		}
-	}
-
 	for detach := range []bool{true, false} {
 		err := create(context.Background(), testContainerID, bundlePath, testConsole, pidFilePath, true, true, runtimeConfig)
 		assert.Errorf(err, "%+v", detach)
-		assert.False(vcmock.IsMockError(err))
 		os.RemoveAll(path)
 	}
 }

--- a/pkg/katautils/config-settings.go
+++ b/pkg/katautils/config-settings.go
@@ -15,7 +15,6 @@ var defaultInitrdPath = "/usr/share/kata-containers/kata-containers-initrd.img"
 var defaultFirmwarePath = ""
 var defaultMachineAccelerators = ""
 var defaultShimPath = "/usr/libexec/kata-containers/kata-shim"
-var systemdUnitName = "kata-containers.target"
 
 const defaultKernelParams = ""
 const defaultMachineType = "pc"

--- a/pkg/katautils/create_test.go
+++ b/pkg/katautils/create_test.go
@@ -203,10 +203,6 @@ func TestSetKernelParams(t *testing.T) {
 
 	err := SetKernelParams(testContainerID, &config)
 	assert.NoError(err)
-
-	if needSystemd(config.HypervisorConfig) {
-		assert.NotEmpty(config.HypervisorConfig.KernelParams)
-	}
 }
 
 func TestSetKernelParamsUserOptionTakesPriority(t *testing.T) {


### PR DESCRIPTION
Let kernel start the default init daemon (/sbin/init) and rid of
all related to systemd.
Currently we are tied to systemd because we have hardcoded it, we use
systemd even when we don't know if the image has it. Now that we can use
kata-agent as init process in rootfs images (kata-containers/agent#376), we
should use it, since we are responsible for any security flaw found in
kata-containers, it doesn't matter if we wrote that code or not (systemd).
The usage of kata-agent as init process brings performance improvements in
boot time and memory footprint.

Depends-on: github.com/kata-containers/tests#948

fixes #767

Signed-off-by: Julio Montes <julio.montes@intel.com>