### PR TITLE
vfio: clear the Mac address for SRIOV NIC passthrough

### DIFF
--- a/virtcontainers/physical_endpoint.go
+++ b/virtcontainers/physical_endpoint.go
@@ -179,9 +179,10 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 	vendorDeviceID := fmt.Sprintf("%s %s", vendorID, deviceID)
 	vendorDeviceID = strings.TrimSpace(vendorDeviceID)
 
+	// pass the null string macaddr to agent to avoid updateInterface failure
 	physicalEndpoint := &PhysicalEndpoint{
 		IfaceName:      netInfo.Iface.Name,
-		HardAddr:       netInfo.Iface.HardwareAddr.String(),
+		HardAddr:       "",
 		VendorDeviceID: vendorDeviceID,
 		EndpointType:   PhysicalEndpointType,
 		Driver:         driver,


### PR DESCRIPTION
When passes a vf to qemu, the guest kernel driver(eg. mlx5) might
set the mac address. Thus without this patch, the updateInterface
in kata agent side will be failed and the vfio-pci can't be passed
to qemu command line

The fix includes 2 parts:
runtime side: set the mac address to null
agent side check the link name if the mac address is null

Fixes: #914
Signed-off-by: Jia He <justin.he@arm.com>