### PR TITLE
shimv2: get the kata configure file from env KATA_CONF_FILE

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -63,7 +63,10 @@ func New(ctx context.Context, id string, publisher events.Publisher) (cdshim.Shi
 	logrus.SetOutput(ioutil.Discard)
 	vci.SetLogger(ctx, logger)
 	katautils.SetLogger(ctx, logger, logger.Logger.Level)
-	_, runtimeConfig, err := katautils.LoadConfiguration("", false, true)
+
+	// Try to get the config file from the env KATA_CONF_FILE
+	confPath := os.Getenv("KATA_CONF_FILE")
+	_, runtimeConfig, err := katautils.LoadConfiguration(confPath, false, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the env KATA_CONF_FILE was set, shimv2 will use it as the
kata configure file, otherwise, it will try to find it from
/etc and /usr/share directory.

Fixes: #1091

Signed-off-by: fupan <lifupan@gmail.com>