### PR TITLE
virtcontainers: Create the kata agent vsock earlier

### DIFF
--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -646,8 +646,10 @@ func TestAgentPathAPI(t *testing.T) {
 	c.UseVSock = true
 	err = k2.generateVMSocket(id, c)
 	assert.Nil(err)
-	_, ok = k2.vmSocket.(kataVSOCK)
+	s, ok := k2.vmSocket.(kataVSOCK)
 	assert.True(ok)
+	// Check that the VSOCK port is properly allocated
+	assert.Equal(s.port, uint32(vSockPort))
 }
 
 func TestAgentConfigure(t *testing.T) {


### PR DESCRIPTION
We generate the vsock CID randomly, we know at agent init time how to
set it up. So let's simplify the agent flow and allocate the
vsock and its vhost fd when we do generate the VM socket.

Fixes: #1013

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>