### PR TITLE
test: add tests for sandbox creation rollback and cleanup

### DIFF
--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 
@@ -275,4 +277,22 @@ func TestHyperCopyFile(t *testing.T) {
 
 	err := h.copyFile("", "")
 	assert.Nil(err)
+}
+
+func TestHyperCleanupSandbox(t *testing.T) {
+	assert := assert.New(t)
+
+	s := Sandbox{
+		id: "testFoo",
+	}
+	dir := path.Join(defaultSharedDir, s.id)
+	err := os.MkdirAll(dir, 0777)
+	assert.Nil(err)
+
+	h := &hyper{}
+	h.cleanup(s.id)
+
+	if _, err = os.Stat(dir); os.IsExist(err) {
+		t.Fatalf("%s still exists\n", dir)
+	}
 }

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -925,4 +926,22 @@ func TestKataCopyFile(t *testing.T) {
 
 	err = k.copyFile(src.Name(), dst.Name())
 	assert.NoError(err)
+}
+
+func TestKataCleanupSandbox(t *testing.T) {
+	assert := assert.New(t)
+
+	s := Sandbox{
+		id: "testFoo",
+	}
+	dir := path.Join(kataHostSharedDir, s.id)
+	err := os.MkdirAll(dir, 0777)
+	assert.Nil(err)
+
+	k := &kataAgent{}
+	k.cleanup(s.id)
+
+	if _, err = os.Stat(dir); os.IsExist(err) {
+		t.Fatalf("%s still exists\n", dir)
+	}
 }


### PR DESCRIPTION
When sandbox creation failed, we should do rollback operations to
cleanup those files and folders. Including:
- share path
- cgroup subsystems
- sandbox local resources

Fixes: #862

Signed-off-by: l00397676 <lujingxiao@huawei.com>