### PR TITLE
virtcontainers: Rely on new interface LinkType field

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -17,8 +17,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )

--- a/cli/network_test.go
+++ b/cli/network_test.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/netmon/netmon.go
+++ b/netmon/netmon.go
@@ -21,8 +21,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/runtime/pkg/signals"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/vishvananda/netlink"
@@ -275,7 +275,7 @@ func convertInterface(linkAttrs *netlink.LinkAttrs, addrs []netlink.Addr) types.
 		netMask, _ := addr.Mask.Size()
 
 		ipAddr := &types.IPAddress{
-			Family:  types.IPFamily(netlinkFamily),
+			Family:  netlinkFamily,
 			Address: addr.IP.String(),
 			Mask:    fmt.Sprintf("%d", netMask),
 		}

--- a/netmon/netmon.go
+++ b/netmon/netmon.go
@@ -259,7 +259,7 @@ func (n *netmon) listenNetlinkEvents() error {
 // convertInterface converts a link and its IP addresses as defined by netlink
 // package, into the Interface structure format expected by kata-runtime to
 // describe an interface and its associated IP addresses.
-func convertInterface(linkAttrs *netlink.LinkAttrs, addrs []netlink.Addr) types.Interface {
+func convertInterface(linkAttrs *netlink.LinkAttrs, linkType string, addrs []netlink.Addr) types.Interface {
 	if linkAttrs == nil {
 		netmonLog.Warn("Link attributes are nil")
 		return types.Interface{}
@@ -289,6 +289,7 @@ func convertInterface(linkAttrs *netlink.LinkAttrs, addrs []netlink.Addr) types.
 		IPAddresses: ipAddrs,
 		Mtu:         uint64(linkAttrs.MTU),
 		HwAddr:      linkAttrs.HardwareAddr.String(),
+		LinkType:    linkType,
 	}
 
 	netmonLog.WithField("interface", iface).Debug("Interface converted")
@@ -369,7 +370,7 @@ func (n *netmon) scanNetwork() error {
 			continue
 		}
 
-		iface := convertInterface(linkAttrs, addrs)
+		iface := convertInterface(linkAttrs, link.Type(), addrs)
 		n.netIfaces[linkAttrs.Index] = iface
 	}
 
@@ -497,7 +498,7 @@ func (n *netmon) handleRTMNewLink(ev netlink.LinkUpdate) error {
 	}
 
 	// Convert the interfaces in the appropriate structure format.
-	iface := convertInterface(linkAttrs, addrs)
+	iface := convertInterface(linkAttrs, ev.Link.Type(), addrs)
 
 	// Add the interface through the Kata CLI.
 	if err := n.addInterfaceCLI(iface); err != nil {

--- a/netmon/netmon_test.go
+++ b/netmon/netmon_test.go
@@ -174,6 +174,8 @@ func TestConvertInterface(t *testing.T) {
 		HardwareAddr: hwAddr,
 	}
 
+	linkType := "link_type_test"
+
 	expected := types.Interface{
 		Device: testIfaceName,
 		Name:   testIfaceName,
@@ -186,9 +188,10 @@ func TestConvertInterface(t *testing.T) {
 				Mask:    "0",
 			},
 		},
+		LinkType: linkType,
 	}
 
-	got := convertInterface(linkAttrs, addrs)
+	got := convertInterface(linkAttrs, linkType, addrs)
 	assert.True(t, reflect.DeepEqual(expected, got),
 		"Got %+v\nExpected %+v", got, expected)
 }
@@ -264,10 +267,11 @@ func testCreateDummyNetwork(t *testing.T, handler *netlink.Handle) (int, types.I
 	assert.NotNil(t, attrs)
 
 	iface := types.Interface{
-		Device: testIfaceName,
-		Name:   testIfaceName,
-		Mtu:    uint64(testMTU),
-		HwAddr: testHwAddr,
+		Device:   testIfaceName,
+		Name:     testIfaceName,
+		Mtu:      uint64(testMTU),
+		HwAddr:   testHwAddr,
+		LinkType: link.Type(),
 	}
 
 	return attrs.Index, iface

--- a/netmon/netmon_test.go
+++ b/netmon/netmon_test.go
@@ -16,7 +16,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/kata-containers/agent/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
@@ -181,7 +181,7 @@ func TestConvertInterface(t *testing.T) {
 		HwAddr: testHwAddr,
 		IPAddresses: []*types.IPAddress{
 			{
-				Family:  types.IPFamily(netlinkFamily),
+				Family:  netlinkFamily,
 				Address: testIPAddress,
 				Mask:    "0",
 			},

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/agent/protocols/grpc"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/mitchellh/mapstructure"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -11,9 +11,9 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -18,11 +18,11 @@ import (
 	"github.com/vishvananda/netlink"
 
 	proxyClient "github.com/clearcontainers/proxy/client"
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/agent/protocols/grpc"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/hyperstart"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -13,9 +13,9 @@ import (
 	"context"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/kata-containers/agent/pkg/types"
+	aTypes "github.com/kata-containers/agent/pkg/types"
 	pb "github.com/kata-containers/agent/protocols/grpc"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
@@ -31,6 +31,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 )
 
 var (
@@ -185,16 +186,16 @@ func (p *gRPCProxy) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRe
 	return emptyResp, nil
 }
 
-func (p *gRPCProxy) AddInterface(ctx context.Context, req *pb.AddInterfaceRequest) (*types.Interface, error) {
+func (p *gRPCProxy) AddInterface(ctx context.Context, req *pb.AddInterfaceRequest) (*aTypes.Interface, error) {
 	return nil, nil
 }
 
-func (p *gRPCProxy) RemoveInterface(ctx context.Context, req *pb.RemoveInterfaceRequest) (*types.Interface, error) {
+func (p *gRPCProxy) RemoveInterface(ctx context.Context, req *pb.RemoveInterfaceRequest) (*aTypes.Interface, error) {
 	return nil, nil
 }
 
-func (p *gRPCProxy) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*types.Interface, error) {
-	return &types.Interface{}, nil
+func (p *gRPCProxy) UpdateInterface(ctx context.Context, req *pb.UpdateInterfaceRequest) (*aTypes.Interface, error) {
+	return &aTypes.Interface{}, nil
 }
 
 func (p *gRPCProxy) UpdateRoutes(ctx context.Context, req *pb.UpdateRoutesRequest) (*pb.Routes, error) {

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
-	"github.com/kata-containers/agent/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -1182,7 +1182,7 @@ func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*types.Interface
 			}
 			netMask, _ := addr.Mask.Size()
 			ipAddress := types.IPAddress{
-				Family:  types.IPFamily_v4,
+				Family:  netlink.FAMILY_V4,
 				Address: addr.IP.String(),
 				Mask:    fmt.Sprintf("%d", netMask),
 			}

--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kata-containers/agent/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 )
@@ -162,8 +162,8 @@ func TestGenerateInterfacesAndRoutes(t *testing.T) {
 	// Build expected results:
 	//
 	expectedAddresses := []*types.IPAddress{
-		{Family: 0, Address: "172.17.0.2", Mask: "16"},
-		{Family: 0, Address: "182.17.0.2", Mask: "16"},
+		{Family: netlink.FAMILY_V4, Address: "172.17.0.2", Mask: "16"},
+		{Family: netlink.FAMILY_V4, Address: "182.17.0.2", Mask: "16"},
 	}
 
 	expectedInterfaces := []*types.Interface{

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -8,8 +8,8 @@ package virtcontainers
 import (
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/agent/protocols/grpc"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
 )

--- a/virtcontainers/pkg/types/types.go
+++ b/virtcontainers/pkg/types/types.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+// IPAddress describes an IP address.
+type IPAddress struct {
+	Family  int
+	Address string
+	Mask    string
+}
+
+// Interface describes a network interface.
+type Interface struct {
+	Device      string
+	Name        string
+	IPAddresses []*IPAddress
+	Mtu         uint64
+	HwAddr      string
+	// pciAddr is the PCI address in the format  "bridgeAddr/deviceAddr".
+	// Here, bridgeAddr is the address at which the bridge is attached on the root bus,
+	// while deviceAddr is the address at which the network device is attached on the bridge.
+	PciAddr string
+	// LinkType defines the type of interface described by this structure.
+	// The expected values are the one that are defined by the netlink
+	// library, regarding each type of link. Here is a non exhaustive
+	// list: "veth", "macvtap", "vlan", "macvlan", "tap", ...
+	LinkType string
+}
+
+// Route describes a network route.
+type Route struct {
+	Dest    string
+	Gateway string
+	Device  string
+	Source  string
+	Scope   uint32
+}

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -9,10 +9,10 @@ import (
 	"io"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -9,10 +9,10 @@ import (
 	"context"
 	"syscall"
 
-	"github.com/kata-containers/agent/pkg/types"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -21,12 +21,12 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 
-	"github.com/kata-containers/agent/pkg/types"
 	"github.com/kata-containers/agent/protocols/grpc"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	deviceManager "github.com/kata-containers/runtime/virtcontainers/device/manager"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/vishvananda/netlink"
 )
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1098,13 +1098,6 @@ func (s *Sandbox) generateNetInfo(inf *types.Interface) (NetworkInfo, error) {
 		addrs = append(addrs, *netlinkAddr)
 	}
 
-	var ifaceType string
-	if s.config.NetworkConfig.InterworkingModel == NetXConnectNoneModel {
-		ifaceType = "tap"
-	} else {
-		ifaceType = "veth"
-	}
-
 	return NetworkInfo{
 		Iface: NetlinkIface{
 			LinkAttrs: netlink.LinkAttrs{
@@ -1112,7 +1105,7 @@ func (s *Sandbox) generateNetInfo(inf *types.Interface) (NetworkInfo, error) {
 				HardwareAddr: hw,
 				MTU:          int(inf.Mtu),
 			},
-			Type: ifaceType,
+			Type: inf.LinkType,
 		},
 		Addrs: addrs,
 	}, nil


### PR DESCRIPTION
The logic wants that virtcontainers should be the place where the common packages should be defined. This pull request takes care of defining generic network structures into a new package `pkg/types/types.go`, which is basically a duplication of what is defined by the agent. But this allows virtcontainers and its consumers (kata-runtime, kata-netmon, kata-containerd-shim) to be independent from the agent.

Based on the new package that define a new field `LinkType` for the structure `Interface`, Kata does not need anymore to do any assumption about the type of interface that needs to be added.

Fixes #866
Fixes #876