### PR TITLE
update: Return memory to host on memory update.

### DIFF
--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -112,6 +112,9 @@ type qemuArch interface {
 	// addBridge adds a new Bridge to the list of Bridges
 	addBridge(types.Bridge)
 
+	// appendBalloonDevice appens a Balloon device to devices
+	appendBalloonDevice(devices []govmmQemu.Device, balloonID string) ([]govmmQemu.Device, error)
+
 	// handleImagePath handles the Hypervisor Config image path
 	handleImagePath(config HypervisorConfig)
 
@@ -684,4 +687,17 @@ func (q *qemuArchBase) setBridges(bridges []types.Bridge) {
 
 func (q *qemuArchBase) addBridge(b types.Bridge) {
 	q.Bridges = append(q.Bridges, b)
+}
+
+func (q *qemuArchBase) appendBalloonDevice(devices []govmmQemu.Device, balloonID string) ([]govmmQemu.Device, error) {
+	if balloonID == "" {
+		return devices, fmt.Errorf("Balloon ID is empty")
+	}
+	devices = append(devices,
+		govmmQemu.BalloonDevice{
+			ID: balloonID,
+		},
+	)
+
+	return devices, nil
 }

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	govmmQemu "github.com/intel/govmm/qemu"
@@ -561,4 +562,38 @@ func TestQemuArchBaseAppendNetwork(t *testing.T) {
 	devices, err = qemuArchBase.appendNetwork(devices, macvtapEp)
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
+}
+
+func TestQemuArchBaseAppendBalloonDevice(t *testing.T) {
+	expectedDevices := []govmmQemu.Device{
+		govmmQemu.BalloonDevice{
+			ID: balloonID,
+		},
+	}
+	type args struct {
+		devices   []govmmQemu.Device
+		balloonID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []govmmQemu.Device
+		wantErr bool
+	}{
+		{"Empty ID", args{[]govmmQemu.Device{}, ""}, []govmmQemu.Device{}, true},
+		{"Use valid ID", args{[]govmmQemu.Device{}, balloonID}, expectedDevices, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &qemuArchBase{}
+			got, err := q.appendBalloonDevice(tt.args.devices, tt.args.balloonID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Got  %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -567,3 +567,28 @@ func TestQemuGetpids(t *testing.T) {
 	assert.True(pids[0] == 100)
 	assert.True(pids[1] == 200)
 }
+
+func TestQemuUpdateMemoryBalloon(t *testing.T) {
+	type fields struct {
+		qmp *govmmQemu.QMP
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		sizeMB  uint32
+		wantErr bool
+	}{
+		{"qmp nil", fields{}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &qemu{}
+			q.qmpMonitorCh.qmp = tt.fields.qmp
+			if err := q.updateMemoryBalloon(tt.sizeMB); (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wanted = %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If memory update will reduce memory we want to get memory
back to the host and restrict the guest to use more memory.
```bash
$ docker exec -ti kata-1 free -h
              total        used        free      shared  buff/cache   available
Mem:           5.9G         23M        5.8G        8.2M         18M        5.8G
Swap:            0B          0B          0B
$ docker update --memory 2G kata-1
kata-1
$ docker exec -ti kata-1 free -h
              total        used        free      shared  buff/cache   available
Mem:           1.9G         56M        1.8G        8.2M         18M        1.8G
Swap:            0B          0B          0B
```

Fixes: #790 

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>