### PR TITLE
Detect unsupported endpoint

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1395,8 +1395,10 @@ func createEndpoint(netInfo NetworkInfo, idx int, model NetInterworkingModel) (E
 		if socketPath != "" {
 			networkLogger().WithField("interface", netInfo.Iface.Name).Info("VhostUser network interface found")
 			endpoint, err = createVhostUserEndpoint(netInfo, socketPath)
-		} else {
+		} else if netInfo.Iface.Type == "veth" {
 			endpoint, err = createVirtualNetworkEndpoint(idx, netInfo.Iface.Name, model)
+		} else {
+			networkLogger().WithField("endpoint-type", netInfo.Iface.Type).Info("Skipping unsupported endpoint")
 		}
 	}
 


### PR DESCRIPTION
 network: Do not fallback to virtual endpoints
    
 Detect veth endpoint explicitly for VirtualEndpoint.
 If unsupported endpoint is found, skip the endpoint.
 While this is not ideal, it will help us to work with
  certain CNI plugins like calico.
    
 Fixes #892
