### PR TITLE
kata-env: Show runtime trace setting

### DIFF
--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -25,7 +25,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.19"
+const formatVersion = "1.0.20"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -65,6 +65,7 @@ type RuntimeInfo struct {
 	Version         RuntimeVersionInfo
 	Config          RuntimeConfigInfo
 	Debug           bool
+	Trace           bool
 	DisableNewNetNs bool
 	Path            string
 }
@@ -173,6 +174,7 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 
 	return RuntimeInfo{
 		Debug:           config.Debug,
+		Trace:           config.Trace,
 		Version:         runtimeVersion,
 		Config:          runtimeConfig,
 		Path:            runtimePath,

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -24,10 +24,11 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 
+	"strconv"
+
 	"github.com/kata-containers/runtime/pkg/katautils"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/stretchr/testify/assert"
-	"strconv"
 )
 
 const testProxyVersion = "proxy version 0.1"
@@ -45,6 +46,7 @@ var (
 	hypervisorDebug = false
 	proxyDebug      = false
 	runtimeDebug    = false
+	runtimeTrace    = false
 	shimDebug       = false
 	netmonDebug     = false
 )
@@ -116,6 +118,7 @@ func makeRuntimeConfigFileData(hypervisor, hypervisorPath, kernelPath, imagePath
 
         [runtime]
 	enable_debug = ` + strconv.FormatBool(runtimeDebug) + `
+	enable_tracing = ` + strconv.FormatBool(runtimeTrace) + `
 	disable_new_netns= ` + strconv.FormatBool(disableNewNetNs)
 }
 
@@ -359,6 +362,7 @@ func getExpectedRuntimeDetails(config oci.RuntimeConfig, configFile string) Runt
 		},
 		Path:            runtimePath,
 		Debug:           config.Debug,
+		Trace:           config.Trace,
 		DisableNewNetNs: config.DisableNewNetNs,
 	}
 }
@@ -501,13 +505,14 @@ func TestEnvGetEnvInfo(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	// Run test twice to ensure the individual component debug options are
-	// tested.
-	for _, debug := range []bool{false, true} {
-		hypervisorDebug = debug
-		proxyDebug = debug
-		runtimeDebug = debug
-		shimDebug = debug
+	// Run test twice to ensure the individual component debug+trace
+	// options are tested.
+	for _, toggle := range []bool{false, true} {
+		hypervisorDebug = toggle
+		proxyDebug = toggle
+		runtimeDebug = toggle
+		runtimeTrace = toggle
+		shimDebug = toggle
 
 		configFile, config, err := makeRuntimeConfig(tmpdir)
 		assert.NoError(t, err)

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -628,7 +628,8 @@ func LoadConfiguration(configPath string, ignoreLogging, builtIn bool) (resolved
 		kataUtilsLogger.Logger.Level = originalLoggerLevel
 	}
 
-	tracing = tomlConf.Runtime.Tracing
+	config.Trace = tomlConf.Runtime.Tracing
+	tracing = config.Trace
 
 	if tomlConf.Runtime.InterNetworkModel != "" {
 		err = config.InterNetworkModel.SetModel(tomlConf.Runtime.InterNetworkModel)

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -121,6 +121,7 @@ type RuntimeConfig struct {
 	InterNetworkModel vc.NetInterworkingModel
 	FactoryConfig     FactoryConfig
 	Debug             bool
+	Trace             bool
 
 	//Determines if create a netns for hypervisor process
 	DisableNewNetNs bool


### PR DESCRIPTION
Show whether runtime tracing is enabled in the output of `kata-env`.

Fixes #936.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>