### PR TITLE
network: Don't assume multiple queues support by default

### DIFF
--- a/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/virtcontainers/bridgedmacvlan_endpoint.go
@@ -84,7 +84,7 @@ func (endpoint *BridgedMacvlanEndpoint) NetworkPair() *NetworkInterfacePair {
 // Attach for virtual endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
 func (endpoint *BridgedMacvlanEndpoint) Attach(h hypervisor) error {
-	if err := xconnectVMNetwork(endpoint, true, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual ep")
 		return err
 	}
@@ -102,7 +102,7 @@ func (endpoint *BridgedMacvlanEndpoint) Detach(netNsCreated bool, netNsPath stri
 	}
 
 	return doNetNS(netNsPath, func(_ ns.NetNS) error {
-		return xconnectVMNetwork(endpoint, false, 0, false)
+		return xDisconnectVMNetwork(endpoint)
 	})
 }
 

--- a/virtcontainers/capabilities.go
+++ b/virtcontainers/capabilities.go
@@ -8,6 +8,7 @@ package virtcontainers
 const (
 	blockDeviceSupport = 1 << iota
 	blockDeviceHotplugSupport
+	multiQueueSupport
 )
 
 type capabilities struct {
@@ -34,4 +35,15 @@ func (caps *capabilities) isBlockDeviceHotplugSupported() bool {
 
 func (caps *capabilities) setBlockDeviceHotplugSupport() {
 	caps.flags |= blockDeviceHotplugSupport
+}
+
+func (caps *capabilities) isMultiQueueSupported() bool {
+	if caps.flags&multiQueueSupport != 0 {
+		return true
+	}
+	return false
+}
+
+func (caps *capabilities) setMultiQueueSupport() {
+	caps.flags |= multiQueueSupport
 }

--- a/virtcontainers/ipvlan_endpoint.go
+++ b/virtcontainers/ipvlan_endpoint.go
@@ -87,7 +87,7 @@ func (endpoint *IPVlanEndpoint) NetworkPair() *NetworkInterfacePair {
 // Attach for virtual endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
 func (endpoint *IPVlanEndpoint) Attach(h hypervisor) error {
-	if err := xconnectVMNetwork(endpoint, true, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual ep")
 		return err
 	}
@@ -105,7 +105,7 @@ func (endpoint *IPVlanEndpoint) Detach(netNsCreated bool, netNsPath string) erro
 	}
 
 	return doNetNS(netNsPath, func(_ ns.NetNS) error {
-		return xconnectVMNetwork(endpoint, false, 0, false)
+		return xDisconnectVMNetwork(endpoint)
 	})
 }
 

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -505,7 +505,12 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 func xConnectVMNetwork(endpoint Endpoint, h hypervisor) error {
 	netPair := endpoint.NetworkPair()
 
-	queues := int(h.hypervisorConfig().NumVCPUs)
+	queues := 0
+	caps := h.capabilities()
+	if caps.isMultiQueueSupported() {
+		queues = int(h.hypervisorConfig().NumVCPUs)
+	}
+
 	disableVhostNet := h.hypervisorConfig().DisableVhostNet
 
 	if netPair.NetInterworkingModel == NetXConnectDefaultModel {

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -108,6 +108,8 @@ func (q *qemuAmd64) capabilities() capabilities {
 		caps.setBlockDeviceHotplugSupport()
 	}
 
+	caps.setMultiQueueSupport()
+
 	return caps
 }
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -237,6 +237,7 @@ func (q *qemuArchBase) kernelParameters(debug bool) []Param {
 func (q *qemuArchBase) capabilities() capabilities {
 	var caps capabilities
 	caps.setBlockDeviceHotplugSupport()
+	caps.setMultiQueueSupport()
 	return caps
 }
 

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -94,6 +94,8 @@ func (q *qemuPPC64le) capabilities() capabilities {
 		caps.setBlockDeviceHotplugSupport()
 	}
 
+	caps.setMultiQueueSupport()
+
 	return caps
 }
 

--- a/virtcontainers/veth_endpoint.go
+++ b/virtcontainers/veth_endpoint.go
@@ -88,7 +88,7 @@ func (endpoint *VethEndpoint) SetProperties(properties NetworkInfo) {
 // Attach for veth endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
 func (endpoint *VethEndpoint) Attach(h hypervisor) error {
-	if err := xconnectVMNetwork(endpoint, true, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual endpoint")
 		return err
 	}
@@ -106,13 +106,13 @@ func (endpoint *VethEndpoint) Detach(netNsCreated bool, netNsPath string) error 
 	}
 
 	return doNetNS(netNsPath, func(_ ns.NetNS) error {
-		return xconnectVMNetwork(endpoint, false, 0, false)
+		return xDisconnectVMNetwork(endpoint)
 	})
 }
 
 // HotAttach for the veth endpoint uses hot plug device
 func (endpoint *VethEndpoint) HotAttach(h hypervisor) error {
-	if err := xconnectVMNetwork(endpoint, true, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual ep")
 		return err
 	}
@@ -131,7 +131,7 @@ func (endpoint *VethEndpoint) HotDetach(h hypervisor, netNsCreated bool, netNsPa
 	}
 
 	if err := doNetNS(netNsPath, func(_ ns.NetNS) error {
-		return xconnectVMNetwork(endpoint, false, 0, h.hypervisorConfig().DisableVhostNet)
+		return xDisconnectVMNetwork(endpoint)
 	}); err != nil {
 		networkLogger().WithError(err).Warn("Error un-bridging virtual ep")
 	}


### PR DESCRIPTION
This pull request reorganizes slightly the network code to be able to check the hypervisor capabilities. A new hypervisor capabilities called `multiQueueSupport` has been added, and can be used to determine if the network should be setup with or without multiple queues.