### PR TITLE
config: Check factory config

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -193,6 +193,8 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 #
 # When disabled, new VMs are created from scratch.
 #
+# Note: Requires "initrd=" to be set ("image=" is not supported).
+#
 # Default false
 #enable_template = true
 

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -677,6 +677,10 @@ func checkConfig(config oci.RuntimeConfig) error {
 		return err
 	}
 
+	if err := checkFactoryConfig(config); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -707,6 +711,15 @@ func checkNetNsConfig(config oci.RuntimeConfig) error {
 			return fmt.Errorf("config disable_new_netns only works with 'none' internetworking_model")
 		}
 	}
+	return nil
+}
+
+// checkFactoryConfig ensures the VM factory configuration is valid.
+func checkFactoryConfig(config oci.RuntimeConfig) error {
+	if config.FactoryConfig.Template && config.HypervisorConfig.InitrdPath == "" {
+		return errors.New("Factory option enable_template requires an initrd image")
+	}
+
 	return nil
 }
 

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -659,15 +659,25 @@ func LoadConfiguration(configPath string, ignoreLogging, builtIn bool) (resolved
 	}
 
 	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs
-	if err := checkNetNsConfig(config); err != nil {
-		return "", config, err
-	}
 
-	if err := checkHypervisorConfig(config.HypervisorConfig); err != nil {
+	if err := checkConfig(config); err != nil {
 		return "", config, err
 	}
 
 	return resolved, config, nil
+}
+
+// checkConfig checks the validity of the specified config.
+func checkConfig(config oci.RuntimeConfig) error {
+	if err := checkNetNsConfig(config); err != nil {
+		return err
+	}
+
+	if err := checkHypervisorConfig(config.HypervisorConfig); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func updateConfig(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig, builtIn bool) error {

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -651,16 +651,16 @@ func LoadConfiguration(configPath string, ignoreLogging, builtIn bool) (resolved
 		return "", config, err
 	}
 
-	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs
-	if err := checkNetNsConfig(config); err != nil {
-		return "", config, err
-	}
-
 	// use no proxy if HypervisorConfig.UseVSock is true
 	if config.HypervisorConfig.UseVSock {
 		kataUtilsLogger.Info("VSOCK supported, configure to not use proxy")
 		config.ProxyType = vc.NoProxyType
 		config.ProxyConfig = vc.ProxyConfig{}
+	}
+
+	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs
+	if err := checkNetNsConfig(config); err != nil {
+		return "", config, err
 	}
 
 	if err := checkHypervisorConfig(config.HypervisorConfig); err != nil {

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -1497,3 +1497,44 @@ func TestCheckNetNsConfig(t *testing.T) {
 	err = checkNetNsConfig(config)
 	assert.Error(err)
 }
+
+func TestCheckFactoryConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		factoryEnabled bool
+		imagePath      string
+		initrdPath     string
+		expectError    bool
+	}
+
+	data := []testData{
+		{false, "", "", false},
+		{false, "image", "", false},
+		{false, "", "initrd", false},
+
+		{true, "", "initrd", false},
+		{true, "image", "", true},
+	}
+
+	for i, d := range data {
+		config := oci.RuntimeConfig{
+			HypervisorConfig: vc.HypervisorConfig{
+				ImagePath:  d.imagePath,
+				InitrdPath: d.initrdPath,
+			},
+
+			FactoryConfig: oci.FactoryConfig{
+				Template: d.factoryEnabled,
+			},
+		}
+
+		err := checkFactoryConfig(config)
+
+		if d.expectError {
+			assert.Error(err, "test %d (%+v)", i, d)
+		} else {
+			assert.NoError(err, "test %d (%+v)", i, d)
+		}
+	}
+}


### PR DESCRIPTION
If VM factory templating is enabled (`enable_template=true`), error if
the configured image is not an `initrd=` one.

Also add a note to the config file explaining that a normal image cannot
be used - only initrd images are supported.

Fixes #948.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>