### PR TITLE
vsock potential bug: Close vsock fd

### DIFF
--- a/virtcontainers/utils/utils_linux.go
+++ b/virtcontainers/utils/utils_linux.go
@@ -76,14 +76,16 @@ func FindContextID() (*os.File, uint64, error) {
 	// Looking for the first available context ID.
 	for cid := contextID; cid <= maxUInt; cid++ {
 		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
-			return vsockFd, cid, nil
+			vsockFd.Close()
+			return nil, cid, nil
 		}
 	}
 
 	// Last chance to get a free context ID.
 	for cid := contextID - 1; cid >= firstContextID; cid-- {
 		if err := ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, cid); err == nil {
-			return vsockFd, cid, nil
+			vsockFd.Close()
+			return nil, cid, nil
 		}
 	}
 


### PR DESCRIPTION
The vsock fd opened when trying to find a free CID prevents
firecracker from opening that vsock fd.

Currently there is no other consumer of this vsockfd close it
and return nil.

Fixes: #1053

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>