### PR TITLE
network: Do not fallback to virtual endpoints

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1385,8 +1385,10 @@ func createEndpointsFromScan(networkNSPath string, config NetworkConfig) ([]Endp
 				if socketPath != "" {
 					cnmLogger().WithField("interface", netInfo.Iface.Name).Info("VhostUser network interface found")
 					endpoint, err = createVhostUserEndpoint(netInfo, socketPath)
-				} else {
+				} else if netInfo.Iface.Type == "veth" {
 					endpoint, err = createVirtualNetworkEndpoint(idx, netInfo.Iface.Name, config.InterworkingModel)
+				} else {
+					networkLogger().WithField("endpoint-type", netInfo.Iface.Type).Info("Skipping unsupported endpoint")
 				}
 			}
 


### PR DESCRIPTION
Detect veth endpoint explicitly for VirtualEndpoint.
If unsupported endpoint is found, skip the endpoint.
While this is not ideal, it will help us to work with
certain CNI plugins like calico.

Fixes #892

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>