### PR TITLE
kata-check: do not require nested vt

### DIFF
--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -291,7 +291,10 @@ var kataCheckCLICommand = cli.Command{
 		span, _ := trace(ctx, "kata-check")
 		defer span.Finish()
 
-		setCPUtype()
+		err = setCPUtype()
+		if err != nil {
+			return err
+		}
 
 		details := vmContainerCapableDetails{
 			cpuInfoFile:           procCPUInfo,

--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -60,7 +60,7 @@ const (
 var (
 	procCPUInfo  = "/proc/cpuinfo"
 	sysModuleDir = "/sys/module"
-	modInfoCmd   = "modinfo"
+	modProbeCmd  = "modprobe"
 )
 
 // variables rather than consts to allow tests to modify them
@@ -120,8 +120,9 @@ func haveKernelModule(module string) bool {
 		return true
 	}
 
-	// Now, check if the module is unloaded, but available
-	cmd := exec.Command(modInfoCmd, module)
+	// Now, check if the module is unloaded, but available.
+	// And modprobe it if so.
+	cmd := exec.Command(modProbeCmd, module)
 	err := cmd.Run()
 	return err == nil
 }

--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -67,7 +67,6 @@ func setCPUtype() {
 			"kvm_intel": {
 				desc: "Intel KVM",
 				parameters: map[string]string{
-					"nested": "Y",
 					// "VMX Unrestricted mode support". This is used
 					// as a heuristic to determine if the system is
 					// "new enough" to run a Kata Container
@@ -97,9 +96,6 @@ func setCPUtype() {
 			},
 			"kvm_amd": {
 				desc: "AMD KVM",
-				parameters: map[string]string{
-					"nested": "1",
-				},
 			},
 			"vhost": {
 				desc: msgKernelVirtio,

--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -6,9 +6,12 @@
 package main
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"strings"
+
+	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
 const (
@@ -45,13 +48,23 @@ var archRequiredCPUAttribs map[string]string
 // required module parameters.
 var archRequiredKernelModules map[string]kernelModule
 
-func setCPUtype() {
+func setCPUtype() error {
 	cpuType = getCPUtype()
 
 	if cpuType == cpuTypeUnknown {
-		kataLog.Fatal("Unknown CPU Type")
-		exit(1)
+		return fmt.Errorf("Unknow CPU Type")
 	} else if cpuType == cpuTypeIntel {
+		var kvmIntelParams map[string]string
+		onVMM, err := vc.RunningOnVMM(procCPUInfo)
+		if err != nil && !onVMM {
+			kvmIntelParams = map[string]string{
+				// "VMX Unrestricted mode support". This is used
+				// as a heuristic to determine if the system is
+				// "new enough" to run a Kata Container
+				// (atleast a Westmere).
+				"unrestricted_guest": "Y",
+			}
+		}
 		archRequiredCPUFlags = map[string]string{
 			"vmx":    "Virtualization support",
 			"lm":     "64Bit CPU",
@@ -65,14 +78,8 @@ func setCPUtype() {
 				desc: msgKernelVM,
 			},
 			"kvm_intel": {
-				desc: "Intel KVM",
-				parameters: map[string]string{
-					// "VMX Unrestricted mode support". This is used
-					// as a heuristic to determine if the system is
-					// "new enough" to run a Kata Container
-					// (atleast a Westmere).
-					"unrestricted_guest": "Y",
-				},
+				desc:       "Intel KVM",
+				parameters: kvmIntelParams,
 			},
 			"vhost": {
 				desc: msgKernelVirtio,
@@ -105,6 +112,8 @@ func setCPUtype() {
 			},
 		}
 	}
+
+	return nil
 }
 
 func getCPUtype() int {

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -81,9 +81,7 @@ func TestCCCheckCLIFunction(t *testing.T) {
 			{archGenuineIntel, "lm vmx sse4_1", false},
 		}
 
-		moduleData = []testModuleData{
-			{filepath.Join(sysModuleDir, "kvm_intel/parameters/unrestricted_guest"), false, "Y"},
-		}
+		moduleData = []testModuleData{}
 	} else if cpuType == cpuTypeAMD {
 		cpuData = []testCPUData{
 			{archAuthenticAMD, "lm svm sse4_1", false},
@@ -393,7 +391,7 @@ func TestCheckHostIsVMContainerCapable(t *testing.T) {
 	}
 
 	err = hostIsVMContainerCapable(details)
-	assert.Error(err)
+	assert.Nil(err)
 }
 
 func TestArchKernelParamHandler(t *testing.T) {

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -83,16 +83,13 @@ func TestCCCheckCLIFunction(t *testing.T) {
 
 		moduleData = []testModuleData{
 			{filepath.Join(sysModuleDir, "kvm_intel/parameters/unrestricted_guest"), false, "Y"},
-			{filepath.Join(sysModuleDir, "kvm_intel/parameters/nested"), false, "Y"},
 		}
 	} else if cpuType == cpuTypeAMD {
 		cpuData = []testCPUData{
 			{archAuthenticAMD, "lm svm sse4_1", false},
 		}
 
-		moduleData = []testModuleData{
-			{filepath.Join(sysModuleDir, "kvm_amd/parameters/nested"), false, "1"},
-		}
+		moduleData = []testModuleData{}
 	}
 
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0666)

--- a/cli/kata-check_arm64.go
+++ b/cli/kata-check_arm64.go
@@ -40,7 +40,8 @@ var archRequiredKernelModules = map[string]kernelModule{
 	},
 }
 
-func setCPUtype() {
+func setCPUtype() error {
+	return nil
 }
 
 // kvmIsUsable determines if it will be possible to create a full virtual machine

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -44,7 +44,8 @@ var archRequiredKernelModules = map[string]kernelModule{
 	},
 }
 
-func setCPUtype() {
+func setCPUtype() error {
+	return nil
 }
 
 func archHostCanCreateVMContainer() error {

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -448,15 +448,15 @@ func TestCheckHaveKernelModule(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	savedModInfoCmd := modInfoCmd
+	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
 
 	// XXX: override (fake the modprobe command failing)
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 	sysModuleDir = filepath.Join(dir, "sys/module")
 
 	defer func() {
-		modInfoCmd = savedModInfoCmd
+		modProbeCmd = savedModProbeCmd
 		sysModuleDir = savedSysModuleDir
 	}()
 
@@ -471,13 +471,13 @@ func TestCheckHaveKernelModule(t *testing.T) {
 	assert.False(result)
 
 	// XXX: override - make our fake "modprobe" succeed
-	modInfoCmd = "true"
+	modProbeCmd = "true"
 
 	result = haveKernelModule(module)
 	assert.True(result)
 
 	// disable "modprobe" again
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 
 	fooDir := filepath.Join(sysModuleDir, module)
 	err = os.MkdirAll(fooDir, testDirMode)
@@ -498,15 +498,15 @@ func TestCheckCheckKernelModules(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	savedModInfoCmd := modInfoCmd
+	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
 
 	// XXX: override (fake the modprobe command failing)
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 	sysModuleDir = filepath.Join(dir, "sys/module")
 
 	defer func() {
-		modInfoCmd = savedModInfoCmd
+		modProbeCmd = savedModProbeCmd
 		sysModuleDir = savedSysModuleDir
 	}()
 
@@ -590,15 +590,15 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 		},
 	}
 
-	savedModInfoCmd := modInfoCmd
+	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
 
 	// XXX: override (fake the modprobe command failing)
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 	sysModuleDir = filepath.Join(dir, "sys/module")
 
 	defer func() {
-		modInfoCmd = savedModInfoCmd
+		modProbeCmd = savedModProbeCmd
 		sysModuleDir = savedSysModuleDir
 	}()
 
@@ -637,15 +637,15 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 		},
 	}
 
-	savedModInfoCmd := modInfoCmd
+	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
 
 	// XXX: override (fake the modprobe command failing)
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 	sysModuleDir = filepath.Join(dir, "sys/module")
 
 	defer func() {
-		modInfoCmd = savedModInfoCmd
+		modProbeCmd = savedModProbeCmd
 		sysModuleDir = savedSysModuleDir
 	}()
 
@@ -700,15 +700,15 @@ func TestCheckKernelParamHandler(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	savedModInfoCmd := modInfoCmd
+	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
 
 	// XXX: override (fake the modprobe command failing)
-	modInfoCmd = "false"
+	modProbeCmd = "false"
 	sysModuleDir = filepath.Join(dir, "sys/module")
 
 	defer func() {
-		modInfoCmd = savedModInfoCmd
+		modProbeCmd = savedModProbeCmd
 		sysModuleDir = savedSysModuleDir
 	}()
 

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -325,7 +325,10 @@ func getHypervisorInfo(config oci.RuntimeConfig) HypervisorInfo {
 }
 
 func getEnvInfo(configFile string, config oci.RuntimeConfig) (env EnvInfo, err error) {
-	setCPUtype()
+	err = setCPUtype()
+	if err != nil {
+		return EnvInfo{}, err
+	}
 
 	meta := getMetaInfo()
 


### PR DESCRIPTION
We do not really require nested VT to run kata containers. Let's not
depend on it being there.

Let's see if it fixes the recent nested vt related CI issues.