### PR TITLE
enable default network endpoints hotplug for vm factory

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1430,9 +1430,9 @@ type network interface {
 	run(networkNSPath string, cb func() error) error
 
 	// add adds all needed interfaces inside the network namespace.
-	add(sandbox *Sandbox) error
+	add(sandbox *Sandbox, hotplug bool) error
 
 	// remove unbridges and deletes TAP interfaces. It also removes virtual network
 	// interfaces and deletes the network namespace.
-	remove(sandbox *Sandbox) error
+	remove(sandbox *Sandbox, hotunplug bool) error
 }

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1194,6 +1194,7 @@ func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*types.Interface
 			Name:        endpoint.Name(),
 			Mtu:         uint64(endpoint.Properties().Iface.MTU),
 			HwAddr:      endpoint.HardwareAddr(),
+			PciAddr:     endpoint.PciAddr(),
 		}
 
 		ifaces = append(ifaces, &ifc)

--- a/virtcontainers/noop_network.go
+++ b/virtcontainers/noop_network.go
@@ -19,13 +19,13 @@ func (n *noopNetwork) run(networkNSPath string, cb func() error) error {
 
 // add adds all needed interfaces inside the network namespace the Noop network.
 // It does nothing.
-func (n *noopNetwork) add(sandbox *Sandbox) error {
+func (n *noopNetwork) add(sandbox *Sandbox, hotattach bool) error {
 	return nil
 }
 
 // remove unbridges and deletes TAP interfaces. It also removes virtual network
 // interfaces and deletes the network namespace for the Noop network.
 // It does nothing.
-func (n *noopNetwork) remove(sandbox *Sandbox) error {
+func (n *noopNetwork) remove(sandbox *Sandbox, hotdetach bool) error {
 	return nil
 }


### PR DESCRIPTION
For non-factory case, default network endpoints are cold plugged. But for vm factory, we need to hotplug them after vm is assigned to the new sandbox.