### PR TITLE
block: Advertise block support for q35

### DIFF
--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -102,8 +102,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 func (q *qemuAmd64) capabilities() capabilities {
 	var caps capabilities
 
-	// Only pc machine type supports hotplugging drives
-	if q.machineType == QemuPC {
+	if q.machineType == QemuPC || q.machineType == QemuQ35 {
 		caps.setBlockDeviceHotplugSupport()
 	}
 

--- a/virtcontainers/qemu_amd64_test.go
+++ b/virtcontainers/qemu_amd64_test.go
@@ -31,7 +31,7 @@ func TestQemuAmd64Capabilities(t *testing.T) {
 
 	amd64 = newTestQemu(QemuQ35)
 	caps = amd64.capabilities()
-	assert.False(caps.isBlockDeviceHotplugSupported())
+	assert.True(caps.isBlockDeviceHotplugSupported())
 }
 
 func TestQemuAmd64Bridges(t *testing.T) {


### PR DESCRIPTION
Add block device capability for q35 as this machine type supports it.
This was never added with the introduction of q35 support.

Fixes #771

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>