### PR TITLE
cli: allow to kill a stopped container and sandbox

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -404,6 +404,7 @@ func (c *Container) setContainerState(state stateString) error {
 		return errNeedState
 	}
 
+	c.Logger().Debugf("Setting container state from %v to %v", c.state.State, state)
 	// update in-memory state
 	c.state.State = state
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1569,6 +1569,11 @@ func (s *Sandbox) Stop() error {
 	span, _ := s.trace("stop")
 	defer span.Finish()
 
+	if s.state.State == StateStopped {
+		s.Logger().Info("sandbox already stopped")
+		return nil
+	}
+
 	if err := s.state.validTransition(s.state.State, StateStopped); err != nil {
 		return err
 	}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1754,3 +1754,10 @@ func TestStartNetworkMonitor(t *testing.T) {
 	err = s.startNetworkMonitor()
 	assert.Nil(t, err)
 }
+
+func TestSandboxStopStopped(t *testing.T) {
+	s := &Sandbox{state: State{State: StateStopped}}
+	err := s.Stop()
+
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
cri containerd calls kill on stopped sandbox and if we
fail the call, it can cause `cri stopp` command to fail
too.

Also add a few logs to track container state transitioning.

Fixes: #1084
