### PR TITLE
fix: fail to do clean without named return

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -62,11 +62,9 @@ func CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	return s, err
 }
 
-func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (_ *Sandbox, err error) {
 	span, ctx := trace(ctx, "createSandboxFromConfig")
 	defer span.Finish()
-
-	var err error
 
 	// Create the sandbox.
 	s, err := createSandbox(ctx, sandboxConfig, factory)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -795,7 +795,7 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	return s, nil
 }
 
-func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (_ *Sandbox, err error) {
 	span, ctx := trace(ctx, "newSandbox")
 	defer span.Finish()
 

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -91,7 +91,7 @@ func setupProxy(h hypervisor, agent agent, config VMConfig, id string) (int, str
 }
 
 // NewVM creates a new VM based on provided VMConfig.
-func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
+func NewVM(ctx context.Context, config VMConfig) (_ *VM, err error) {
 	var (
 		proxy proxy
 		pid   int


### PR DESCRIPTION
```
defer func() {
    if err != nil {

    }
}
```
when returned variable is not named, if err is re-defined in if
condition, like `if err := s.getAndStoreGuestDetails(); err != nil`
in `createSandboxFromConfig()`, defer function can not catch error.
So it better to make returned err named.
Other change in virtcontainers/sandbox.go and virtcontainers/vm.go
is not must, but make more sense.

Signed-off-by: Ace-Tang <aceapril@126.com>