### PR TITLE
katautils: fix the issue of shimv2 boot failed with vsock enabled

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -709,7 +709,10 @@ func updateConfig(configPath string, tomlConf tomlConfig, config *oci.RuntimeCon
 		config.ProxyType = vc.KataBuiltInProxyType
 		config.ShimType = vc.KataBuiltInShimType
 		config.AgentType = vc.KataContainersAgent
-		config.AgentConfig = vc.KataAgentConfig{LongLiveConn: true}
+		config.AgentConfig = vc.KataAgentConfig{
+			LongLiveConn: true,
+			UseVSock:     config.HypervisorConfig.UseVSock,
+		}
 	}
 
 	return nil


### PR DESCRIPTION
shimv2 missed to enable vsock in KataAgentConfig.

Fixes: #1037

Signed-off-by: Fupan Li <lifupan@gmail.com>