### PR TITLE
qemu-arm64: refactor 'console=hvc0,hvc1' for kata-agent debugging

### DIFF
--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -33,7 +33,8 @@ var qemuPaths = map[string]string{
 }
 
 var kernelParams = []Param{
-	{"console", "ttyAMA0"},
+	{"console", "hvc0"},
+	{"console", "hvc1"},
 	{"iommu.passthrough", "0"},
 }
 


### PR DESCRIPTION
Since kata-agent is using virtio-console to output debugging info and the console ports are available in the guest as `/dev/hvc0` and `/dev/hvc1`, we should swap origin console type `console=ttyAMA0` with `console=hvc0,hvc1`.

Fixes: #1033

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <Wei.Chen@arm.com>