### PR TITLE
agent: change 9pfs mount option to cache=mmap

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -56,7 +56,7 @@ var (
 	kata9pDevType        = "9p"
 	kataBlkDevType       = "blk"
 	kataSCSIDevType      = "scsi"
-	sharedDir9pOptions   = []string{"trans=virtio,version=9p2000.L", "nodev"}
+	sharedDir9pOptions   = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
 	shmDir               = "shm"
 	kataEphemeralDevType = "ephemeral"
 	ephemeralPath        = filepath.Join(kataGuestSandboxDir, kataEphemeralDevType)


### PR DESCRIPTION
It does not give better pjdfstest results but allows us to pass
ubuntu `apt update`, fedora `dnf install`, and also launch `mariadb:latest`.

Fixes: #769

cc @sboeuf @WeiZhang555 @gnawux @egernst 