### PR TITLE
virtcontainers: Add context when creating tests sandboxes

### DIFF
--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1184,6 +1184,7 @@ func TestSandboxAttachDevicesVFIO(t *testing.T) {
 		storage:    &filesystem{},
 		hypervisor: &mockHypervisor{},
 		devManager: dm,
+		ctx:        context.Background(),
 	}
 
 	containers[c.id].sandbox = &sandbox
@@ -1565,6 +1566,7 @@ func TestAttachBlockDevice(t *testing.T) {
 		storage:    fs,
 		hypervisor: hypervisor,
 		config:     sconfig,
+		ctx:        context.Background(),
 	}
 
 	contID := "100"
@@ -1653,6 +1655,7 @@ func TestPreAddDevice(t *testing.T) {
 		hypervisor: hypervisor,
 		config:     sconfig,
 		devManager: dm,
+		ctx:        context.Background(),
 	}
 
 	contID := "100"
@@ -1743,6 +1746,7 @@ func TestStartNetworkMonitor(t *testing.T) {
 		networkNS: NetworkNamespace{
 			NetNsPath: fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid()),
 		},
+		ctx: context.Background(),
 	}
 
 	err = s.startNetworkMonitor()


### PR DESCRIPTION
We can use the background context when creating test sandboxes from the
sanbox unit tests. This shuts the "trace called before context set"
erros down.

Fixes: #1048

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>