### PR TITLE
cli: add guest hook path option (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ const defaultDisableNestingChecks bool = $(DEFDISABLENESTINGCHECKS)
 const defaultMsize9p uint32 = $(DEFMSIZE9P)
 const defaultHotplugVFIOOnRootBus bool = $(DEFHOTPLUGVFIOONROOTBUS)
 const defaultEntropySource = "$(DEFENTROPYSOURCE)"
+const defaultGuestHookPath string = ""
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "$(CONFIG_PATH)"

--- a/cli/config.go
+++ b/cli/config.go
@@ -98,6 +98,7 @@ type hypervisor struct {
 	UseVSock              bool   `toml:"use_vsock"`
 	HotplugVFIOOnRootBus  bool   `toml:"hotplug_vfio_on_root_bus"`
 	DisableVhostNet       bool   `toml:"disable_vhost_net"`
+	GuestHookPath         string `toml:"guest_hook_path"`
 }
 
 type proxy struct {
@@ -303,6 +304,13 @@ func (h hypervisor) useVSock() bool {
 	return h.UseVSock
 }
 
+func (h hypervisor) guestHookPath() string {
+	if h.GuestHookPath == "" {
+		return defaultGuestHookPath
+	}
+	return h.GuestHookPath
+}
+
 func (p proxy) path() string {
 	if p.Path == "" {
 		return defaultProxyPath
@@ -427,6 +435,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		UseVSock:              useVSock,
 		HotplugVFIOOnRootBus:  h.HotplugVFIOOnRootBus,
 		DisableVhostNet:       h.DisableVhostNet,
+		GuestHookPath:         h.guestHookPath(),
 	}, nil
 }
 
@@ -548,6 +557,7 @@ func loadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 		EnableIOThreads:       defaultEnableIOThreads,
 		Msize9p:               defaultMsize9p,
 		HotplugVFIOOnRootBus:  defaultHotplugVFIOOnRootBus,
+		GuestHookPath:         defaultGuestHookPath,
 	}
 
 	err = config.InterNetworkModel.SetModel(defaultInterNetworkingModel)

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -167,6 +167,23 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # all practical purposes.
 #entropy_source= "@DEFENTROPYSOURCE@"
 
+# Path to OCI hook binaries in the *guest rootfs*.
+# This does not affect host-side hooks which must instead be added to
+# the OCI spec passed to the runtime.
+#
+# You can create a rootfs with hooks by customizing the osbuilder scripts:
+# https://github.com/kata-containers/osbuilder
+#
+# Hooks must be stored in a subdirectory of guest_hook_path according to their
+# hook type, i.e. "guest_hook_path/{prestart,postart,poststop}".
+# The agent will scan these directories for executable files and add them, in
+# lexicographical order, to the lifecycle of the guest container.
+# Hooks are executed in the runtime namespace of the guest. See the official documentation:
+# https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks
+# Warnings will be logged if any error is encountered will scanning for hooks,
+# but it will not abort container execution.
+#guest_hook_path = "/usr/share/oci/hooks"
+
 [factory]
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -61,6 +61,7 @@ func makeRuntimeConfigFileData(hypervisor, hypervisorPath, kernelPath, imagePath
 	hotplug_vfio_on_root_bus =  ` + strconv.FormatBool(hotplugVFIOOnRootBus) + `
 	msize_9p = ` + strconv.FormatUint(uint64(defaultMsize9p), 10) + `
 	enable_debug = ` + strconv.FormatBool(hypervisorDebug) + `
+	guest_hook_path = "` + defaultGuestHookPath + `"
 
 	[proxy.kata]
 	enable_debug = ` + strconv.FormatBool(proxyDebug) + `
@@ -163,6 +164,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		Msize9p:               defaultMsize9p,
 		MemSlots:              defaultMemSlots,
 		EntropySource:         defaultEntropySource,
+		GuestHookPath:         defaultGuestHookPath,
 	}
 
 	agentConfig := vc.KataAgentConfig{}
@@ -599,6 +601,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		Mlock:                 !defaultEnableSwap,
 		BlockDeviceDriver:     defaultBlockDeviceDriver,
 		Msize9p:               defaultMsize9p,
+		GuestHookPath:         defaultGuestHookPath,
 	}
 
 	expectedAgentConfig := vc.KataAgentConfig{}
@@ -1079,6 +1082,21 @@ func TestHypervisorDefaultsImage(t *testing.T) {
 	p, err = h.image()
 	assert.NoError(err)
 	assert.Equal(p, "")
+}
+
+func TestHypervisorDefaultsGuestHookPath(t *testing.T) {
+	assert := assert.New(t)
+
+	h := hypervisor{}
+	guestHookPath := h.guestHookPath()
+	assert.Equal(guestHookPath, defaultGuestHookPath, "default guest hook path wrong")
+
+	testGuestHookPath := "/test/guest/hook/path"
+	h = hypervisor{
+		GuestHookPath: testGuestHookPath,
+	}
+	guestHookPath = h.guestHookPath()
+	assert.Equal(guestHookPath, testGuestHookPath, "custom guest hook path wrong")
 }
 
 func TestProxyDefaults(t *testing.T) {

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -250,6 +250,9 @@ type HypervisorConfig struct {
 
 	// DisableVhostNet is used to indicate if host supports vhost_net
 	DisableVhostNet bool
+
+	// GuestHookPath is the path within the VM that will be used for 'drop-in' hooks
+	GuestHookPath string
 }
 
 type threadIDs struct {

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -632,10 +632,11 @@ func (k *kataAgent) startSandbox(sandbox *Sandbox) error {
 	}
 
 	req := &grpc.CreateSandboxRequest{
-		Hostname:     hostname,
-		Storages:     storages,
-		SandboxPidns: sandbox.sharePidNs,
-		SandboxId:    sandbox.id,
+		Hostname:      hostname,
+		Storages:      storages,
+		SandboxPidns:  sandbox.sharePidNs,
+		SandboxId:     sandbox.id,
+		GuestHookPath: sandbox.config.HypervisorConfig.GuestHookPath,
 	}
 
 	_, err = k.sendReq(req)


### PR DESCRIPTION
Replaces #720 

- Rebased on current master
- Re-vendoring of `kata-containers/agent`, in a separate commit.
- Better documentation of the location of guest hooks per https://github.com/kata-containers/agent/pull/365#discussion_r217945769