### PR TITLE
network: Use tc filtering rules in bridge mode

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -234,6 +234,10 @@ path = "@NETMONPATH@"
 #   - none
 #     Used when customize network. Only creates a tap device. No veth pair.
 #
+#   - tcfilter
+#     Uses tc filter rules to redirect traffic from the network interface
+#     provided by plugin to a tap interface connected to the VM.
+#
 internetworking_model="@DEFNETWORKMODEL@"
 
 # If enabled, the runtime will create opentracing.io traces and spans.

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -68,22 +68,36 @@ func (n NetInterworkingModel) IsValid() bool {
 	return 0 <= int(n) && int(n) < int(NetXConnectInvalidModel)
 }
 
+const (
+	defaultNetModelStr = "default"
+
+	bridgedNetModelStr = "bridged"
+
+	macvtapNetModelStr = "macvtap"
+
+	enlightenedNetModelStr = "enlightened"
+
+	tcFilterNetModelStr = "tcfilter"
+
+	noneNetModelStr = "none"
+)
+
 //SetModel change the model string value
 func (n *NetInterworkingModel) SetModel(modelName string) error {
 	switch modelName {
-	case "default":
+	case defaultNetModelStr:
 		*n = DefaultNetInterworkingModel
 		return nil
-	case "bridged":
+	case bridgedNetModelStr:
 		*n = NetXConnectBridgedModel
 		return nil
-	case "macvtap":
+	case macvtapNetModelStr:
 		*n = NetXConnectMacVtapModel
 		return nil
-	case "enlightened":
+	case enlightenedNetModelStr:
 		*n = NetXConnectEnlightenedModel
 		return nil
-	case "tcfilter":
+	case tcFilterNetModelStr:
 		*n = NetXConnectTCFilterModel
 		return nil
 	case "none":

--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -213,12 +213,12 @@ func TestNetInterworkingModelSetModel(t *testing.T) {
 		wantErr   bool
 	}{
 		{"Invalid Model", "Invalid", true},
-		{"default Model", "default", false},
-		{"bridged Model", "bridged", false},
-		{"macvtap Model", "macvtap", false},
-		{"enlightened Model", "enlightened", false},
-		{"tcfilter Model", "tcfilter", false},
-		{"none Model", "none", false},
+		{"default Model", defaultNetModelStr, false},
+		{"bridged Model", bridgedNetModelStr, false},
+		{"macvtap Model", macvtapNetModelStr, false},
+		{"enlightened Model", enlightenedNetModelStr, false},
+		{"tcfilter Model", tcFilterNetModelStr, false},
+		{"none Model", noneNetModelStr, false},
 	}
 
 	for _, tt := range tests {

--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -192,6 +192,7 @@ func TestNetInterworkingModelIsValid(t *testing.T) {
 		{"Invalid Model", NetXConnectInvalidModel, false},
 		{"Default Model", NetXConnectDefaultModel, true},
 		{"Bridged Model", NetXConnectBridgedModel, true},
+		{"TC Filter Model", NetXConnectTCFilterModel, true},
 		{"Macvtap Model", NetXConnectMacVtapModel, true},
 		{"Enlightened Model", NetXConnectEnlightenedModel, true},
 	}
@@ -216,6 +217,7 @@ func TestNetInterworkingModelSetModel(t *testing.T) {
 		{"bridged Model", "bridged", false},
 		{"macvtap Model", "macvtap", false},
 		{"enlightened Model", "enlightened", false},
+		{"tcfilter Model", "tcfilter", false},
 		{"none Model", "none", false},
 	}
 


### PR DESCRIPTION
Instead of creating a bridge, use tc filter rules to redirect
traffic between veth and tap interface.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>