### PR TITLE
kata-runtime: Return correct kata-env on ppc64le

### DIFF
--- a/cli/kata-check_ppc64le_test.go
+++ b/cli/kata-check_ppc64le_test.go
@@ -220,7 +220,7 @@ func TestGetCPUDetails(t *testing.T) {
 	const validVendorName = ""
 	validVendor := fmt.Sprintf(`%s  : %s`, archCPUVendorField, validVendorName)
 
-	const validModelName = "POWER8"
+	const validModelName = "8247-22L"
 	validModel := fmt.Sprintf(`%s   : %s`, archCPUModelField, validModelName)
 
 	validContents := fmt.Sprintf(`


### PR DESCRIPTION
The contents of /proc/cpuinfo were
trimmed and hence the "model" field could
not be parsed despite being a field in
/proc/cpuinfo. Fix this issue.

Fixes: #1089

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com