### PR TITLE
 kernel: make kernel option arch-dependent and update it to v4.19.8 for aarch64

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -128,7 +128,15 @@ assets:
   kernel:
     description: "Linux kernel optimised for virtual machines"
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
-    version: "v4.14.67"
+    architecture:
+      x86_64:
+        version: &default-kernel-version "v4.14.67"
+      ppc64le:
+        version: *default-kernel-version
+      aarch64:
+        version: "v4.19.8"
+      s390x:
+        version: "v4.19.8"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
For including dev-kernel build process, we should add related options
in version.yaml

Fixes: #972

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <Wei.Chen@arm.com>