### PR TITLE
virtcontainers: change uint32 to uint64 for ioctl

### DIFF
--- a/virtcontainers/utils/utils_linux.go
+++ b/virtcontainers/utils/utils_linux.go
@@ -24,7 +24,7 @@ var ioctlFunc = ioctl
 
 var maxUInt uint32 = 1<<32 - 1
 
-func ioctl(fd uintptr, request int, arg1 uint32) error {
+func ioctl(fd uintptr, request int, arg1 uint64) error {
 	if _, _, errno := unix.Syscall(
 		unix.SYS_IOCTL,
 		fd,
@@ -72,14 +72,14 @@ func FindContextID() (*os.File, uint32, error) {
 
 	// Looking for the first available context ID.
 	for cid := contextID; cid <= maxUInt; cid++ {
-		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
+		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, uint64(cid)); err == nil {
 			return vsockFd, cid, nil
 		}
 	}
 
 	// Last chance to get a free context ID.
 	for cid := contextID - 1; cid >= firstContextID; cid-- {
-		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
+		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, uint64(cid)); err == nil {
 			return vsockFd, cid, nil
 		}
 	}

--- a/virtcontainers/utils/utils_linux_test.go
+++ b/virtcontainers/utils/utils_linux_test.go
@@ -15,7 +15,7 @@ import (
 func TestFindContextID(t *testing.T) {
 	assert := assert.New(t)
 
-	ioctlFunc = func(fd uintptr, request int, arg1 uint32) error {
+	ioctlFunc = func(fd uintptr, request int, arg1 uint64) error {
 		return errors.New("ioctl")
 	}
 


### PR DESCRIPTION
The PR changes the parameter args from uint32 to uint64 for ioctl function. That leads to an endianess bug.

Fixes: #947

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>