### PR TITLE
Update cid vsock

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -73,7 +73,7 @@ type KataAgentConfig struct {
 }
 
 type kataVSOCK struct {
-	contextID uint32
+	contextID uint64
 	port      uint32
 	vhostFd   *os.File
 }

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -422,7 +422,7 @@ func (q *qemuArchBase) appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOC
 	devices = append(devices,
 		govmmQemu.VSOCKDevice{
 			ID:            fmt.Sprintf("vsock-%d", vsock.contextID),
-			ContextID:     uint64(vsock.contextID),
+			ContextID:     vsock.contextID,
 			VHostFD:       vsock.vhostFd,
 			DisableModern: q.nestedRun,
 		},

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -249,14 +249,14 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 }
 
 func TestQemuAddDeviceKataVSOCK(t *testing.T) {
-	contextID := uint32(3)
+	contextID := uint64(3)
 	port := uint32(1024)
 	vHostFD := os.NewFile(1, "vsock")
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.VSOCKDevice{
 			ID:        fmt.Sprintf("vsock-%d", contextID),
-			ContextID: uint64(contextID),
+			ContextID: contextID,
 			VHostFD:   vHostFD,
 		},
 	}

--- a/virtcontainers/utils/utils_linux_test.go
+++ b/virtcontainers/utils/utils_linux_test.go
@@ -26,7 +26,7 @@ func TestFindContextID(t *testing.T) {
 		maxUInt = orgMaxUInt
 	}()
 	VHostVSockDevicePath = "/dev/null"
-	maxUInt = uint32(1000000)
+	maxUInt = uint64(1000000)
 
 	f, cid, err := FindContextID()
 	assert.Nil(f)


### PR DESCRIPTION
The PR changes the Contex ID of Vsock from `uint32` to `uint64`. Otherwise, that leads to an endianess issue. For more information see https://github.com/kata-containers/runtime/issues/947.

Fixes: #958