### PR TITLE
build: introduction of archConvertStatFs function

### DIFF
--- a/cli/oci.go
+++ b/cli/oci.go
@@ -123,7 +123,7 @@ func isCgroupMounted(cgroupPath string) bool {
 		return false
 	}
 
-	if statFs.Type != int64(cgroupFsType) {
+	if statFs.Type != archConvertStatFs(cgroupFsType) {
 		return false
 	}
 

--- a/cli/utils_arch_base.go
+++ b/cli/utils_arch_base.go
@@ -1,0 +1,10 @@
+// +build !s390x
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+func archConvertStatFs(cgroupFsType int) int64 {
+	return int64(cgroupFsType)
+}


### PR DESCRIPTION
Fixes: #908

Type of StatFs is not always declared as int64 for all the architecture(e.g s390x).
The function archConvertStatFs could be reimplemented for other architecture
to correctly convert the StatFs.Type.

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>