### PR TITLE
golang.mk: Check and install yq before use it

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -6,7 +6,14 @@
 # Check that the system golang version is within the required version range
 # for this project.
 
-golang_version_min=$(shell yq r versions.yaml languages.golang.version)
+have_yq=$(shell if [ -x "$(GOPATH)/bin/yq" ]; then echo "true"; else echo ""; fi)
+ifeq (,$(have_yq))
+    install_yq=$(shell .ci/install-yq.sh)
+endif
+ifneq (,$(install_yq))
+    $(error "ERROR: install yq failed")
+endif
+golang_version_min=$(shell $(GOPATH)/bin/yq r versions.yaml languages.golang.version)
 
 ifeq (,$(golang_version_min))
     $(error "ERROR: cannot determine minimum golang version")


### PR DESCRIPTION
golang.mk call yq to get golang_version_min but some environments do
not install it.
This patch check and install yq before use it to handle the issue.

Fixes #899

Signed-off-by: Hui Zhu <teawater@hyper.sh>