### PR TITLE
virtcontainers: network: Use multiqueue flag only when appropriate

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -407,11 +407,15 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 			MulticastSnooping: expectedLink.(*netlink.Bridge).MulticastSnooping,
 		}
 	case (&netlink.Tuntap{}).Type():
+		flags := netlink.TUNTAP_VNET_HDR
+		if queues > 0 {
+			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
+		}
 		newLink = &netlink.Tuntap{
 			LinkAttrs: netlink.LinkAttrs{Name: name},
 			Mode:      netlink.TUNTAP_MODE_TAP,
 			Queues:    queues,
-			Flags:     netlink.TUNTAP_MULTI_QUEUE_DEFAULTS | netlink.TUNTAP_VNET_HDR,
+			Flags:     flags,
 		}
 	case (&netlink.Macvtap{}).Type():
 		qlen := expectedLink.Attrs().TxQLen


### PR DESCRIPTION
The multiqueue flag associated with the TUNTAP network device cannot
be used if the number of queues indicates 0. When 0, this means the
multiqueue is not supported, and we cannot use the according flag.

Fixes #1051

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>