### PR TITLE
First createSandboxFromConfig simplification

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -105,21 +105,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		}
 	}()
 
-	// Once startVM is done, we want to guarantee
-	// that the sandbox is manageable. For that we need
-	// to start the sandbox inside the VM.
-	if err = s.agent.startSandbox(s); err != nil {
-		return nil, err
-	}
-
-	// rollback to stop sandbox in VM
-	defer func() {
-		if err != nil {
-			s.agent.stopSandbox(s)
-		}
-	}()
-
-	if err = s.getAndStoreGuestDetails(); err != nil {
+	if err := s.getAndStoreGuestDetails(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -234,12 +234,8 @@ func StartSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
 	}
 	defer s.releaseStatelessSandbox()
 
-	return startSandbox(s)
-}
-
-func startSandbox(s *Sandbox) (*Sandbox, error) {
 	// Start it
-	err := s.Start()
+	err = s.Start()
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +281,7 @@ func RunSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	span, ctx := trace(ctx, "RunSandbox")
 	defer span.Finish()
 
+	// Create the sandbox
 	s, err := createSandboxFromConfig(ctx, sandboxConfig, factory)
 	if err != nil {
 		return nil, err
@@ -297,7 +294,13 @@ func RunSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	}
 	defer unlockSandbox(lockFile)
 
-	return startSandbox(s)
+	// Start the sandbox
+	err = s.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // ListSandbox is the virtcontainers sandbox listing entry point.

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1234,8 +1234,17 @@ func (s *Sandbox) startVM() error {
 		}
 	}
 
-	// Store the network
 	s.Logger().Info("VM started")
+
+	// Once the hypervisor is done starting the sandbox,
+	// we want to guarantee that it is manageable.
+	// For that we need to ask the agent to start the
+	// sandbox inside the VM.
+	if err := s.agent.startSandbox(s); err != nil {
+		return err
+	}
+
+	s.Logger().Info("Agent started in the sandbox")
 
 	return nil
 }
@@ -1244,6 +1253,10 @@ func (s *Sandbox) startVM() error {
 func (s *Sandbox) stopVM() error {
 	span, _ := s.trace("stopVM")
 	defer span.Finish()
+
+	if err := s.agent.stopSandbox(s); err != nil {
+		s.Logger().WithError(err).WithField("sandboxid", s.id).Warning("Agent did not stop sandbox")
+	}
 
 	return s.hypervisor.stopSandbox()
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1254,10 +1254,12 @@ func (s *Sandbox) stopVM() error {
 	span, _ := s.trace("stopVM")
 	defer span.Finish()
 
+	s.Logger().Info("Stopping sandbox in the VM")
 	if err := s.agent.stopSandbox(s); err != nil {
 		s.Logger().WithError(err).WithField("sandboxid", s.id).Warning("Agent did not stop sandbox")
 	}
 
+	s.Logger().Info("Stopping VM")
 	return s.hypervisor.stopSandbox()
 }
 
@@ -1592,12 +1594,7 @@ func (s *Sandbox) Stop() error {
 		}
 	}
 
-	if err := s.agent.stopSandbox(s); err != nil {
-		return err
-	}
-
-	s.Logger().Info("Stopping VM")
-	if err := s.hypervisor.stopSandbox(); err != nil {
+	if err := s.stopVM(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We include `agent.startSandbox` into `startVM` as those 2 always go together.