### PR TITLE
block: Add new block storage driver "nvdimm"

### DIFF
--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -91,8 +91,8 @@ default_memory = @DEFMEMSZ@
 disable_block_device_use = @DEFDISABLEBLOCK@
 
 # Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. This is either virtio-scsi or 
-# virtio-blk.
+# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
+# or nvdimm.
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER@"
 
 # Specifies cache-related options will be set to block devices or not.

--- a/cli/config/configuration.toml.in
+++ b/cli/config/configuration.toml.in
@@ -82,6 +82,13 @@ default_memory = @DEFMEMSZ@
 # This is will determine the times that memory will be hotadded to sandbox/VM.
 #memory_slots = @DEFMEMSLOTS@
 
+# The size in MiB will be plused to max memory of hypervisor.
+# It is the memory address space for the NVDIMM devie.
+# If set block storage driver (block_device_driver) to "nvdimm",
+# should set memory_offset to the size of block device.
+# Default 0
+#memory_offset = 0
+
 # Disable block device from being used for a container's rootfs.
 # In case of a storage driver like devicemapper where a container's 
 # root file system is backed by a block device, the block device is passed

--- a/pkg/katautils/config-settings.go
+++ b/pkg/katautils/config-settings.go
@@ -24,6 +24,7 @@ const defaultVCPUCount uint32 = 1
 const defaultMaxVCPUCount uint32 = 0
 const defaultMemSize uint32 = 2048 // MiB
 const defaultMemSlots uint32 = 10
+const defaultMemOffset uint32 = 0 // MiB
 const defaultBridgesCount uint32 = 1
 const defaultInterNetworkingModel = "macvtap"
 const defaultDisableBlockDeviceUse bool = false

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -294,7 +294,7 @@ func (h hypervisor) defaultBridges() uint32 {
 }
 
 func (h hypervisor) blockDeviceDriver() (string, error) {
-	supportedBlockDrivers := []string{config.VirtioSCSI, config.VirtioBlock, config.VirtioMmio}
+	supportedBlockDrivers := []string{config.VirtioSCSI, config.VirtioBlock, config.VirtioMmio, config.Nvdimm}
 
 	if h.BlockDeviceDriver == "" {
 		return defaultBlockDeviceDriver, nil

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -98,6 +98,7 @@ type hypervisor struct {
 	DefaultMaxVCPUs         uint32 `toml:"default_maxvcpus"`
 	MemorySize              uint32 `toml:"default_memory"`
 	MemSlots                uint32 `toml:"memory_slots"`
+	MemOffset               uint32 `toml:"memory_offset"`
 	DefaultBridges          uint32 `toml:"default_bridges"`
 	Msize9p                 uint32 `toml:"msize_9p"`
 	DisableBlockDeviceUse   bool   `toml:"disable_block_device_use"`
@@ -279,6 +280,15 @@ func (h hypervisor) defaultMemSlots() uint32 {
 	}
 
 	return slots
+}
+
+func (h hypervisor) defaultMemOffset() uint32 {
+	offset := h.MemOffset
+	if offset == 0 {
+		offset = defaultMemOffset
+	}
+
+	return offset
 }
 
 func (h hypervisor) defaultBridges() uint32 {
@@ -514,6 +524,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DefaultMaxVCPUs:         h.defaultMaxVCPUs(),
 		MemorySize:              h.defaultMemSz(),
 		MemSlots:                h.defaultMemSlots(),
+		MemOffset:               h.defaultMemOffset(),
 		EntropySource:           h.GetEntropySource(),
 		DefaultBridges:          h.defaultBridges(),
 		DisableBlockDeviceUse:   h.DisableBlockDeviceUse,
@@ -677,6 +688,7 @@ func initConfig() (config oci.RuntimeConfig, err error) {
 		NumVCPUs:                defaultVCPUCount,
 		DefaultMaxVCPUs:         defaultMaxVCPUCount,
 		MemorySize:              defaultMemSize,
+		MemOffset:               defaultMemOffset,
 		DefaultBridges:          defaultBridgesCount,
 		MemPrealloc:             defaultEnableMemPrealloc,
 		HugePages:               defaultEnableHugePages,

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -47,6 +47,9 @@ const (
 
 	// VirtioSCSI means use virtio-scsi for hotplugging drives
 	VirtioSCSI = "virtio-scsi"
+
+	// Nvdimm means use nvdimm for hotplugging drives
+	Nvdimm = "nvdimm"
 )
 
 // Defining these as a variable instead of a const, to allow
@@ -118,6 +121,9 @@ type BlockDrive struct {
 	// SCSI Address of the block device, in case the device is attached using SCSI driver
 	// SCSI address is in the format SCSI-Id:LUN
 	SCSIAddr string
+
+	// NvdimmID is the nvdimm id inside the VM
+	NvdimmID string
 
 	// VirtPath at which the device appears inside the VM, outside of the container mount namespace
 	VirtPath string

--- a/virtcontainers/device/drivers/block.go
+++ b/virtcontainers/device/drivers/block.go
@@ -78,7 +78,7 @@ func (device *BlockDevice) Attach(devReceiver api.DeviceReceiver) (err error) {
 		}
 
 		drive.SCSIAddr = scsiAddr
-	} else {
+	} else if customOptions["block-driver"] != "nvdimm" {
 		var globalIdx int
 
 		switch customOptions["block-driver"] {
@@ -102,7 +102,7 @@ func (device *BlockDevice) Attach(devReceiver api.DeviceReceiver) (err error) {
 		drive.VirtPath = filepath.Join("/dev", driveName)
 	}
 
-	deviceLogger().WithField("device", device.DeviceInfo.HostPath).Info("Attaching block device")
+	deviceLogger().WithField("device", device.DeviceInfo.HostPath).WithField("VirtPath", drive.VirtPath).Infof("Attaching %s device", customOptions["block-driver"])
 	device.BlockDrive = drive
 	if err = devReceiver.HotplugAddDevice(device, config.DeviceBlock); err != nil {
 		return err

--- a/virtcontainers/device/manager/manager.go
+++ b/virtcontainers/device/manager/manager.go
@@ -26,6 +26,8 @@ const (
 	VirtioBlock string = "virtio-blk"
 	// VirtioSCSI indicates block driver is virtio-scsi based
 	VirtioSCSI string = "virtio-scsi"
+	// Nvdimm indicates block driver is nvdimm based
+	Nvdimm string = "nvdimm"
 )
 
 var (
@@ -61,6 +63,8 @@ func NewDeviceManager(blockDriver string, devices []api.Device) api.DeviceManage
 		dm.blockDriver = VirtioMmio
 	} else if blockDriver == VirtioBlock {
 		dm.blockDriver = VirtioBlock
+	} else if blockDriver == Nvdimm {
+		dm.blockDriver = Nvdimm
 	} else {
 		dm.blockDriver = VirtioSCSI
 	}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -169,6 +169,9 @@ type HypervisorConfig struct {
 	// MemSlots specifies default memory slots the VM.
 	MemSlots uint32
 
+	// MemOffset specifies memory space for nvdimm device
+	MemOffset uint32
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -62,6 +62,7 @@ var (
 	kataMmioBlkDevType   = "mmioblk"
 	kataBlkDevType       = "blk"
 	kataSCSIDevType      = "scsi"
+	kataNvdimmDevType    = "nvdimm"
 	sharedDir9pOptions   = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
 	shmDir               = "shm"
 	kataEphemeralDevType = "ephemeral"
@@ -883,6 +884,9 @@ func (k *kataAgent) appendDevices(deviceList []*grpc.Device, c *Container) []*gr
 		case config.VirtioSCSI:
 			kataDevice.Type = kataSCSIDevType
 			kataDevice.Id = d.SCSIAddr
+		case config.Nvdimm:
+			kataDevice.Type = kataNvdimmDevType
+			kataDevice.VmPath = fmt.Sprintf("/dev/pmem%s", d.NvdimmID)
 		}
 
 		deviceList = append(deviceList, kataDevice)

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1435,12 +1435,11 @@ func genericBridges(number uint32, machineType string) []Bridge {
 	return bridges
 }
 
-func genericMemoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {
-	// NVDIMM device needs memory space 1024MB
+func genericMemoryTopology(memoryMb, hostMemoryMb uint64, slots uint8, memoryOffset uint32) govmmQemu.Memory {
+	// image NVDIMM device needs memory space 1024MB
 	// See https://github.com/clearcontainers/runtime/issues/380
-	memoryOffset := 1024
+	memoryOffset += 1024
 
-	// add 1G memory space for nvdimm device (vm guest image)
 	memMax := fmt.Sprintf("%dM", hostMemoryMb+uint64(memoryOffset))
 
 	mem := fmt.Sprintf("%dM", memoryMb)

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -87,6 +87,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	q := &qemuAmd64{
 		qemuArchBase{
 			machineType:           machineType,
+			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
 			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
@@ -96,6 +97,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	}
 
 	q.handleImagePath(config)
+
 	return q
 }
 
@@ -126,7 +128,7 @@ func (q *qemuAmd64) cpuModel() string {
 }
 
 func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {
-	return genericMemoryTopology(memoryMb, hostMemoryMb, slots)
+	return genericMemoryTopology(memoryMb, hostMemoryMb, slots, q.memoryOffset)
 }
 
 func (q *qemuAmd64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -103,6 +103,7 @@ type qemuArch interface {
 
 type qemuArchBase struct {
 	machineType           string
+	memoryOffset          uint32
 	nestedRun             bool
 	vhost                 bool
 	networkIndex          int

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -136,6 +136,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	q := &qemuArm64{
 		qemuArchBase{
 			machineType:           machineType,
+			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
 			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -74,6 +74,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	q := &qemuPPC64le{
 		qemuArchBase{
 			machineType:           machineType,
+			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
 			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
@@ -83,6 +84,9 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	}
 
 	q.handleImagePath(config)
+
+	q.memoryOffset = config.MemOffset
+
 	return q
 }
 
@@ -121,7 +125,7 @@ func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8)
 		hostMemoryMb = defaultMemMaxPPC64le
 	}
 
-	return genericMemoryTopology(memoryMb, hostMemoryMb, slots)
+	return genericMemoryTopology(memoryMb, hostMemoryMb, slots, q.memoryOffset)
 }
 
 func (q *qemuPPC64le) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -61,6 +61,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	q := &qemuS390x{
 		qemuArchBase{
 			machineType:           machineType,
+			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
 			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,


### PR DESCRIPTION
These patches need the agent patch in https://github.com/kata-containers/agent/pull/424.

Set block_device_driver to "nvdimm" will make the hypervisor use
the block device as NVDIMM disk.

The nvdimm driver's read speed is faster than others.

Following is result of the disk io test rand 128k read, 128k write, 4k read and 4k write:
nvdimm:
READ: bw=12.1GiB/s (12.9GB/s), 1471MiB/s-1558MiB/s (1543MB/s-1634MB/s), io=10.6TiB (11.7TB), run=900001-900001msec
WRITE: bw=153MiB/s (160MB/s), 6240KiB/s-35.3MiB/s (6390kB/s-36.0MB/s), io=134GiB (144GB), run=900001-900005msec
READ: bw=1025MiB/s (1075MB/s), 1025MiB/s-1025MiB/s (1075MB/s-1075MB/s), io=901GiB (967GB), run=900001-900001msec
WRITE: bw=56.9MiB/s (59.7MB/s), 6092KiB/s-9323KiB/s (6238kB/s-9547kB/s), io=50.0GiB (53.7GB), run=900001-900004msec

virtio-scsi:
READ: bw=353MiB/s (370MB/s), 44.1MiB/s-44.1MiB/s (46.2MB/s-46.3MB/s), io=310GiB (333GB), run=900066-900077msec
WRITE: bw=145MiB/s (152MB/s), 18.1MiB/s-18.2MiB/s (18.9MB/s-19.0MB/s), io=127GiB (137GB), run=900101-900136msec
READ: bw=68.0MiB/s (72.3MB/s), 68.0MiB/s-68.0MiB/s (72.3MB/s-72.3MB/s), io=60.6GiB (65.1GB), run=900009-900009msec
WRITE: bw=115MiB/s (120MB/s), 14.2MiB/s-14.4MiB/s (14.9MB/s-15.1MB/s), io=101GiB (108GB), run=900022-900110msec