### PR TITLE
virtcontainers: Add function supportGuestMemoryHotplug

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1070,6 +1070,10 @@ func (q *qemu) hotplugRemoveCPUs(amount uint32) (uint32, error) {
 }
 
 func (q *qemu) hotplugMemory(memDev *memoryDevice, op operation) (int, error) {
+
+	if !q.arch.supportGuestMemoryHotplug() {
+		return 0, fmt.Errorf("guest memory hotplug not supported")
+	}
 	if memDev.sizeMB < 0 {
 		return 0, fmt.Errorf("cannot hotplug negative size (%d) memory", memDev.sizeMB)
 	}

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -93,6 +93,9 @@ type qemuArch interface {
 
 	// handleImagePath handles the Hypervisor Config image path
 	handleImagePath(config HypervisorConfig)
+
+	// supportGuestMemoryHotplug returns if the guest supports memory hotplug
+	supportGuestMemoryHotplug() bool
 }
 
 type qemuArchBase struct {
@@ -558,4 +561,8 @@ func (q *qemuArchBase) handleImagePath(config HypervisorConfig) {
 		q.kernelParamsNonDebug = append(q.kernelParamsNonDebug, kernelParamsSystemdNonDebug...)
 		q.kernelParamsDebug = append(q.kernelParamsDebug, kernelParamsSystemdDebug...)
 	}
+}
+
+func (q *qemuArchBase) supportGuestMemoryHotplug() bool {
+	return true
 }

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -350,6 +350,7 @@ func TestHotplugRemoveMemory(t *testing.T) {
 	qemuConfig := newQemuConfig()
 	fs := &filesystem{}
 	q := &qemu{
+		arch:    &qemuArchBase{},
 		config:  qemuConfig,
 		storage: fs,
 	}


### PR DESCRIPTION
This PR defines a new function supportGuestMemoryHotplug that
clearly defines if the architecture supports memory hotplug. The function
can be reimplemented in virtcontainers/qemu_$arch.go file for each
architecture.

Fixes: #910

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>