### PR TITLE
Network: use device name in the host to determine nic's type

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1101,7 +1101,7 @@ func (s *Sandbox) generateNetInfo(inf *types.Interface) (NetworkInfo, error) {
 	return NetworkInfo{
 		Iface: NetlinkIface{
 			LinkAttrs: netlink.LinkAttrs{
-				Name:         inf.Name,
+				Name:         inf.Device,
 				HardwareAddr: hw,
 				MTU:          int(inf.Mtu),
 			},


### PR DESCRIPTION
When adding interface, we should use device field in API to determine a
nic's type, not the name we set into the VM.

Fixes #981

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>