### PR TITLE
vfio: Change the way the driver is fetched

### DIFF
--- a/virtcontainers/physical_endpoint.go
+++ b/virtcontainers/physical_endpoint.go
@@ -8,6 +8,7 @@ package virtcontainers
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -143,11 +144,14 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 		return nil, err
 	}
 
-	// Get Driver
-	driver, err := ethHandle.DriverName(netInfo.Iface.Name)
+	// Get driver by following symlink /sys/bus/pci/devices/$bdf/driver
+	driverPath := filepath.Join(sysPCIDevicesPath, bdf, "driver")
+	link, err := os.Readlink(driverPath)
 	if err != nil {
 		return nil, err
 	}
+
+	driver := filepath.Base(link)
 
 	// Get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
 


### PR DESCRIPTION
Instead of using ethtool for getting the driver for network
devices, use sysfs instead. This is because in case of virtio
devices, ethtool returns virtio-net instead of virtio-pci for
virtio network devices. We need to bind/unbind from virtio-pci
driver in case of virtio-net devices.

Fixes #612

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>