### PR TITLE
cli: fix the issue of using wrong path to get version

### DIFF
--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -239,7 +239,8 @@ func getProxyInfo(config oci.RuntimeConfig) (ProxyInfo, error) {
 		return ProxyInfo{Type: string(config.ProxyType)}, nil
 	}
 
-	version, err := getCommandVersion(defaultProxyPath)
+	proxyConfig := config.ProxyConfig
+	version, err := getCommandVersion(proxyConfig.Path)
 	if err != nil {
 		version = unknown
 	}
@@ -247,24 +248,26 @@ func getProxyInfo(config oci.RuntimeConfig) (ProxyInfo, error) {
 	proxy := ProxyInfo{
 		Type:    string(config.ProxyType),
 		Version: version,
-		Path:    config.ProxyConfig.Path,
-		Debug:   config.ProxyConfig.Debug,
+		Path:    proxyConfig.Path,
+		Debug:   proxyConfig.Debug,
 	}
 
 	return proxy, nil
 }
 
 func getNetmonInfo(config oci.RuntimeConfig) (NetmonInfo, error) {
-	version, err := getCommandVersion(defaultNetmonPath)
+	netmonConfig := config.NetmonConfig
+
+	version, err := getCommandVersion(netmonConfig.Path)
 	if err != nil {
 		version = unknown
 	}
 
 	netmon := NetmonInfo{
 		Version: version,
-		Path:    config.NetmonConfig.Path,
-		Debug:   config.NetmonConfig.Debug,
-		Enable:  config.NetmonConfig.Enable,
+		Path:    netmonConfig.Path,
+		Debug:   netmonConfig.Debug,
+		Enable:  netmonConfig.Enable,
 	}
 
 	return netmon, nil

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testProxyURL = "file:///proxyURL"
 const testProxyVersion = "proxy version 0.1"
 const testShimVersion = "shim version 0.1"
 const testNetmonVersion = "netmon version 0.1"
@@ -68,10 +67,6 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	enableIOThreads := true
 	hotplugVFIOOnRootBus := true
 	disableNewNetNs := false
-
-	// override
-	defaultProxyPath = proxyPath
-	defaultNetmonPath = netmonPath
 
 	filesToCreate := []string{
 		hypervisorPath,
@@ -115,7 +110,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 		kernelParams,
 		machineType,
 		shimPath,
-		testProxyURL,
+		proxyPath,
 		netmonPath,
 		logPath,
 		disableBlock,
@@ -626,7 +621,7 @@ func TestEnvGetProxyInfoNoVersion(t *testing.T) {
 	assert.NoError(t, err)
 
 	// remove the proxy ensuring its version cannot be queried
-	err = os.Remove(defaultProxyPath)
+	err = os.Remove(config.ProxyConfig.Path)
 	assert.NoError(t, err)
 
 	expectedProxy.Version = unknown
@@ -670,7 +665,7 @@ func TestEnvGetNetmonInfoNoVersion(t *testing.T) {
 	assert.NoError(t, err)
 
 	// remove the netmon ensuring its version cannot be queried
-	err = os.Remove(defaultNetmonPath)
+	err = os.Remove(config.NetmonConfig.Path)
 	assert.NoError(t, err)
 
 	expectedNetmon.Version = unknown


### PR DESCRIPTION
Both of the netmon and proxy should use the right path
figured out from the configure instead of the default settings
to get their versions.

Fixes: #868

Signed-off-by: Fupan Li <lifupan@gmail.com>