### PR TITLE
network: Sort endpoints by name

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -1386,6 +1387,12 @@ func createEndpointsFromScan(networkNSPath string, config NetworkConfig) ([]Endp
 
 		idx++
 	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		return endpoints[i].Name() < endpoints[j].Name()
+	})
+
+	networkLogger().WithField("endpoints", endpoints).Info("Endpoints found after scan")
 
 	return endpoints, nil
 }


### PR DESCRIPTION
Sort endpoints by name to control the order in which
they are passed to the VM as the interface name inside
the VM depends on the order in which it is passed.

Long term we should come up with a more robust approach.

Fixes #785

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit 8f1b28da34e5091d5383448ac163de148d1b96d4)