### PR TITLE
virtcontainers: add support for CPU affinity at pod granularity

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -972,8 +972,8 @@ func (c *Container) update(resources specs.LinuxResources) error {
 		return err
 	}
 
-	if c.state.State != StateRunning {
-		return fmt.Errorf("Container not running, impossible to update")
+	if !(c.state.State == StateRunning || c.state.State == StateReady) {
+		return fmt.Errorf("Container is not running and not created, cannot update")
 	}
 
 	// fetch current configuration


### PR DESCRIPTION
Original logic would not allow a container to be updated if it wasn't
in the running state. A container should be able to be updated if it
is either running or is created and in ready state.

This better matches the logic in CRI-O today, and allows for the use
case where a created container is updated by due to K8S CPU manager
adjusting the CPU affinity of a created but not yet running container.

Fixes #878

Signed-off-by: Eric Ernst <eric.ernst@intel.com>