### PR TITLE
virtcontainers: fix sandbox startup sequence

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -709,3 +709,7 @@ func (fc *firecracker) getThreadIDs() (*threadIDs, error) {
 func (fc *firecracker) cleanup() error {
 	return nil
 }
+
+func (fc *firecracker) waitAgent(ctx context.Context) error {
+	return nil
+}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -607,4 +607,5 @@ type hypervisor interface {
 	hypervisorConfig() HypervisorConfig
 	getThreadIDs() (*threadIDs, error)
 	cleanup() error
+	waitAgent(ctx context.Context) error
 }

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -105,3 +105,7 @@ func (m *mockHypervisor) getThreadIDs() (*threadIDs, error) {
 func (m *mockHypervisor) cleanup() error {
 	return nil
 }
+
+func (m *mockHypervisor) waitAgent(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Wait the event of agent open the virt serial port frontend before
send request to agent.

Fixes #1020

Signed-off-by: NingBo <ning.bo9@zte.com.cn>