### PR TITLE
katautils: check config factory/template and vsock

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -737,8 +737,14 @@ func checkNetNsConfig(config oci.RuntimeConfig) error {
 
 // checkFactoryConfig ensures the VM factory configuration is valid.
 func checkFactoryConfig(config oci.RuntimeConfig) error {
-	if config.FactoryConfig.Template && config.HypervisorConfig.InitrdPath == "" {
-		return errors.New("Factory option enable_template requires an initrd image")
+	if config.FactoryConfig.Template {
+		if config.HypervisorConfig.InitrdPath == "" {
+			return errors.New("Factory option enable_template requires an initrd image")
+		}
+
+		if config.HypervisorConfig.UseVSock {
+			return errors.New("config vsock conflicts with factory, please disable one of them")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Vsock conflicts with factory, when both of them are enabled,
kata will try to create a new vm template which is useless,
thus it's better to disable template to save a lot of time.

Fixes: #1055

Signed-off-by: fupan <lifupan@gmail.com>