### PR TITLE
shim: Add trace config option

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -212,6 +212,17 @@ path = "@SHIMPATH@"
 # (default: disabled)
 #enable_debug = true
 
+# If enabled, the shim will create opentracing.io traces and spans.
+# (See https://www.jaegertracing.io/docs/getting-started).
+#
+# Note: By default, the shim runs in a separate network namespace. Therefore,
+# to allow it to send trace details to the Jaeger agent running on the host,
+# it is necessary to set 'disable_new_netns=true' so that it runs in the host
+# network namespace.
+#
+# (default: disabled)
+#enable_tracing = true
+
 [agent.@PROJECT_TYPE@]
 # There is no field for this section. The goal is only to be able to
 # specify which type of agent the user wants to use.

--- a/virtcontainers/kata_shim.go
+++ b/virtcontainers/kata_shim.go
@@ -57,5 +57,9 @@ func (s *kataShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 		args = append(args, "-log", "debug")
 	}
 
+	if config.Trace {
+		args = append(args, "-trace")
+	}
+
 	return startShim(args, params)
 }

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -56,6 +56,7 @@ type ShimParams struct {
 type ShimConfig struct {
 	Path  string
 	Debug bool
+	Trace bool
 }
 
 // Set sets a shim type based on the input string.


### PR DESCRIPTION
Add a new `enable_tracing` option to `configuration.toml` to enable shim tracing.
    
Fixes #934.
    
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>