### PR TITLE
vc: qemu: Add config option to choose entropy source.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ DEFMEMSLOTS := 10
 DEFBRIDGES := 1
 #Default network model
 DEFNETWORKMODEL := macvtap
+#Default entropy source
+DEFENTROPYSOURCE := /dev/urandom
 
 DEFDISABLEBLOCK := false
 DEFBLOCKSTORAGEDRIVER := virtio-scsi
@@ -222,6 +224,8 @@ USER_VARS += DEFENABLEDEBUG
 USER_VARS += DEFDISABLENESTINGCHECKS
 USER_VARS += DEFMSIZE9P
 USER_VARS += DEFHOTPLUGVFIOONROOTBUS
+USER_VARS += DEFENTROPYSOURCE
+
 
 V              = @
 Q              = $(V:1=)
@@ -323,6 +327,7 @@ const defaultEnableDebug bool = $(DEFENABLEDEBUG)
 const defaultDisableNestingChecks bool = $(DEFDISABLENESTINGCHECKS)
 const defaultMsize9p uint32 = $(DEFMSIZE9P)
 const defaultHotplugVFIOOnRootBus bool = $(DEFHOTPLUGVFIOONROOTBUS)
+const defaultEntropySource = "$(DEFENTROPYSOURCE)"
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(CONFIG_PATH)"
@@ -413,6 +418,7 @@ $(GENERATED_FILES): %: %.in Makefile VERSION
 		-e "s|@DEFDISABLENESTINGCHECKS@|$(DEFDISABLENESTINGCHECKS)|g" \
 		-e "s|@DEFMSIZE9P@|$(DEFMSIZE9P)|g" \
 		-e "s|@DEFHOTPLUGONROOTBUS@|$(DEFHOTPLUGVFIOONROOTBUS)|g" \
+		-e "s|@DEFENTROPYSOURCE@|$(DEFENTROPYSOURCE)|g" \
 		$< > $@
 
 generate-config: $(CONFIG)

--- a/cli/config.go
+++ b/cli/config.go
@@ -81,6 +81,7 @@ type hypervisor struct {
 	KernelParams          string `toml:"kernel_params"`
 	MachineType           string `toml:"machine_type"`
 	BlockDeviceDriver     string `toml:"block_device_driver"`
+	EntropySource         string `toml:"entropy_source"`
 	NumVCPUs              int32  `toml:"default_vcpus"`
 	DefaultMaxVCPUs       uint32 `toml:"default_maxvcpus"`
 	MemorySize            uint32 `toml:"default_memory"`
@@ -206,6 +207,14 @@ func (h hypervisor) machineType() string {
 	}
 
 	return h.MachineType
+}
+
+func (h hypervisor) GetEntropySource() string {
+	if h.EntropySource == "" {
+		return defaultEntropySource
+	}
+
+	return h.EntropySource
 }
 
 func (h hypervisor) defaultVCPUs() uint32 {
@@ -403,6 +412,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DefaultMaxVCPUs:       h.defaultMaxVCPUs(),
 		MemorySize:            h.defaultMemSz(),
 		MemSlots:              h.defaultMemSlots(),
+		EntropySource:         h.GetEntropySource(),
 		DefaultBridges:        h.defaultBridges(),
 		DisableBlockDeviceUse: h.DisableBlockDeviceUse,
 		MemPrealloc:           h.MemPrealloc,

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -155,6 +155,17 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # If host doesn't support vhost_net, set to true. Thus we won't create vhost fds for nics.
 # Default false
 #disable_vhost_net = true
+#
+# Default entropy source.
+# The path to a host source of entropy (including a real hardware RNG)
+# /dev/urandom and /dev/random are two main options.
+# Be aware that /dev/random is a blocking source of entropy.  If the host
+# runs out of entropy, the VMs boot time will increase leading to get startup
+# timeouts.
+# The source of entropy /dev/urandom is non-blocking and provides a
+# generally acceptable source of entropy. It should work well for pretty much
+# all practical purposes.
+#entropy_source= "@DEFENTROPYSOURCE@"
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -160,6 +160,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		HotplugVFIOOnRootBus:  hotplugVFIOOnRootBus,
 		Msize9p:               defaultMsize9p,
 		MemSlots:              defaultMemSlots,
+		EntropySource:         defaultEntropySource,
 	}
 
 	agentConfig := vc.KataAgentConfig{}

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -25,7 +25,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.17"
+const formatVersion = "1.0.18"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -81,6 +81,7 @@ type HypervisorInfo struct {
 	Version           string
 	Path              string
 	BlockDeviceDriver string
+	EntropySource     string
 	Msize9p           uint32
 	MemorySlots       uint32
 	Debug             bool
@@ -319,6 +320,7 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 		Msize9p:           config.HypervisorConfig.Msize9p,
 		UseVSock:          config.HypervisorConfig.UseVSock,
 		MemorySlots:       config.HypervisorConfig.MemSlots,
+		EntropySource:     config.HypervisorConfig.EntropySource,
 	}
 }
 

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -264,6 +264,7 @@ func getExpectedHypervisor(config oci.RuntimeConfig) HypervisorInfo {
 		Msize9p:           config.HypervisorConfig.Msize9p,
 		MemorySlots:       config.HypervisorConfig.MemSlots,
 		Debug:             config.HypervisorConfig.Debug,
+		EntropySource:     config.HypervisorConfig.EntropySource,
 	}
 }
 

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -142,6 +142,8 @@ type VFIODev struct {
 type RNGDev struct {
 	// ID is used to identify the device in the hypervisor options.
 	ID string
+	// Filename is the file to use as entropy source.
+	Filename string
 }
 
 // VhostUserDeviceAttrs represents data shared by most vhost-user devices

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -196,6 +196,10 @@ type HypervisorConfig struct {
 	// BootFromTemplate is true.
 	DevicesStatePath string
 
+	// EntropySource is the path to a host source of
+	// entropy (/dev/random, /dev/urandom or real hardware RNG device)
+	EntropySource string
+
 	// customAssets is a map of assets.
 	// Each value in that map takes precedence over the configured assets.
 	// For example, if there is a value for the "kernel" key in this map,

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -496,7 +496,8 @@ func (q *qemu) createSandbox() error {
 	}
 	// Add RNG device to hypervisor
 	rngDev := config.RNGDev{
-		ID: rngID,
+		ID:       rngID,
+		Filename: q.config.EntropySource,
 	}
 	qemuConfig.Devices = q.arch.appendRNGDevice(qemuConfig.Devices, rngDev)
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -525,7 +525,8 @@ func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev conf
 func (q *qemuArchBase) appendRNGDevice(devices []govmmQemu.Device, rngDev config.RNGDev) []govmmQemu.Device {
 	devices = append(devices,
 		govmmQemu.RngDevice{
-			ID: rngDev.ID,
+			ID:       rngDev.ID,
+			Filename: rngDev.Filename,
 		},
 	)
 


### PR DESCRIPTION
Today we use `/dev/random` as entropy source.
This is a blocking entropy source, when the
host is getting a low amount of entropy the
Kata VM startup takes longer because block
trying to get entropy from the source.

This change allow to change the entropy source.
For example: urandom
Fixes: #702