### PR TITLE
shimv2: fix the error of reaping qemu process mistakenly

### DIFF
--- a/cli/containerd-shim-kata-v2/main.go
+++ b/cli/containerd-shim-kata-v2/main.go
@@ -10,6 +10,11 @@ import (
 	"github.com/kata-containers/runtime/containerd-shim-v2"
 )
 
+func shimConfig(config *shim.Config){
+	config.NoReaper = true
+	config.NoSubreaper = true
+}
+
 func main() {
-	shim.Run("io.containerd.kata.v2", containerdshim.New)
+	shim.Run("io.containerd.kata.v2", containerdshim.New, shimConfig)
 }

--- a/vendor/github.com/containerd/containerd/runtime/v2/shim/shim.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/shim/shim.go
@@ -53,6 +53,17 @@ type Shim interface {
 	StartShim(ctx context.Context, id, containerdBinary, containerdAddress string) (string, error)
 }
 
+// BinaryOpts allows the configuration of a shims binary setup
+type BinaryOpts func(*Config)
+
+// Config of shim binary options provided by shim implementations
+type Config struct {
+	// NoSubreaper disables setting the shim as a child subreaper
+	NoSubreaper bool
+	// NoReaper disables the shim binary from reaping any child process implicitly
+	NoReaper bool
+}
+
 var (
 	debugFlag            bool
 	idFlag               string
@@ -107,27 +118,34 @@ func setLogger(ctx context.Context, id string) error {
 }
 
 // Run initializes and runs a shim server
-func Run(id string, initFunc Init) {
-	if err := run(id, initFunc); err != nil {
+func Run(id string, initFunc Init, opts ...BinaryOpts) {
+	var config Config
+	for _, o := range opts {
+		o(&config)
+	}
+	if err := run(id, initFunc, config); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", id, err)
 		os.Exit(1)
 	}
 }
 
-func run(id string, initFunc Init) error {
+func run(id string, initFunc Init, config Config) error {
 	parseFlags()
 	setRuntime()
 
-	signals, err := setupSignals()
+	signals, err := setupSignals(config)
 	if err != nil {
 		return err
 	}
-	if err := subreaper(); err != nil {
-		return err
+	if !config.NoSubreaper {
+		if err := subreaper(); err != nil {
+			return err
+		}
 	}
 	publisher := &remoteEventsPublisher{
 		address:              addressFlag,
 		containerdBinaryPath: containerdBinaryFlag,
+		noReaper:             config.NoReaper,
 	}
 	if namespaceFlag == "" {
 		return fmt.Errorf("shim namespace cannot be empty")
@@ -254,4 +272,5 @@ func dumpStacks(logger *logrus.Entry) {
 type remoteEventsPublisher struct {
 	address              string
 	containerdBinaryPath string
+	noReaper             bool
 }

--- a/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_unix.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_unix.go
@@ -39,9 +39,13 @@ import (
 
 // setupSignals creates a new signal handler for all signals and sets the shim as a
 // sub-reaper so that the container processes are reparented
-func setupSignals() (chan os.Signal, error) {
+func setupSignals(config Config) (chan os.Signal, error) {
 	signals := make(chan os.Signal, 32)
-	signal.Notify(signals, unix.SIGTERM, unix.SIGINT, unix.SIGCHLD, unix.SIGPIPE)
+	smp := []os.Signal{unix.SIGTERM, unix.SIGINT, unix.SIGPIPE}
+	if !config.NoReaper {
+		smp = append(smp, unix.SIGCHLD)
+	}
+	signal.Notify(signals, smp...)
 	return signals, nil
 }
 
@@ -102,6 +106,15 @@ func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event
 	}
 	cmd := exec.CommandContext(ctx, l.containerdBinaryPath, "--address", l.address, "publish", "--topic", topic, "--namespace", ns)
 	cmd.Stdin = bytes.NewReader(data)
+	if l.noReaper {
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		if err := cmd.Wait(); err != nil {
+			return errors.Wrap(err, "failed to publish event")
+		}
+		return nil
+	}
 	c, err := Default.Start(cmd)
 	if err != nil {
 		return err

--- a/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_windows.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_windows.go
@@ -40,7 +40,7 @@ import (
 )
 
 // setupSignals creates a new signal handler for all signals
-func setupSignals() (chan os.Signal, error) {
+func setupSignals(config Config) (chan os.Signal, error) {
 	signals := make(chan os.Signal, 32)
 	return signals, nil
 }


### PR DESCRIPTION
For kata shimv2, it doesn't need to reap it's container processes
since all of them are running in VM, thus there is no need to
set it as a subreaper and also no need to take care of the SIGCHLD
singal.

So this commit will try to unset the subreaper and ignore the SIGCHLD
signal. Since ignoring the SIGCHLD signal will break the containerd
shim's events.Publisher publish method, thus here re-write a publish
function to publish the events to containerd.

Fixes: #939

Signed-off-by: fupan <lifupan@gmail.com>