### PR TITLE
build: check golang version meets min req.

### DIFF
--- a/.ci/install-yq.sh
+++ b/.ci/install-yq.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# If we fail for any reason a message will be displayed
+die() {
+	msg="$*"
+	echo "ERROR: $msg" >&2
+	exit 1
+}
+
+# Install the yq yaml query package from the mikefarah github repo
+# Install via binary download, as we may not have golang installed at this point
+function install_yq() {
+	GOPATH=${GOPATH:-${HOME}/go}
+	local yq_path="${GOPATH}/bin/yq"
+	local yq_pkg="github.com/mikefarah/yq"
+	[ -x  "${GOPATH}/bin/yq" ] && return
+
+	read -r -a sysInfo <<< "$(uname -sm)"
+
+	case "${sysInfo[0]}" in
+	"Linux" | "Darwin")
+		goos="${sysInfo[0],}"
+		;;
+	"*")
+		die "OS ${sysInfo[0]} not supported"
+		;;
+	esac
+
+	case "${sysInfo[1]}" in
+	"aarch64")
+		goarch=arm64
+		;;
+	"ppc64le")
+		goarch=ppc64le
+		;;
+	"x86_64")
+		goarch=amd64
+		;;
+	"s390x")
+		goarch=s390x
+		;;
+	"*")
+		die "Arch ${sysInfo[1]} not supported"
+		;;
+	esac
+
+	mkdir -p "${GOPATH}/bin"
+
+	# Workaround to get latest release from github (to not use github token).
+	# Get the redirection to latest release on github.
+	yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
+	# The redirected url should include the latest release version
+	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
+	yq_version=$(basename "${yq_latest_url}")
+
+	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
+	curl -o "${yq_path}" -L ${yq_url}
+	chmod +x ${yq_path}
+
+	if ! command -v "${yq_path}" >/dev/null; then
+		die "Cannot not get ${yq_path} executable"
+	fi
+}
+
+install_yq

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,15 @@ go:
 env:
   - target_branch=$TRAVIS_BRANCH
 
+before_install:
+  - sudo apt update -y -qq
+  - sudo apt install -y -qq curl	# for yq installer
+
 before_script:
   - ".ci/static-checks.sh"
 
 install:
   - cd ${TRAVIS_BUILD_DIR}
+  - ".ci/install-yq.sh"
   - make
   - sudo -E PATH=$PATH make install

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ done)
 GOARCH=$(shell go env GOARCH)
 HOST_ARCH=$(shell arch)
 
+include golang.mk
+
 ifeq ($(ARCH),)
 	ARCH = $(GOARCH)
 endif

--- a/golang.mk
+++ b/golang.mk
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Check that the system golang version is within the required version range
+# for this project.
+
+golang_version_min=$(shell yq r versions.yaml languages.golang.version)
+
+ifeq (,$(golang_version_min))
+    $(error "ERROR: cannot determine minimum golang version")
+endif
+
+golang_version_min_fields=$(subst ., ,$(golang_version_min))
+
+golang_version_min_major=$(word 1,$(golang_version_min_fields))
+golang_version_min_minor=$(word 2,$(golang_version_min_fields))
+
+# for error messages
+golang_version_needed=$(golang_version_min_major).$(golang_version_min_minor)
+
+golang_version_raw=$(shell go version 2>/dev/null)
+
+ifeq (,$(golang_version_raw))
+    $(error "ERROR: cannot determine golang version")
+endif
+
+# determine actual version of golang
+golang_version=$(subst go,,$(word 3,$(golang_version_raw)))
+
+golang_version_fields=$(subst ., ,$(golang_version))
+
+golang_version_major=$(word 1,$(golang_version_fields))
+golang_version_minor=$(word 2,$(golang_version_fields))
+
+golang_major_ok=$(shell test $(golang_version_major) -ge $(golang_version_min_major) && echo ok)
+golang_minor_ok=$(shell test $(golang_version_major) -eq $(golang_version_min_major) -a $(golang_version_minor) -ge $(golang_version_min_minor) && echo ok)
+
+ifeq (,$(golang_major_ok))
+    $(error "ERROR: golang major version too old: got $(golang_version), need atleast $(golang_version_needed)")
+endif
+
+ifeq (,$(golang_minor_ok))
+    $(error "ERROR: golang minor version too old: got $(golang_version), need atleast $(golang_version_needed)")
+endif

--- a/versions.yaml
+++ b/versions.yaml
@@ -189,7 +189,10 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     version: "1.10.4"
     meta:
-      newest-version: "1.11"
+      description: |
+        'newest-version' is the latest version known to work when
+        building Kata
+      newest-version: "1.11.1"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
Check that the system golang version is new enough to build with
according to the data from the `versions.yaml` file.

Update the verions in the versions.yaml accordingly, and add a note
describing what the 'newest-version' item represents.
Note, we only do a minimum requirement check, and are not checking
against the 'newest-version' info from the yaml.

Fixes: #148

Inspired-by: Wei Zhang <zhangwei555@huawei.com>
Idea-by: James O. D. Hunt <james.o.hunt@intel.com>
Signed-off-by: Graham Whaley <graham.whaley@intel.com>