### PR TITLE
network: Use constant string for "none" network model

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -100,7 +100,7 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 	case tcFilterNetModelStr:
 		*n = NetXConnectTCFilterModel
 		return nil
-	case "none":
+	case noneNetModelStr:
 		*n = NetXConnectNoneModel
 		return nil
 	}


### PR DESCRIPTION
Align with other network models.

Fixes #884.

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>