### PR TITLE
sandbox: Extend sandbox API

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -468,12 +468,7 @@ func StartContainer(ctx context.Context, sandboxID, containerID string) (VCConta
 	}
 	defer s.releaseStatelessSandbox()
 
-	c, err := s.StartContainer(containerID)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
+	return s.StartContainer(containerID)
 }
 
 // StopContainer is the virtcontainers container stopping entry point.

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -784,17 +784,11 @@ func togglePauseContainer(ctx context.Context, sandboxID, containerID string, pa
 	}
 	defer s.releaseStatelessSandbox()
 
-	// Fetch the container.
-	c, err := s.findContainer(containerID)
-	if err != nil {
-		return err
-	}
-
 	if pause {
-		return c.pause()
+		return s.PauseContainer(containerID)
 	}
 
-	return c.resume()
+	return s.ResumeContainer(containerID)
 }
 
 // PauseContainer is the virtcontainers container pause entry point.

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -702,13 +702,7 @@ func ProcessListContainer(ctx context.Context, sandboxID, containerID string, op
 	}
 	defer s.releaseStatelessSandbox()
 
-	// Fetch the container.
-	c, err := s.findContainer(containerID)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.processList(options)
+	return s.ProcessListContainer(containerID, options)
 }
 
 // UpdateContainer is the virtcontainers entry point to update

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -655,19 +655,7 @@ func KillContainer(ctx context.Context, sandboxID, containerID string, signal sy
 	}
 	defer s.releaseStatelessSandbox()
 
-	// Fetch the container.
-	c, err := s.findContainer(containerID)
-	if err != nil {
-		return err
-	}
-
-	// Send a signal to the process.
-	err = c.kill(signal, all)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.KillContainer(containerID, signal, all)
 }
 
 // PauseSandbox is the virtcontainers pausing entry point which pauses an

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -502,19 +502,7 @@ func StopContainer(ctx context.Context, sandboxID, containerID string) (VCContai
 	}
 	defer s.releaseStatelessSandbox()
 
-	// Fetch the container.
-	c, err := s.findContainer(containerID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Stop it.
-	err = c.stop()
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
+	return s.StopContainer(containerID)
 }
 
 // EnterContainer is the virtcontainers container command execution entry point.

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -264,13 +264,8 @@ func StopSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
 	defer s.releaseStatelessSandbox()
 
 	// Stop it.
-	err = s.stop()
+	err = s.Stop()
 	if err != nil {
-		return nil, err
-	}
-
-	// Remove the network.
-	if err := s.removeNetwork(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -232,7 +232,7 @@ func StartSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
 
 func startSandbox(s *Sandbox) (*Sandbox, error) {
 	// Start it
-	err := s.start()
+	err := s.Start()
 	if err != nil {
 		return nil, err
 	}

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -81,6 +81,8 @@ type VCSandbox interface {
 	KillContainer(containerID string, signal syscall.Signal, all bool) error
 	StatusContainer(containerID string) (ContainerStatus, error)
 	StatsContainer(containerID string) (ContainerStats, error)
+	PauseContainer(containerID string) error
+	ResumeContainer(containerID string) error
 	EnterContainer(containerID string, cmd Cmd) (VCContainer, *Process, error)
 	UpdateContainer(containerID string, resources specs.LinuxResources) error
 	ProcessListContainer(containerID string, options ProcessListOptions) (ProcessList, error)

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -67,6 +67,7 @@ type VCSandbox interface {
 	SetAnnotations(annotations map[string]string) error
 
 	Start() error
+	Stop() error
 	Pause() error
 	Resume() error
 	Release() error

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -66,6 +66,7 @@ type VCSandbox interface {
 	ID() string
 	SetAnnotations(annotations map[string]string) error
 
+	Start() error
 	Pause() error
 	Resume() error
 	Release() error

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -77,6 +77,7 @@ type VCSandbox interface {
 	CreateContainer(contConfig ContainerConfig) (VCContainer, error)
 	DeleteContainer(contID string) (VCContainer, error)
 	StartContainer(containerID string) (VCContainer, error)
+	StopContainer(containerID string) (VCContainer, error)
 	StatusContainer(containerID string) (ContainerStatus, error)
 	StatsContainer(containerID string) (ContainerStats, error)
 	EnterContainer(containerID string, cmd Cmd) (VCContainer, *Process, error)

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -78,6 +78,7 @@ type VCSandbox interface {
 	DeleteContainer(contID string) (VCContainer, error)
 	StartContainer(containerID string) (VCContainer, error)
 	StopContainer(containerID string) (VCContainer, error)
+	KillContainer(containerID string, signal syscall.Signal, all bool) error
 	StatusContainer(containerID string) (ContainerStatus, error)
 	StatsContainer(containerID string) (ContainerStats, error)
 	EnterContainer(containerID string, cmd Cmd) (VCContainer, *Process, error)

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -83,6 +83,7 @@ type VCSandbox interface {
 	StatsContainer(containerID string) (ContainerStats, error)
 	EnterContainer(containerID string, cmd Cmd) (VCContainer, *Process, error)
 	UpdateContainer(containerID string, resources specs.LinuxResources) error
+	ProcessListContainer(containerID string, options ProcessListOptions) (ProcessList, error)
 	WaitProcess(containerID, processID string) (int32, error)
 	SignalProcess(containerID, processID string, signal syscall.Signal, all bool) error
 	WinsizeProcess(containerID, processID string, height, width uint32) error

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -72,6 +72,11 @@ func (s *Sandbox) Start() error {
 	return nil
 }
 
+// Stop implements the VCSandbox function of the same name.
+func (s *Sandbox) Stop() error {
+	return nil
+}
+
 // Pause implements the VCSandbox function of the same name.
 func (s *Sandbox) Pause() error {
 	return nil

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -127,6 +127,16 @@ func (s *Sandbox) StatsContainer(contID string) (vc.ContainerStats, error) {
 	return vc.ContainerStats{}, nil
 }
 
+// PauseContainer implements the VCSandbox function of the same name.
+func (s *Sandbox) PauseContainer(contID string) error {
+	return nil
+}
+
+// ResumeContainer implements the VCSandbox function of the same name.
+func (s *Sandbox) ResumeContainer(contID string) error {
+	return nil
+}
+
 // Status implements the VCSandbox function of the same name.
 func (s *Sandbox) Status() vc.SandboxStatus {
 	return vc.SandboxStatus{}

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -112,6 +112,11 @@ func (s *Sandbox) StopContainer(contID string) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 
+// KillContainer implements the VCSandbox function of the same name.
+func (s *Sandbox) KillContainer(contID string, signal syscall.Signal, all bool) error {
+	return nil
+}
+
 // StatusContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
 	return vc.ContainerStatus{}, nil

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -67,6 +67,11 @@ func (s *Sandbox) Release() error {
 	return nil
 }
 
+// Start implements the VCSandbox function of the same name.
+func (s *Sandbox) Start() error {
+	return nil
+}
+
 // Pause implements the VCSandbox function of the same name.
 func (s *Sandbox) Pause() error {
 	return nil

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -147,6 +147,11 @@ func (s *Sandbox) UpdateContainer(containerID string, resources specs.LinuxResou
 	return nil
 }
 
+// ProcessListContainer implements the VCSandbox function of the same name.
+func (s *Sandbox) ProcessListContainer(containerID string, options vc.ProcessListOptions) (vc.ProcessList, error) {
+	return nil, nil
+}
+
 // WaitProcess implements the VCSandbox function of the same name.
 func (s *Sandbox) WaitProcess(containerID, processID string) (int32, error) {
 	return 0, nil

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -107,6 +107,11 @@ func (s *Sandbox) StartContainer(contID string) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 
+// StopContainer implements the VCSandbox function of the same name.
+func (s *Sandbox) StopContainer(contID string) (vc.VCContainer, error) {
+	return &Container{}, nil
+}
+
 // StatusContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
 	return vc.ContainerStatus{}, nil

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1320,6 +1320,22 @@ func (s *Sandbox) StartContainer(containerID string) (VCContainer, error) {
 	return c, nil
 }
 
+// StopContainer stops a container in the sandbox
+func (s *Sandbox) StopContainer(containerID string) (VCContainer, error) {
+	// Fetch the container.
+	c, err := s.findContainer(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stop it.
+	if err := c.stop(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
 // DeleteContainer deletes a container from the sandbox
 func (s *Sandbox) DeleteContainer(containerID string) (VCContainer, error) {
 	if containerID == "" {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1463,6 +1463,30 @@ func (s *Sandbox) StatsContainer(containerID string) (ContainerStats, error) {
 	return *stats, nil
 }
 
+// PauseContainer pauses a running container.
+func (s *Sandbox) PauseContainer(containerID string) error {
+	// Fetch the container.
+	c, err := s.findContainer(containerID)
+	if err != nil {
+		return err
+	}
+
+	// Pause the container.
+	return c.pause()
+}
+
+// ResumeContainer resumes a paused container.
+func (s *Sandbox) ResumeContainer(containerID string) error {
+	// Fetch the container.
+	c, err := s.findContainer(containerID)
+	if err != nil {
+		return err
+	}
+
+	// Resume the container.
+	return c.resume()
+}
+
 // createContainers registers all containers to the proxy, create the
 // containers in the guest and starts one shim per container.
 func (s *Sandbox) createContainers() error {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1442,9 +1442,9 @@ func (s *Sandbox) createContainers() error {
 	return nil
 }
 
-// start starts a sandbox. The containers that are making the sandbox
+// Start starts a sandbox. The containers that are making the sandbox
 // will be started.
-func (s *Sandbox) start() error {
+func (s *Sandbox) Start() error {
 	if err := s.state.validTransition(s.state.State, StateRunning); err != nil {
 		return err
 	}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1464,9 +1464,9 @@ func (s *Sandbox) Start() error {
 	return nil
 }
 
-// stop stops a sandbox. The containers that are making the sandbox
+// Stop stops a sandbox. The containers that are making the sandbox
 // will be destroyed.
-func (s *Sandbox) stop() error {
+func (s *Sandbox) Stop() error {
 	span, _ := s.trace("stop")
 	defer span.Finish()
 
@@ -1489,7 +1489,12 @@ func (s *Sandbox) stop() error {
 		return err
 	}
 
-	return s.setSandboxState(StateStopped)
+	if err := s.setSandboxState(StateStopped); err != nil {
+		return err
+	}
+
+	// Remove the network.
+	return s.removeNetwork()
 }
 
 // Pause pauses the sandbox

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1383,6 +1383,19 @@ func (s *Sandbox) DeleteContainer(containerID string) (VCContainer, error) {
 	return c, nil
 }
 
+// ProcessListContainer lists every process running inside a specific
+// container in the sandbox.
+func (s *Sandbox) ProcessListContainer(containerID string, options ProcessListOptions) (ProcessList, error) {
+	// Fetch the container.
+	c, err := s.findContainer(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the process list related to the container.
+	return c.processList(options)
+}
+
 // StatusContainer gets the status of a container
 // TODO: update container status properly, see kata-containers/runtime#253
 func (s *Sandbox) StatusContainer(containerID string) (ContainerStatus, error) {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1336,6 +1336,18 @@ func (s *Sandbox) StopContainer(containerID string) (VCContainer, error) {
 	return c, nil
 }
 
+// KillContainer signals a container in the sandbox
+func (s *Sandbox) KillContainer(containerID string, signal syscall.Signal, all bool) error {
+	// Fetch the container.
+	c, err := s.findContainer(containerID)
+	if err != nil {
+		return err
+	}
+
+	// Send a signal to the process.
+	return c.kill(signal, all)
+}
+
 // DeleteContainer deletes a container from the sandbox
 func (s *Sandbox) DeleteContainer(containerID string) (VCContainer, error) {
 	if containerID == "" {

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1345,7 +1345,7 @@ func TestStartContainer(t *testing.T) {
 	_, err = s.StartContainer(contID)
 	assert.NotNil(t, err, "Starting non-existing container should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	contConfig := newTestContainerConfigNoop(contID)
@@ -1401,7 +1401,7 @@ func TestEnterContainer(t *testing.T) {
 	_, _, err = s.EnterContainer(contID, cmd)
 	assert.NotNil(t, err, "Entering non-running container should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	_, _, err = s.EnterContainer(contID, cmd)
@@ -1416,7 +1416,7 @@ func TestMonitor(t *testing.T) {
 	_, err = s.Monitor()
 	assert.NotNil(t, err, "Monitoring non-running container should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	_, err = s.Monitor()
@@ -1438,7 +1438,7 @@ func TestWaitProcess(t *testing.T) {
 	_, err = s.WaitProcess(contID, execID)
 	assert.NotNil(t, err, "Wait process in stopped sandbox should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	_, err = s.WaitProcess(contID, execID)
@@ -1468,7 +1468,7 @@ func TestSignalProcess(t *testing.T) {
 	err = s.SignalProcess(contID, execID, syscall.SIGKILL, true)
 	assert.NotNil(t, err, "Wait process in stopped sandbox should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	err = s.SignalProcess(contID, execID, syscall.SIGKILL, false)
@@ -1498,7 +1498,7 @@ func TestWinsizeProcess(t *testing.T) {
 	err = s.WinsizeProcess(contID, execID, 100, 200)
 	assert.NotNil(t, err, "Winsize process in stopped sandbox should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	err = s.WinsizeProcess(contID, execID, 100, 200)
@@ -1528,7 +1528,7 @@ func TestContainerProcessIOStream(t *testing.T) {
 	_, _, _, err = s.IOStream(contID, execID)
 	assert.NotNil(t, err, "Winsize process in stopped sandbox should fail")
 
-	err = s.start()
+	err = s.Start()
 	assert.Nil(t, err, "Failed to start sandbox: %v", err)
 
 	_, _, _, err = s.IOStream(contID, execID)


### PR DESCRIPTION
In order to support use cases such as `kata-containerd-shim-v2`, where we have a long running process holding the `Sandbox` pointer, there is no reason to call into the stateless functions, as they would recreate a new `Sandbox` pointer and the corresponding ones for containers.

Instead, this PR allows such case to use the sandbox API directly, avoiding to waste time in re-initialization and duplication.

Fixes #903