### PR TITLE
config: Add firecracker as a supported hypervisor configuration

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -547,7 +547,7 @@ func newShimConfig(s shim) (vc.ShimConfig, error) {
 	}, nil
 }
 
-func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
+func updateRuntimeConfigHypervisor(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
 	for k, hypervisor := range tomlConf.Hypervisor {
 		var err error
 		var hConfig vc.HypervisorConfig
@@ -567,6 +567,10 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 		config.HypervisorConfig = hConfig
 	}
 
+	return nil
+}
+
+func updateRuntimeConfigProxy(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
 	for k, proxy := range tomlConf.Proxy {
 		switch k {
 		case ccProxyTableType:
@@ -581,6 +585,10 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 		}
 	}
 
+	return nil
+}
+
+func updateRuntimeConfigAgent(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
 	for k := range tomlConf.Agent {
 		switch k {
 		case hyperstartAgentTableType:
@@ -595,6 +603,10 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 		}
 	}
 
+	return nil
+}
+
+func updateRuntimeConfigShim(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
 	for k, shim := range tomlConf.Shim {
 		switch k {
 		case ccShimTableType:
@@ -609,6 +621,26 @@ func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.Run
 		}
 
 		config.ShimConfig = shConfig
+	}
+
+	return nil
+}
+
+func updateRuntimeConfig(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig) error {
+	if err := updateRuntimeConfigHypervisor(configPath, tomlConf, config); err != nil {
+		return err
+	}
+
+	if err := updateRuntimeConfigProxy(configPath, tomlConf, config); err != nil {
+		return err
+	}
+
+	if err := updateRuntimeConfigAgent(configPath, tomlConf, config); err != nil {
+		return err
+	}
+
+	if err := updateRuntimeConfigShim(configPath, tomlConf, config); err != nil {
+		return err
 	}
 
 	fConfig, err := newFactoryConfig(tomlConf.Factory)


### PR DESCRIPTION
    In order to let the user choose firecracker hypervisor instead of
    QEMU (from the configuration.toml), let's add it to the list of
    supported hypervisors.
    
    Fixes #1042
    
    Depends-on: github.com/kata-containers/runtime#1044
    
    Signed-off-by: Eric Ernst <eric.ernst@intel.com>
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>