### PR TITLE
cli: fix parameter order error in cli/ps.go

### DIFF
--- a/cli/ps.go
+++ b/cli/ps.go
@@ -92,7 +92,7 @@ func ps(ctx context.Context, containerID, format string, args []string) error {
 
 	options.Format = format
 
-	msg, err := vci.ProcessListContainer(ctx, containerID, sandboxID, options)
+	msg, err := vci.ProcessListContainer(ctx, sandboxID, containerID, options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes: #1017
reason: when calls vci.ProcessListContainer, fix wrong parameter order

Signed-off-by: x00464843 <xueshaojia@huawei.com>