### PR TITLE
virtcontainers: qemu: Add proper support for virt machine type

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,11 +123,11 @@
   revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
-  digest = "1:034b5648db9f53a2b6f4f84925ee031cbeaba69daa10d95e74e8242707d7a5b0"
+  digest = "1:c63a5bf4f3fd94ae838ce53e3492c0a467c40d09cada9301d228df7164ba4e55"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "9905ae92c5915c07abeb669eaa4d7f7408834b51"
+  revision = "f03df80fc3dc52f65ed6c7d12806279b44185d32"
 
 [[projects]]
   digest = "1:672470f31bc4e50f9ba09a1af7ab6035bf8b1452db64dfd79b1a22614bb30710"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "9905ae92c5915c07abeb669eaa4d7f7408834b51"
+  revision = "f03df80fc3dc52f65ed6c7d12806279b44185d32"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1194,7 +1194,8 @@ func (q *qemu) disconnect() {
 // genericAppendBridges appends to devices the given bridges
 func genericAppendBridges(devices []govmmQemu.Device, bridges []Bridge, machineType string) []govmmQemu.Device {
 	bus := defaultPCBridgeBus
-	if machineType == QemuQ35 {
+	switch machineType {
+	case QemuQ35, QemuVirt:
 		bus = defaultBridgeBus
 	}
 
@@ -1227,13 +1228,14 @@ func genericBridges(number uint32, machineType string) []Bridge {
 	var bt bridgeType
 
 	switch machineType {
-
 	case QemuQ35:
 		// currently only pci bridges are supported
 		// qemu-2.10 will introduce pcie bridges
 		fallthrough
 	case QemuPC:
 		bt = pciBridge
+	case QemuVirt:
+		bt = pcieBridge
 	case QemuPseries:
 		bt = pciBridge
 	default:

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -102,7 +102,9 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 func (q *qemuAmd64) capabilities() capabilities {
 	var caps capabilities
 
-	if q.machineType == QemuPC || q.machineType == QemuQ35 {
+	if q.machineType == QemuPC ||
+		q.machineType == QemuQ35 ||
+		q.machineType == QemuVirt {
 		caps.setBlockDeviceHotplugSupport()
 	}
 


### PR DESCRIPTION
The virt machine type provided by the NEMU project needs to be
supported the same way we support pc and q35 machine types.

First, this patch takes care of adding the hotpluggable block device
capability to this machine type, this way when using devicemapper, we
prevent the code from falling back on using 9pfs instead of SCSI.

It also add one or several bridges to this machine type, as the code
is tightly coupled to the fact that a bridge is required for PCI
hotplug.

At last, it changes the name of the PCI host bridge (main bus), to
use "pcie.0". The default set up from pc machine type "pci.0" is not
suitable for this machine type.

Fixes #804

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>