### PR TITLE
create/run: Make bundle path default to cwd

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -560,6 +561,13 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	// Rewrite the file
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
+
+	err = create(context.Background(), testContainerID, "", testConsole, pidFilePath, false, true, runtimeConfig)
+	assert.Error(err, "bundle path not set")
+
+	re := regexp.MustCompile("config.json.*no such file or directory")
+	matches := re.FindAllStringSubmatch(err.Error(), -1)
+	assert.NotEmpty(matches)
 
 	for _, detach := range []bool{true, false} {
 		err := create(context.Background(), testContainerID, bundlePath, testConsole, pidFilePath, detach, true, runtimeConfig)

--- a/virtcontainers/monitor.go
+++ b/virtcontainers/monitor.go
@@ -18,9 +18,9 @@ type monitor struct {
 	sandbox       *Sandbox
 	checkInterval time.Duration
 	watchers      []chan error
+	wg            sync.WaitGroup
 	running       bool
 	stopCh        chan bool
-	wg            sync.WaitGroup
 }
 
 func newMonitor(s *Sandbox) *monitor {

--- a/virtcontainers/pkg/mock/cc_proxy_mock.go
+++ b/virtcontainers/pkg/mock/cc_proxy_mock.go
@@ -25,7 +25,6 @@ type CCProxyMock struct {
 	sync.Mutex
 
 	t              *testing.T
-	wg             sync.WaitGroup
 	connectionPath string
 
 	// proxy socket
@@ -43,6 +42,8 @@ type CCProxyMock struct {
 	Signal           chan ShimSignal
 	ShimDisconnected chan bool
 	StdinReceived    chan bool
+
+	wg sync.WaitGroup
 
 	stopped bool
 }


### PR DESCRIPTION
The bundle path was documented as defaulting to the current directory
but was not being set to that value if not explicitly specified.

Also moved factory creation code to a new `handleFactory()` function to
avoid cyclomatic complexity issues.

Fixes #821.

(cherry picked from commit 8831245e30bc6d0e3c2e88f465016b4a05e7bf9a)

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>