### PR TITLE
virtcontainers: revert "fix shared dir resource remaining"

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -163,9 +163,6 @@ type agent interface {
 	// stopSandbox will tell the agent to stop all containers related to the Sandbox.
 	stopSandbox(sandbox *Sandbox) error
 
-	// cleanup will clean the resources for sandbox
-	cleanupSandbox(sandbox *Sandbox) error
-
 	// createContainer will tell the agent to create a container related to a Sandbox.
 	createContainer(sandbox *Sandbox, c *Container) (*Process, error)
 

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -953,10 +953,6 @@ func (h *hyper) resumeContainer(sandbox *Sandbox, c Container) error {
 	return nil
 }
 
-func (h *hyper) cleanupSandbox(sandbox *Sandbox) error {
-	return nil
-}
-
 func (h *hyper) reseedRNG(data []byte) error {
 	// hyperstart-agent does not support reseeding
 	return nil

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -670,10 +670,6 @@ func (k *kataAgent) stopSandbox(sandbox *Sandbox) error {
 	return nil
 }
 
-func (k *kataAgent) cleanupSandbox(sandbox *Sandbox) error {
-	return os.RemoveAll(filepath.Join(kataHostSharedDir, sandbox.id))
-}
-
 func (k *kataAgent) replaceOCIMountSource(spec *specs.Spec, guestMounts []Mount) error {
 	ociMounts := spec.Mounts
 
@@ -1167,14 +1163,7 @@ func (k *kataAgent) stopContainer(sandbox *Sandbox, c Container) error {
 		return err
 	}
 
-	if err := bindUnmountContainerRootfs(k.ctx, kataHostSharedDir, sandbox.id, c.id); err != nil {
-		return err
-	}
-
-	// since rootfs is umounted it's safe to remove the dir now
-	rootPathParent := filepath.Join(kataHostSharedDir, sandbox.id, c.id)
-
-	return os.RemoveAll(rootPathParent)
+	return bindUnmountContainerRootfs(k.ctx, kataHostSharedDir, sandbox.id, c.id)
 }
 
 func (k *kataAgent) signalProcess(c *Container, processID string, signal syscall.Signal, all bool) error {

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -58,11 +58,6 @@ func (n *noopAgent) stopSandbox(sandbox *Sandbox) error {
 	return nil
 }
 
-// cleanup is the Noop agent clean up resource implementation. It does nothing.
-func (n *noopAgent) cleanupSandbox(sandbox *Sandbox) error {
-	return nil
-}
-
 // createContainer is the Noop agent Container creation implementation. It does nothing.
 func (n *noopAgent) createContainer(sandbox *Sandbox, c *Container) (*Process, error) {
 	return &Process{}, nil

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1455,13 +1455,6 @@ func (s *Sandbox) stop() error {
 		return err
 	}
 
-	// vm is stopped remove the sandbox shared dir
-	if err := s.agent.cleanupSandbox(s); err != nil {
-		// cleanup resource failed shouldn't block destroy sandbox
-		// just raise a warning
-		s.Logger().WithError(err).Warnf("cleanup sandbox failed")
-	}
-
 	return s.setSandboxState(StateStopped)
 }
 


### PR DESCRIPTION
This reverts commit 8a6d383715f6cd8e0777ab5d14a421129bdff8c0.

Don't remove all directories in the shared directory because
`docker cp` re-mounts all the mount points specified in the
config.json causing serious problems in the host.

fixes #777

Signed-off-by: Julio Montes <julio.montes@intel.com>