### PR TITLE
mounts: Ignore existing mounts if they cannot be honored

### DIFF
--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -549,7 +549,7 @@ func (h *hyper) startOneContainer(sandbox *Sandbox, c *Container) error {
 	//TODO : Enter mount namespace
 
 	// Handle container mounts
-	newMounts, err := c.mountSharedDirMounts(defaultSharedDir, "")
+	newMounts, _, err := c.mountSharedDirMounts(defaultSharedDir, "")
 	if err != nil {
 		bindUnmountAllRootfs(c.ctx, defaultSharedDir, sandbox)
 		return err

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1706,10 +1706,12 @@ func TestPreAddDevice(t *testing.T) {
 		},
 	}
 
-	mounts, err := container.mountSharedDirMounts("", "")
+	mounts, ignoreMounts, err := container.mountSharedDirMounts("", "")
 	assert.Nil(t, err)
 	assert.Equal(t, len(mounts), 0,
 		"mounts should contain nothing because it only contains a block device")
+	assert.Equal(t, len(ignoreMounts), 0,
+		"ignoreMounts should contain nothing because it only contains a block device")
 }
 
 func TestGetNetNs(t *testing.T) {


### PR DESCRIPTION
In case we use an hypervisor that cannot support filesystem sharing,
we copy files over to the VM rootfs through the gRPC protocol. This
is a nice workaround, but it only works with regular files, which
means no device file, no socket file, no directory, etc... can be
sent this way.

This is a limitation that we accept here, by simply ignoring those
non-regular files.

Fixes #1068

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>