### PR TITLE
block: Fix how rootfs is passed to kata-agent using virtio-blk

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -850,7 +850,7 @@ func (k *kataAgent) buildContainerRootfs(sandbox *Sandbox, c *Container, rootPat
 
 		if sandbox.config.HypervisorConfig.BlockDeviceDriver == VirtioBlock {
 			rootfs.Driver = kataBlkDevType
-			rootfs.Source = blockDrive.VirtPath
+			rootfs.Source = blockDrive.PCIAddr
 		} else {
 			rootfs.Driver = kataSCSIDevType
 			rootfs.Source = blockDrive.SCSIAddr


### PR DESCRIPTION
Kata agent expects the pci address to be passed and not the
predicted device name.

Fixes #773

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>