### PR TITLE
container: Use lazy unmount

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -544,7 +544,7 @@ func (c *Container) unmountHostMounts() error {
 			span, _ := c.trace("unmount")
 			span.SetTag("host-path", m.HostPath)
 
-			if err := syscall.Unmount(m.HostPath, 0); err != nil {
+			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH); err != nil {
 				c.Logger().WithFields(logrus.Fields{
 					"host-path": m.HostPath,
 					"error":     err,


### PR DESCRIPTION
Unmount recursively to unmount bind-mounted volumes.

Fixes: #965

Signed-off-by: Ning Lu <crossrunning@outlook.com>