### PR TITLE
versions: Add xurls utility

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -178,6 +178,12 @@ externals:
     url: "https://github.com/opencontainers/runc"
     version: "v1.0.0-rc5"
 
+  xurls:
+    description: |
+      Tool used by the CI to check URLs in documents and code comments.
+    url: "https://mvdan.cc/xurls/cmd/xurls"
+    version: "70405f5eab516c9f7b626d803b043415809499a6"
+
 languages:
   description: |
     Details of programming languages requried to build system


### PR DESCRIPTION
Add the [`xurls`](https://mvdan.cc/xurls/cmd/xurls) utility to the
versions database. This tool is used by the CI scripts in the `tests`
repo to check URLs for validity. However, the latest version of `xurls`
requires golang 1.10.3+, but we don't need to use the latest version and
doing so is causing us problems (see
https://github.com/kata-containers/kata-containers/issues/32).

Fixes #854.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>