### PR TITLE
virtcontainers: cgroups: Don't error if no thread ID

### DIFF
--- a/virtcontainers/cgroups.go
+++ b/virtcontainers/cgroups.go
@@ -100,8 +100,14 @@ func (s *Sandbox) applyCPUCgroup(rc *specs.LinuxResources) error {
 	// when new container joins, new CPU could be hotplugged, so we
 	// have to query fresh vcpu info from hypervisor for every time.
 	tids, err := s.hypervisor.getThreadIDs()
-	if err != nil || tids == nil {
+	if err != nil {
 		return fmt.Errorf("failed to get thread ids from hypervisor: %v", err)
+	}
+	if tids == nil {
+		// If there's no tid returned from the hypervisor, this is not
+		// a bug. It simply means there is nothing to constrain, hence
+		// let's return without any error from here.
+		return nil
 	}
 
 	// use Add() to add vcpu thread to s.cgroup, it will write thread id to


### PR DESCRIPTION
In case the hypervisor implementation does not return any thread
ID, this should not issue any error since there is simply nothing
to constraint.

Fixes #1062

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>