### PR TITLE
create/run: Make bundle path default to cwd

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -91,6 +91,17 @@ func create(containerID, bundlePath, console, pidFilePath string, detach bool,
 	kataLog = kataLog.WithField("container", containerID)
 	setExternalLoggers(kataLog)
 
+	if bundlePath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		kataLog.WithField("directory", cwd).Debug("Defaulting bundle path to current directory")
+
+		bundlePath = cwd
+	}
+
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	if bundlePath, err = validCreateParams(containerID, bundlePath); err != nil {
 		return err

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -563,6 +564,13 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	// Rewrite the file
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
+
+	err = create(testContainerID, "", testConsole, pidFilePath, false, runtimeConfig)
+	assert.Error(err, "bundle path not set")
+
+	re := regexp.MustCompile("config.json.*no such file or directory")
+	matches := re.FindAllStringSubmatch(err.Error(), -1)
+	assert.NotEmpty(matches)
 
 	for _, detach := range []bool{true, false} {
 		err := create(testContainerID, bundlePath, testConsole, pidFilePath, detach, runtimeConfig)

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
@@ -284,13 +285,44 @@ func TestRunContainerSuccessful(t *testing.T) {
 		testingImpl.DeleteContainerFunc = nil
 	}()
 
-	err = run(d.sandbox.ID(), d.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+	type errorTestArgs struct {
+		bundlePath string
 
-	// should return ExitError with the message and exit code
-	e, ok := err.(*cli.ExitError)
-	assert.True(ok, "error should be a cli.ExitError: %s", err)
-	assert.Empty(e.Error())
-	assert.NotZero(e.ExitCode())
+		// regex string for text of error message
+		errorRE string
+
+		// If true, expect a cli.ExitError, else expect any other type
+		// of error.
+		expectExitError bool
+	}
+
+	args := []errorTestArgs{
+		{"", "config.json: no such file or directory", false},
+		{d.bundlePath, "", true},
+	}
+
+	for i, a := range args {
+		err = run(d.sandbox.ID(), a.bundlePath, d.consolePath, "", d.pidFilePath, false, d.runtimeConfig)
+		assert.Errorf(err, "test args %d (%+v)", i, a)
+
+		if a.errorRE == "" {
+			assert.Empty(err.Error())
+		} else {
+			re := regexp.MustCompile(a.errorRE)
+			matches := re.FindAllStringSubmatch(err.Error(), -1)
+			assert.NotEmpty(matches)
+		}
+
+		e, ok := err.(*cli.ExitError)
+
+		if a.expectExitError {
+			// should return ExitError with the message and exit code
+			assert.Truef(ok, "test args %d (%+v): error should be a cli.ExitError: %s", i, a, err)
+			assert.NotZero(e.ExitCode())
+		} else {
+			assert.Falsef(ok, "test args %d (%+v): error should not be a cli.ExitError: %s", i, a, err)
+		}
+	}
 }
 
 func TestRunContainerDetachSuccessful(t *testing.T) {


### PR DESCRIPTION
The bundle path was documented as defaulting to the current directory
but was not being set to that value if not explicitly specified.

Fixes #821.

(cherry picked from commit 8831245e30bc6d0e3c2e88f465016b4a05e7bf9a)

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>