### PR TITLE
Initial types package creation

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -16,6 +16,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -163,7 +164,7 @@ func TestDeleteSandbox(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "ready",
 			},
 		}, nil
@@ -180,8 +181,8 @@ func TestDeleteSandbox(t *testing.T) {
 	testingImpl.StatusSandboxFunc = func(ctx context.Context, sandboxID string) (vc.SandboxStatus, error) {
 		return vc.SandboxStatus{
 			ID: sandbox.ID(),
-			State: vc.State{
-				State: vc.StateReady,
+			State: types.State{
+				State: types.StateReady,
 			},
 		}, nil
 	}
@@ -241,7 +242,7 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: "InvalidType",
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "created",
 			},
 		}, nil
@@ -280,7 +281,7 @@ func TestDeleteSandboxRunning(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "running",
 			},
 		}, nil
@@ -298,8 +299,8 @@ func TestDeleteSandboxRunning(t *testing.T) {
 	testingImpl.StatusSandboxFunc = func(ctx context.Context, sandboxID string) (vc.SandboxStatus, error) {
 		return vc.SandboxStatus{
 			ID: sandbox.ID(),
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}
@@ -360,7 +361,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "running",
 			},
 		}, nil
@@ -443,7 +444,7 @@ func TestDeleteContainer(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "ready",
 			},
 		}, nil
@@ -543,7 +544,7 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
 				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
-			State: vc.State{
+			State: types.State{
 				State: "ready",
 			},
 		}, nil
@@ -552,8 +553,8 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 	testingImpl.StatusSandboxFunc = func(ctx context.Context, sandboxID string) (vc.SandboxStatus, error) {
 		return vc.SandboxStatus{
 			ID: sandbox.ID(),
-			State: vc.State{
-				State: vc.StateReady,
+			State: types.State{
+				State: types.StateReady,
 			},
 		}, nil
 	}

--- a/cli/events.go
+++ b/cli/events.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 
 	"github.com/kata-containers/runtime/pkg/katautils"
 	"github.com/sirupsen/logrus"
@@ -175,7 +176,7 @@ information is displayed once every 5 seconds.`,
 		span.SetTag("container", containerID)
 		span.SetTag("sandbox", sandboxID)
 
-		if status.State.State == vc.StateStopped {
+		if status.State.State == types.StateStopped {
 			return fmt.Errorf("container with id %s is not running", status.ID)
 		}
 

--- a/cli/events_test.go
+++ b/cli/events_test.go
@@ -15,6 +15,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -111,8 +112,8 @@ func TestEventsCLISuccessful(t *testing.T) {
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -15,8 +15,9 @@ import (
 	"syscall"
 
 	"github.com/kata-containers/runtime/pkg/katautils"
-	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/types"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
@@ -226,8 +227,8 @@ func execute(ctx context.Context, context *cli.Context) error {
 	span.SetTag("container", containerID)
 
 	// container MUST be ready or running.
-	if status.State.State != vc.StateReady &&
-		status.State.State != vc.StateRunning {
+	if status.State.State != types.StateReady &&
+		status.State.State != types.StateRunning {
 		return fmt.Errorf("Container %s is not ready or running",
 			params.cID)
 	}
@@ -248,7 +249,7 @@ func execute(ctx context.Context, context *cli.Context) error {
 		user = params.ociProcess.User.Username
 	}
 
-	cmd := vc.Cmd{
+	cmd := types.Cmd{
 		Args:        params.ociProcess.Args,
 		Envs:        envVars,
 		WorkDir:     params.ociProcess.Cwd,

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -18,6 +18,7 @@ import (
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -77,7 +78,7 @@ func TestExecuteErrors(t *testing.T) {
 	}
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, vc.State{}, annotations), nil
+		return newSingleContainerStatus(testContainerID, types.State{}, annotations), nil
 	}
 
 	defer func() {
@@ -99,7 +100,7 @@ func TestExecuteErrors(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	containerState := vc.State{}
+	containerState := types.State{}
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
 	}
@@ -109,8 +110,8 @@ func TestExecuteErrors(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 
 	// Container paused
-	containerState = vc.State{
-		State: vc.StatePaused,
+	containerState = types.State{
+		State: types.StatePaused,
 	}
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
@@ -121,8 +122,8 @@ func TestExecuteErrors(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 
 	// Container stopped
-	containerState = vc.State{
-		State: vc.StateStopped,
+	containerState = types.State{
+		State: types.StateStopped,
 	}
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return newSingleContainerStatus(testContainerID, containerState, annotations), nil
@@ -158,8 +159,8 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -207,8 +208,8 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -274,8 +275,8 @@ func TestExecuteWithFlags(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -299,7 +300,7 @@ func TestExecuteWithFlags(t *testing.T) {
 
 	assert.True(vcmock.IsMockError(err))
 
-	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		return &vcmock.Sandbox{}, &vcmock.Container{}, &vc.Process{}, nil
 	}
 
@@ -316,7 +317,7 @@ func TestExecuteWithFlags(t *testing.T) {
 	os.Remove(pidFilePath)
 
 	// Process ran and exited successfully
-	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		workload := []string{"cat", "/dev/null"}
 		command := exec.Command(workload[0], workload[1:]...)
@@ -364,8 +365,8 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -380,7 +381,7 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 		testingImpl.StatusContainerFunc = nil
 	}()
 
-	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		workload := []string{"cat", "/dev/null"}
 		command := exec.Command(workload[0], workload[1:]...)
@@ -443,8 +444,8 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -495,8 +496,8 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -542,7 +543,7 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 
 	workload := []string{"cat", "/dev/null"}
 
-	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		command := exec.Command(workload[0], workload[1:]...)
 		err := command.Start()
@@ -596,8 +597,8 @@ func TestExecuteWithEmptyEnvironmentValue(t *testing.T) {
 		vcAnnotations.ConfigJSONKey:    configJSON,
 	}
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -644,7 +645,7 @@ func TestExecuteWithEmptyEnvironmentValue(t *testing.T) {
 
 	workload := []string{"cat", "/dev/null"}
 
-	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	testingImpl.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		// create a fake container process
 		command := exec.Command(workload[0], workload[1:]...)
 		err := command.Start()

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -132,7 +133,7 @@ func kill(ctx context.Context, containerID, signal string, all bool) error {
 	kataLog.WithField("signal", signal).WithField("container state", status.State.State).Info("kill")
 
 	// container MUST be created, running or paused
-	if status.State.State == vc.StateReady || status.State.State == vc.StateRunning || status.State.State == vc.StatePaused {
+	if status.State.State == types.StateReady || status.State.State == types.StateRunning || status.State.State == types.StatePaused {
 		if err := vci.KillContainer(ctx, sandboxID, containerID, signum, all); err != nil {
 			return err
 		}

--- a/cli/kill_test.go
+++ b/cli/kill_test.go
@@ -16,6 +16,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,8 +65,8 @@ func TestProcessSignal(t *testing.T) {
 func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	annotations := map[string]string{
@@ -122,8 +123,8 @@ func TestKillCLIFunctionSigtermSuccessful(t *testing.T) {
 func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
@@ -150,8 +151,8 @@ func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	annotations := map[string]string{
@@ -200,8 +201,8 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	annotations := map[string]string{
@@ -288,8 +289,8 @@ func TestKillCLIFunctionContainerNotExistFailure(t *testing.T) {
 func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
@@ -316,8 +317,8 @@ func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 func TestKillCLIFunctionStatePausedSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StatePaused,
+	state := types.State{
+		State: types.StatePaused,
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
@@ -347,8 +348,8 @@ func TestKillCLIFunctionStatePausedSuccessful(t *testing.T) {
 func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateStopped,
+	state := types.State{
+		State: types.StateStopped,
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil
@@ -375,8 +376,8 @@ func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -400,8 +401,8 @@ func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 func TestKillCLIFunctionInvalidStateStoppedAllSuccess(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateStopped,
+	state := types.State{
+		State: types.StateStopped,
 	}
 
 	testingImpl.KillContainerFunc = testKillContainerFuncReturnNil

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -26,6 +26,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	jaeger "github.com/uber/jaeger-client-go"
@@ -444,7 +445,7 @@ func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
 }
 
-func newSingleContainerStatus(containerID string, containerState vc.State, annotations map[string]string) vc.ContainerStatus {
+func newSingleContainerStatus(containerID string, containerState types.State, annotations map[string]string) vc.ContainerStatus {
 	return vc.ContainerStatus{
 		ID:          containerID,
 		State:       containerState,

--- a/cli/network.go
+++ b/cli/network.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -132,7 +132,7 @@ func networkModifyCommand(ctx context.Context, containerID, input string, opType
 	setExternalLoggers(ctx, kataLog)
 
 	// container MUST be running
-	if status.State.State != vc.StateRunning {
+	if status.State.State != types.StateRunning {
 		return fmt.Errorf("container %s is not running", containerID)
 	}
 
@@ -201,7 +201,7 @@ func networkListCommand(ctx context.Context, containerID string, opType networkT
 	setExternalLoggers(ctx, kataLog)
 
 	// container MUST be running
-	if status.State.State != vc.StateRunning {
+	if status.State.State != types.StateRunning {
 		return fmt.Errorf("container %s is not running", containerID)
 	}
 

--- a/cli/network.go
+++ b/cli/network.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -152,7 +152,7 @@ func networkModifyCommand(ctx context.Context, containerID, input string, opType
 	}
 	switch opType {
 	case interfaceType:
-		var inf, resultingInf *types.Interface
+		var inf, resultingInf *vcTypes.Interface
 		if err = json.NewDecoder(f).Decode(&inf); err != nil {
 			return err
 		}
@@ -171,7 +171,7 @@ func networkModifyCommand(ctx context.Context, containerID, input string, opType
 		}
 		json.NewEncoder(output).Encode(resultingInf)
 	case routeType:
-		var routes, resultingRoutes []*types.Route
+		var routes, resultingRoutes []*vcTypes.Route
 		if err = json.NewDecoder(f).Decode(&routes); err != nil {
 			return err
 		}
@@ -209,7 +209,7 @@ func networkListCommand(ctx context.Context, containerID string, opType networkT
 
 	switch opType {
 	case interfaceType:
-		var interfaces []*types.Interface
+		var interfaces []*vcTypes.Interface
 		interfaces, err = vci.ListInterfaces(ctx, sandboxID)
 		if err != nil {
 			kataLog.WithField("existing-interfaces", fmt.Sprintf("%+v", interfaces)).
@@ -217,7 +217,7 @@ func networkListCommand(ctx context.Context, containerID string, opType networkT
 		}
 		json.NewEncoder(file).Encode(interfaces)
 	case routeType:
-		var routes []*types.Route
+		var routes []*vcTypes.Route
 		routes, err = vci.ListRoutes(ctx, sandboxID)
 		if err != nil {
 			kataLog.WithField("resulting-routes", fmt.Sprintf("%+v", routes)).

--- a/cli/network_test.go
+++ b/cli/network_test.go
@@ -13,24 +13,24 @@ import (
 	"testing"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	testAddInterfaceFuncReturnNil = func(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+	testAddInterfaceFuncReturnNil = func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 		return nil, nil
 	}
-	testRemoveInterfaceFuncReturnNil = func(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+	testRemoveInterfaceFuncReturnNil = func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 		return nil, nil
 	}
-	testListInterfacesFuncReturnNil = func(ctx context.Context, sandboxID string) ([]*types.Interface, error) {
+	testListInterfacesFuncReturnNil = func(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error) {
 		return nil, nil
 	}
-	testUpdateRoutsFuncReturnNil = func(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error) {
+	testUpdateRoutsFuncReturnNil = func(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 		return nil, nil
 	}
-	testListRoutesFuncReturnNil = func(ctx context.Context, sandboxID string) ([]*types.Route, error) {
+	testListRoutesFuncReturnNil = func(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error) {
 		return nil, nil
 	}
 )

--- a/cli/network_test.go
+++ b/cli/network_test.go
@@ -14,6 +14,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,8 +39,8 @@ var (
 func TestNetworkCliFunction(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	testingImpl.AddInterfaceFunc = testAddInterfaceFuncReturnNil

--- a/cli/pause_test.go
+++ b/cli/pause_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,8 +30,8 @@ var (
 func TestPauseCLIFunctionSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	testingImpl.PauseContainerFunc = testPauseContainerFuncReturnNil
@@ -77,8 +78,8 @@ func TestPauseCLIFunctionContainerNotExistFailure(t *testing.T) {
 func TestPauseCLIFunctionPauseContainerFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)
@@ -102,8 +103,8 @@ func TestPauseCLIFunctionPauseContainerFailure(t *testing.T) {
 func TestResumeCLIFunctionSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	testingImpl.ResumeContainerFunc = testResumeContainerFuncReturnNil
@@ -149,8 +150,8 @@ func TestResumeCLIFunctionContainerNotExistFailure(t *testing.T) {
 func TestResumeCLIFunctionPauseContainerFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	path, err := createTempContainerIDMapping(testContainerID, testSandboxID)

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -80,7 +82,7 @@ func ps(ctx context.Context, containerID, format string, args []string) error {
 	span.SetTag("sandbox", sandboxID)
 
 	// container MUST be running
-	if status.State.State != vc.StateRunning {
+	if status.State.State != types.StateRunning {
 		return fmt.Errorf("Container %s is not running", containerID)
 	}
 

--- a/cli/ps_test.go
+++ b/cli/ps_test.go
@@ -14,6 +14,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -95,8 +96,8 @@ func TestPSSuccessful(t *testing.T) {
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return vc.ContainerStatus{
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 			ID: sandbox.ID(),
 			Annotations: map[string]string{

--- a/cli/update.go
+++ b/cli/update.go
@@ -14,7 +14,8 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/kata-containers/runtime/pkg/katautils"
-	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -164,7 +165,7 @@ other options are ignored.
 		span.SetTag("sandbox", sandboxID)
 
 		// container MUST be running
-		if status.State.State != vc.StateRunning {
+		if status.State.State != types.StateRunning {
 			return fmt.Errorf("Container %s is not running", containerID)
 		}
 

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -15,6 +15,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -94,8 +95,8 @@ func TestUpdateCLIFailure(t *testing.T) {
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}
@@ -167,8 +168,8 @@ func TestUpdateCLISuccessful(t *testing.T) {
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
 			},
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}

--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/containerd/containerd/mount"
 	"github.com/kata-containers/runtime/pkg/katautils"
-	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,7 +22,7 @@ func deleteContainer(ctx context.Context, s *service, c *container) error {
 	if err != nil {
 		return err
 	}
-	if status.State.State != vc.StateStopped {
+	if status.State.State != types.StateStopped {
 		_, err = s.sandbox.StopContainer(c.id)
 		if err != nil {
 			return err

--- a/containerd-shim-v2/exec.go
+++ b/containerd-shim-v2/exec.go
@@ -14,13 +14,13 @@ import (
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	googleProtobuf "github.com/gogo/protobuf/types"
-	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type exec struct {
 	container *container
-	cmds      *vc.Cmd
+	cmds      *types.Cmd
 	tty       *tty
 	ttyio     *ttyIO
 	id        string
@@ -44,17 +44,17 @@ type tty struct {
 	terminal bool
 }
 
-func getEnvs(envs []string) []vc.EnvVar {
-	var vcEnvs = []vc.EnvVar{}
-	var env vc.EnvVar
+func getEnvs(envs []string) []types.EnvVar {
+	var vcEnvs = []types.EnvVar{}
+	var env types.EnvVar
 
 	for _, v := range envs {
 		pair := strings.SplitN(v, "=", 2)
 
 		if len(pair) == 2 {
-			env = vc.EnvVar{Var: pair[0], Value: pair[1]}
+			env = types.EnvVar{Var: pair[0], Value: pair[1]}
 		} else if len(pair) == 1 {
-			env = vc.EnvVar{Var: pair[0], Value: ""}
+			env = types.EnvVar{Var: pair[0], Value: ""}
 		}
 
 		vcEnvs = append(vcEnvs, env)
@@ -91,7 +91,7 @@ func newExec(c *container, stdin, stdout, stderr string, terminal bool, jspec *g
 		terminal: terminal,
 	}
 
-	cmds := &vc.Cmd{
+	cmds := &types.Cmd{
 		Args:            spec.Args,
 		Envs:            getEnvs(spec.Env),
 		User:            fmt.Sprintf("%d", spec.User.UID),

--- a/containerd-shim-v2/pause_test.go
+++ b/containerd-shim-v2/pause_test.go
@@ -15,6 +15,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,8 +39,8 @@ func TestPauseContainerSuccess(t *testing.T) {
 		return vc.ContainerStatus{
 			ID:          testContainerID,
 			Annotations: make(map[string]string),
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}
@@ -86,8 +87,8 @@ func TestPauseContainerFail(t *testing.T) {
 		return vc.ContainerStatus{
 			ID:          testContainerID,
 			Annotations: make(map[string]string),
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}
@@ -129,8 +130,8 @@ func TestResumeContainerSuccess(t *testing.T) {
 		return vc.ContainerStatus{
 			ID:          testContainerID,
 			Annotations: make(map[string]string),
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}
@@ -177,8 +178,8 @@ func TestResumeContainerFail(t *testing.T) {
 		return vc.ContainerStatus{
 			ID:          testContainerID,
 			Annotations: make(map[string]string),
-			State: vc.State{
-				State: vc.StateRunning,
+			State: types.State{
+				State: types.StateRunning,
 			},
 		}, nil
 	}

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/containerd/containerd/api/types/task"
@@ -782,13 +783,13 @@ func (s *service) getContainerStatus(containerID string) (task.Status, error) {
 
 	var status task.Status
 	switch cStatus.State.State {
-	case vc.StateReady:
+	case types.StateReady:
 		status = task.StatusCreated
-	case vc.StateRunning:
+	case types.StateRunning:
 		status = task.StatusRunning
-	case vc.StatePaused:
+	case types.StatePaused:
 		status = task.StatusPaused
-	case vc.StateStopped:
+	case types.StateStopped:
 		status = task.StatusStopped
 	}
 

--- a/netmon/netmon_test.go
+++ b/netmon/netmon_test.go
@@ -16,7 +16,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
@@ -176,12 +176,12 @@ func TestConvertInterface(t *testing.T) {
 
 	linkType := "link_type_test"
 
-	expected := types.Interface{
+	expected := vcTypes.Interface{
 		Device: testIfaceName,
 		Name:   testIfaceName,
 		Mtu:    uint64(testMTU),
 		HwAddr: testHwAddr,
-		IPAddresses: []*types.IPAddress{
+		IPAddresses: []*vcTypes.IPAddress{
 			{
 				Family:  netlinkFamily,
 				Address: testIPAddress,
@@ -211,7 +211,7 @@ func TestConvertRoutes(t *testing.T) {
 		},
 	}
 
-	expected := []types.Route{
+	expected := []vcTypes.Route{
 		{
 			Dest:    testIPAddress,
 			Gateway: testIPAddress,
@@ -245,7 +245,7 @@ func testSetupNetwork(t *testing.T) testTeardownNetwork {
 	}
 }
 
-func testCreateDummyNetwork(t *testing.T, handler *netlink.Handle) (int, types.Interface) {
+func testCreateDummyNetwork(t *testing.T, handler *netlink.Handle) (int, vcTypes.Interface) {
 	hwAddr, err := net.ParseMAC(testHwAddr)
 	assert.Nil(t, err)
 
@@ -266,7 +266,7 @@ func testCreateDummyNetwork(t *testing.T, handler *netlink.Handle) (int, types.I
 	attrs := link.Attrs()
 	assert.NotNil(t, attrs)
 
-	iface := types.Interface{
+	iface := vcTypes.Interface{
 		Device:   testIfaceName,
 		Name:     testIfaceName,
 		Mtu:      uint64(testMTU),
@@ -289,7 +289,7 @@ func TestScanNetwork(t *testing.T) {
 	idx, expected := testCreateDummyNetwork(t, handler)
 
 	n := &netmon{
-		netIfaces:  make(map[int]types.Interface),
+		netIfaces:  make(map[int]vcTypes.Interface),
 		netHandler: handler,
 	}
 
@@ -300,9 +300,9 @@ func TestScanNetwork(t *testing.T) {
 }
 
 func TestStoreDataToSend(t *testing.T) {
-	var got types.Interface
+	var got vcTypes.Interface
 
-	expected := types.Interface{
+	expected := vcTypes.Interface{
 		Device: testIfaceName,
 		Name:   testIfaceName,
 		Mtu:    uint64(testMTU),
@@ -399,15 +399,15 @@ func TestActionsCLI(t *testing.T) {
 	defer os.RemoveAll(testStorageParentPath)
 
 	// Test addInterfaceCLI
-	err = n.addInterfaceCLI(types.Interface{})
+	err = n.addInterfaceCLI(vcTypes.Interface{})
 	assert.Nil(t, err)
 
 	// Test delInterfaceCLI
-	err = n.delInterfaceCLI(types.Interface{})
+	err = n.delInterfaceCLI(vcTypes.Interface{})
 	assert.Nil(t, err)
 
 	// Test updateRoutesCLI
-	err = n.updateRoutesCLI([]types.Route{})
+	err = n.updateRoutesCLI([]vcTypes.Route{})
 	assert.Nil(t, err)
 
 	tearDownNetworkCb := testSetupNetwork(t)
@@ -465,8 +465,8 @@ func TestHandleRTMNewLink(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Interface already exist in list
-	n.netIfaces = make(map[int]types.Interface)
-	n.netIfaces[testIfaceIndex] = types.Interface{}
+	n.netIfaces = make(map[int]vcTypes.Interface)
+	n.netIfaces[testIfaceIndex] = vcTypes.Interface{}
 	ev = netlink.LinkUpdate{
 		Link: &netlink.Dummy{
 			LinkAttrs: netlink.LinkAttrs{
@@ -479,7 +479,7 @@ func TestHandleRTMNewLink(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Flags are not up and running
-	n.netIfaces = make(map[int]types.Interface)
+	n.netIfaces = make(map[int]vcTypes.Interface)
 	ev = netlink.LinkUpdate{
 		Link: &netlink.Dummy{
 			LinkAttrs: netlink.LinkAttrs{
@@ -492,7 +492,7 @@ func TestHandleRTMNewLink(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Invalid link
-	n.netIfaces = make(map[int]types.Interface)
+	n.netIfaces = make(map[int]vcTypes.Interface)
 	ev = netlink.LinkUpdate{
 		Link: &netlink.Dummy{
 			LinkAttrs: netlink.LinkAttrs{
@@ -533,7 +533,7 @@ func TestHandleRTMDelLink(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Interface does not exist in list
-	n.netIfaces = make(map[int]types.Interface)
+	n.netIfaces = make(map[int]vcTypes.Interface)
 	ev = netlink.LinkUpdate{
 		Link: &netlink.Dummy{
 			LinkAttrs: netlink.LinkAttrs{
@@ -548,7 +548,7 @@ func TestHandleRTMDelLink(t *testing.T) {
 
 func TestHandleRTMNewRouteIfaceNotFound(t *testing.T) {
 	n := &netmon{
-		netIfaces: make(map[int]types.Interface),
+		netIfaces: make(map[int]vcTypes.Interface),
 	}
 
 	err := n.handleRTMNewRoute(netlink.RouteUpdate{})

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/kata-containers/agent/protocols/grpc"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/mitchellh/mapstructure"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -234,16 +234,16 @@ type agent interface {
 	reseedRNG(data []byte) error
 
 	// updateInterface will tell the agent to update a nic for an existed Sandbox.
-	updateInterface(inf *types.Interface) (*types.Interface, error)
+	updateInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error)
 
 	// listInterfaces will tell the agent to list interfaces of an existed Sandbox
-	listInterfaces() ([]*types.Interface, error)
+	listInterfaces() ([]*vcTypes.Interface, error)
 
 	// updateRoutes will tell the agent to update route table for an existed Sandbox.
-	updateRoutes(routes []*types.Route) ([]*types.Route, error)
+	updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error)
 
 	// listRoutes will tell the agent to list routes of an existed Sandbox
-	listRoutes() ([]*types.Route, error)
+	listRoutes() ([]*vcTypes.Route, error)
 
 	// getGuestDetails will tell the agent to get some information of guest
 	getGuestDetails(*grpc.GuestDetailsRequest) (*grpc.GuestDetailsResponse, error)

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kata-containers/agent/protocols/grpc"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/mitchellh/mapstructure"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -160,7 +161,7 @@ type agent interface {
 	createSandbox(sandbox *Sandbox) error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error)
+	exec(sandbox *Sandbox, c Container, cmd types.Cmd) (*Process, error)
 
 	// startSandbox will tell the agent to start all containers related to the Sandbox.
 	startSandbox(sandbox *Sandbox) error

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -14,6 +14,7 @@ import (
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
@@ -489,7 +490,7 @@ func StopContainer(ctx context.Context, sandboxID, containerID string) (VCContai
 
 // EnterContainer is the virtcontainers container command execution entry point.
 // EnterContainer enters an already running container and runs a given command.
-func EnterContainer(ctx context.Context, sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error) {
+func EnterContainer(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (VCSandbox, VCContainer, *Process, error) {
 	span, ctx := trace(ctx, "EnterContainer")
 	defer span.Finish()
 
@@ -569,9 +570,9 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 			// We have to check for the process state to make sure
 			// we update the status in case the process is supposed
 			// to be running but has been killed or terminated.
-			if (container.state.State == StateReady ||
-				container.state.State == StateRunning ||
-				container.state.State == StatePaused) &&
+			if (container.state.State == types.StateReady ||
+				container.state.State == types.StateRunning ||
+				container.state.State == types.StatePaused) &&
 				container.process.Pid > 0 {
 
 				running, err := isShimRunning(container.process.Pid)

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -13,7 +13,7 @@ import (
 
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
@@ -804,7 +804,7 @@ func AddDevice(ctx context.Context, sandboxID string, info deviceConfig.DeviceIn
 	return s.AddDevice(info)
 }
 
-func toggleInterface(ctx context.Context, sandboxID string, inf *types.Interface, add bool) (*types.Interface, error) {
+func toggleInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface, add bool) (*vcTypes.Interface, error) {
 	if sandboxID == "" {
 		return nil, errNeedSandboxID
 	}
@@ -829,7 +829,7 @@ func toggleInterface(ctx context.Context, sandboxID string, inf *types.Interface
 }
 
 // AddInterface is the virtcontainers add interface entry point.
-func AddInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func AddInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	span, ctx := trace(ctx, "AddInterface")
 	defer span.Finish()
 
@@ -837,7 +837,7 @@ func AddInterface(ctx context.Context, sandboxID string, inf *types.Interface) (
 }
 
 // RemoveInterface is the virtcontainers remove interface entry point.
-func RemoveInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func RemoveInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	span, ctx := trace(ctx, "RemoveInterface")
 	defer span.Finish()
 
@@ -845,7 +845,7 @@ func RemoveInterface(ctx context.Context, sandboxID string, inf *types.Interface
 }
 
 // ListInterfaces is the virtcontainers list interfaces entry point.
-func ListInterfaces(ctx context.Context, sandboxID string) ([]*types.Interface, error) {
+func ListInterfaces(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error) {
 	span, ctx := trace(ctx, "ListInterfaces")
 	defer span.Finish()
 
@@ -869,7 +869,7 @@ func ListInterfaces(ctx context.Context, sandboxID string) ([]*types.Interface, 
 }
 
 // UpdateRoutes is the virtcontainers update routes entry point.
-func UpdateRoutes(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error) {
+func UpdateRoutes(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	span, ctx := trace(ctx, "UpdateRoutes")
 	defer span.Finish()
 
@@ -893,7 +893,7 @@ func UpdateRoutes(ctx context.Context, sandboxID string, routes []*types.Route) 
 }
 
 // ListRoutes is the virtcontainers list routes entry point.
-func ListRoutes(ctx context.Context, sandboxID string) ([]*types.Route, error) {
+func ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error) {
 	span, ctx := trace(ctx, "ListRoutes")
 	defer span.Finish()
 

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -2422,12 +2422,12 @@ func TestNetworkOperation(t *testing.T) {
 	cleanUp()
 
 	assert := assert.New(t)
-	inf := &types.Interface{
+	inf := &vcTypes.Interface{
 		Name:   "eno1",
 		Mtu:    1500,
 		HwAddr: "02:00:ca:fe:00:48",
 	}
-	ip := types.IPAddress{
+	ip := vcTypes.IPAddress{
 		Family:  0,
 		Address: "192.168.0.101",
 		Mask:    "24",

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,15 +39,15 @@ var containerAnnotations = map[string]string{
 	"container.hello": "container.world",
 }
 
-func newBasicTestCmd() Cmd {
-	envs := []EnvVar{
+func newBasicTestCmd() types.Cmd {
+	envs := []types.EnvVar{
 		{
 			Var:   "PATH",
 			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
 		},
 	}
 
-	cmd := Cmd{
+	cmd := types.Cmd{
 		Args:    strings.Split("/bin/sh", " "),
 		Envs:    envs,
 		WorkDir: "/",
@@ -581,7 +582,7 @@ func TestPauseThenResumeSandboxNoopAgentSuccessful(t *testing.T) {
 	pImpl, ok := p.(*Sandbox)
 	assert.True(t, ok)
 
-	expectedState := StatePaused
+	expectedState := types.StatePaused
 
 	assert.Equal(t, pImpl.state.State, expectedState, "unexpected paused sandbox state")
 
@@ -601,7 +602,7 @@ func TestPauseThenResumeSandboxNoopAgentSuccessful(t *testing.T) {
 	pImpl, ok = p.(*Sandbox)
 	assert.True(t, ok)
 
-	expectedState = StateRunning
+	expectedState = types.StateRunning
 
 	assert.Equal(t, pImpl.state.State, expectedState, "unexpected resumed sandbox state")
 
@@ -868,8 +869,8 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 
 	expectedStatus := SandboxStatus{
 		ID: testSandboxID,
-		State: State{
-			State: StateReady,
+		State: types.State{
+			State: types.StateReady,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
@@ -878,8 +879,8 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
-				State: State{
-					State: StateReady,
+				State: types.State{
+					State: types.StateReady,
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -926,8 +927,8 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 
 	expectedStatus := SandboxStatus{
 		ID: testSandboxID,
-		State: State{
-			State: StateRunning,
+		State: types.State{
+			State: types.StateRunning,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
@@ -936,8 +937,8 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
-				State: State{
-					State: StateRunning,
+				State: types.State{
+					State: types.StateRunning,
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -1776,8 +1777,8 @@ func TestStatusContainerStateReady(t *testing.T) {
 
 	expectedStatus := ContainerStatus{
 		ID: contID,
-		State: State{
-			State: StateReady,
+		State: types.State{
+			State: types.StateReady,
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),
@@ -1851,8 +1852,8 @@ func TestStatusContainerStateRunning(t *testing.T) {
 
 	expectedStatus := ContainerStatus{
 		ID: contID,
-		State: State{
-			State: StateRunning,
+		State: types.State{
+			State: types.StateRunning,
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),
@@ -2044,14 +2045,14 @@ func createNewSandboxConfig(hType HypervisorType, aType AgentType, aConfig inter
 func createNewContainerConfigs(numOfContainers int) []ContainerConfig {
 	var contConfigs []ContainerConfig
 
-	envs := []EnvVar{
+	envs := []types.EnvVar{
 		{
 			Var:   "PATH",
 			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
 		},
 	}
 
-	cmd := Cmd{
+	cmd := types.Cmd{
 		Args:    strings.Split("/bin/ps -A", " "),
 		Envs:    envs,
 		WorkDir: "/",

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -289,8 +290,8 @@ func TestCheckSandboxRunningNotRunningFailure(t *testing.T) {
 func TestCheckSandboxRunningSuccessful(t *testing.T) {
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
@@ -302,24 +303,24 @@ func TestContainerEnterErrorsOnContainerStates(t *testing.T) {
 	assert := assert.New(t)
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
-	cmd := Cmd{}
+	cmd := types.Cmd{}
 
 	// Container state undefined
 	_, err := c.enter(cmd)
 	assert.Error(err)
 
 	// Container paused
-	c.state.State = StatePaused
+	c.state.State = types.StatePaused
 	_, err = c.enter(cmd)
 	assert.Error(err)
 
 	// Container stopped
-	c.state.State = StateStopped
+	c.state.State = types.StateStopped
 	_, err = c.enter(cmd)
 	assert.Error(err)
 }
@@ -328,8 +329,8 @@ func TestContainerWaitErrorState(t *testing.T) {
 	assert := assert.New(t)
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
@@ -340,12 +341,12 @@ func TestContainerWaitErrorState(t *testing.T) {
 	assert.Error(err)
 
 	// Container paused
-	c.state.State = StatePaused
+	c.state.State = types.StatePaused
 	_, err = c.wait(processID)
 	assert.Error(err)
 
 	// Container stopped
-	c.state.State = StateStopped
+	c.state.State = types.StateStopped
 	_, err = c.wait(processID)
 	assert.Error(err)
 }
@@ -354,8 +355,8 @@ func TestKillContainerErrorState(t *testing.T) {
 	assert := assert.New(t)
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
@@ -364,7 +365,7 @@ func TestKillContainerErrorState(t *testing.T) {
 	assert.Error(err)
 
 	// Container stopped
-	c.state.State = StateStopped
+	c.state.State = types.StateStopped
 	err = c.kill(syscall.SIGKILL, true)
 	assert.Error(err)
 }
@@ -373,8 +374,8 @@ func TestWinsizeProcessErrorState(t *testing.T) {
 	assert := assert.New(t)
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
@@ -385,12 +386,12 @@ func TestWinsizeProcessErrorState(t *testing.T) {
 	assert.Error(err)
 
 	// Container paused
-	c.state.State = StatePaused
+	c.state.State = types.StatePaused
 	err = c.winsizeProcess(processID, 100, 200)
 	assert.Error(err)
 
 	// Container stopped
-	c.state.State = StateStopped
+	c.state.State = types.StateStopped
 	err = c.winsizeProcess(processID, 100, 200)
 	assert.Error(err)
 }
@@ -399,8 +400,8 @@ func TestProcessIOStream(t *testing.T) {
 	assert := assert.New(t)
 	c := &Container{
 		sandbox: &Sandbox{
-			state: State{
-				State: StateRunning,
+			state: types.State{
+				State: types.StateRunning,
 			},
 		},
 	}
@@ -411,12 +412,12 @@ func TestProcessIOStream(t *testing.T) {
 	assert.Error(err)
 
 	// Container paused
-	c.state.State = StatePaused
+	c.state.State = types.StatePaused
 	_, _, _, err = c.ioStream(processID)
 	assert.Error(err)
 
 	// Container stopped
-	c.state.State = StateStopped
+	c.state.State = types.StateStopped
 	_, _, _, err = c.ioStream(processID)
 	assert.Error(err)
 }

--- a/virtcontainers/example_pod_run_test.go
+++ b/virtcontainers/example_pod_run_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 const containerRootfs = "/var/lib/container/bundle/"
@@ -18,14 +19,14 @@ const containerRootfs = "/var/lib/container/bundle/"
 // This example creates and starts a single container sandbox,
 // using qemu as the hypervisor and hyperstart as the VM agent.
 func Example_createAndStartSandbox() {
-	envs := []vc.EnvVar{
+	envs := []types.EnvVar{
 		{
 			Var:   "PATH",
 			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
 		},
 	}
 
-	cmd := vc.Cmd{
+	cmd := types.Cmd{
 		Args:    strings.Split("/bin/sh", " "),
 		Envs:    envs,
 		WorkDir: "/",

--- a/virtcontainers/filesystem_resource_storage.go
+++ b/virtcontainers/filesystem_resource_storage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 // sandboxResource is an int representing a sandbox resource type.
@@ -630,7 +631,7 @@ func (fs *filesystem) storeResource(sandboxSpecific bool, sandboxID, containerID
 	case SandboxConfig, ContainerConfig:
 		return fs.storeSandboxAndContainerConfigResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
-	case State:
+	case types.State:
 		return fs.storeStateResource(sandboxSpecific, sandboxID, containerID, resource, file)
 
 	case NetworkNamespace:
@@ -690,11 +691,11 @@ func (fs *filesystem) fetchSandboxConfig(sandboxID string) (SandboxConfig, error
 	return sandboxConfig, nil
 }
 
-func (fs *filesystem) fetchSandboxState(sandboxID string) (State, error) {
-	var state State
+func (fs *filesystem) fetchSandboxState(sandboxID string) (types.State, error) {
+	var state types.State
 
 	if err := fs.fetchResource(true, sandboxID, "", stateFileType, &state); err != nil {
-		return State{}, err
+		return types.State{}, err
 	}
 
 	return state, nil
@@ -797,11 +798,11 @@ func (fs *filesystem) fetchContainerConfig(sandboxID, containerID string) (Conta
 	return config, nil
 }
 
-func (fs *filesystem) fetchContainerState(sandboxID, containerID string) (State, error) {
-	var state State
+func (fs *filesystem) fetchContainerState(sandboxID, containerID string) (types.State, error) {
+	var state types.State
 
 	if err := fs.fetchResource(false, sandboxID, containerID, stateFileType, &state); err != nil {
-		return State{}, err
+		return types.State{}, err
 	}
 
 	return state, nil

--- a/virtcontainers/filesystem_resource_storage_test.go
+++ b/virtcontainers/filesystem_resource_storage_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
@@ -520,7 +521,7 @@ func TestFilesystemStoreResourceFailingContainerConfigResourceURI(t *testing.T) 
 
 func TestFilesystemStoreResourceFailingStateConfigFileType(t *testing.T) {
 	fs := &filesystem{}
-	data := State{}
+	data := types.State{}
 
 	for _, b := range []bool{true, false} {
 		err := fs.storeResource(b, testSandboxID, "100", configFileType, data)
@@ -532,7 +533,7 @@ func TestFilesystemStoreResourceFailingStateConfigFileType(t *testing.T) {
 
 func TestFilesystemStoreResourceFailingStateResourceURI(t *testing.T) {
 	fs := &filesystem{}
-	data := State{}
+	data := types.State{}
 
 	for _, b := range []bool{true, false} {
 		err := fs.storeResource(b, "", "100", stateFileType, data)

--- a/virtcontainers/hack/virtc/main.go
+++ b/virtcontainers/hack/virtc/main.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
@@ -582,14 +583,14 @@ func createContainer(context *cli.Context) error {
 		interactive = true
 	}
 
-	envs := []vc.EnvVar{
+	envs := []types.EnvVar{
 		{
 			Var:   "PATH",
 			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
 		},
 	}
 
-	cmd := vc.Cmd{
+	cmd := types.Cmd{
 		Args:        strings.Split(context.String("cmd"), " "),
 		Envs:        envs,
 		WorkDir:     "/",
@@ -660,14 +661,14 @@ func enterContainer(context *cli.Context) error {
 		interactive = true
 	}
 
-	envs := []vc.EnvVar{
+	envs := []types.EnvVar{
 		{
 			Var:   "PATH",
 			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
 		},
 	}
 
-	cmd := vc.Cmd{
+	cmd := types.Cmd{
 		Args:        strings.Split(context.String("cmd"), " "),
 		Envs:        envs,
 		WorkDir:     "/",

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -22,7 +22,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/hyperstart"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -890,22 +890,22 @@ func (h *hyper) onlineCPUMem(cpus uint32, cpuOnly bool) error {
 	return nil
 }
 
-func (h *hyper) updateInterface(inf *types.Interface) (*types.Interface, error) {
+func (h *hyper) updateInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	// hyperstart-agent does not support update interface
 	return nil, nil
 }
 
-func (h *hyper) listInterfaces() ([]*types.Interface, error) {
+func (h *hyper) listInterfaces() ([]*vcTypes.Interface, error) {
 	// hyperstart-agent does not support list interfaces
 	return nil, nil
 }
 
-func (h *hyper) updateRoutes(routes []*types.Route) ([]*types.Route, error) {
+func (h *hyper) updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	// hyperstart-agent does not support update routes
 	return nil, nil
 }
 
-func (h *hyper) listRoutes() ([]*types.Route, error) {
+func (h *hyper) listRoutes() ([]*vcTypes.Route, error) {
 	// hyperstart-agent does not support list routes
 	return nil, nil
 }

--- a/virtcontainers/hyperstart_agent.go
+++ b/virtcontainers/hyperstart_agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/pkg/hyperstart"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -58,7 +59,7 @@ func (h *hyper) generateSockets(sandbox *Sandbox, c HyperConfig) {
 	}
 
 	for i := 0; i < len(sandboxSocketPaths); i++ {
-		s := Socket{
+		s := types.Socket{
 			DeviceID: fmt.Sprintf(defaultDeviceIDTemplate, i),
 			ID:       fmt.Sprintf(defaultIDTemplate, i),
 			HostPath: sandboxSocketPaths[i],
@@ -83,7 +84,7 @@ type hyper struct {
 	client  *proxyClient.Client
 	state   HyperAgentState
 
-	sockets []Socket
+	sockets []types.Socket
 
 	ctx context.Context
 }
@@ -99,7 +100,7 @@ func (h *hyper) Logger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "hyper")
 }
 
-func (h *hyper) buildHyperContainerProcess(cmd Cmd) (*hyperstart.Process, error) {
+func (h *hyper) buildHyperContainerProcess(cmd types.Cmd) (*hyperstart.Process, error) {
 	var envVars []hyperstart.EnvironmentVar
 
 	for _, e := range cmd.Envs {
@@ -313,7 +314,7 @@ func (h *hyper) configure(hv hypervisor, id, sharePath string, builtin bool, con
 
 	// Adding the hyper shared volume.
 	// This volume contains all bind mounted container bundles.
-	sharedVolume := Volume{
+	sharedVolume := types.Volume{
 		MountTag: mountTag,
 		HostPath: sharePath,
 	}
@@ -339,7 +340,7 @@ func (h *hyper) capabilities() capabilities {
 }
 
 // exec is the agent command execution implementation for hyperstart.
-func (h *hyper) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error) {
+func (h *hyper) exec(sandbox *Sandbox, c Container, cmd types.Cmd) (*Process, error) {
 	token, err := h.attach()
 	if err != nil {
 		return nil, err
@@ -610,7 +611,7 @@ func (h *hyper) startContainer(sandbox *Sandbox, c *Container) error {
 // stopContainer is the agent Container stopping implementation for hyperstart.
 func (h *hyper) stopContainer(sandbox *Sandbox, c Container) error {
 	// Nothing to be done in case the container has not been started.
-	if c.state.State == StateReady {
+	if c.state.State == types.StateReady {
 		return nil
 	}
 
@@ -648,7 +649,7 @@ func (h *hyper) stopOneContainer(sandboxID string, c Container) error {
 func (h *hyper) signalProcess(c *Container, processID string, signal syscall.Signal, all bool) error {
 	// Send the signal to the shim directly in case the container has not
 	// been started yet.
-	if c.state.State == StateReady {
+	if c.state.State == types.StateReady {
 		return signalShim(c.process.Pid, signal)
 	}
 

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/pkg/hyperstart"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 )
@@ -36,7 +37,7 @@ func TestHyperstartGenerateSocketsSuccessful(t *testing.T) {
 
 	h.generateSockets(sandbox, config)
 
-	expectedSockets := []Socket{
+	expectedSockets := []types.Socket{
 		{
 			DeviceID: fmt.Sprintf(defaultDeviceIDTemplate, 0),
 			ID:       fmt.Sprintf(defaultIDTemplate, 0),
@@ -67,7 +68,7 @@ func TestHyperstartGenerateSocketsSuccessfulNoPathProvided(t *testing.T) {
 
 	h.generateSockets(sandbox, config)
 
-	expectedSockets := []Socket{
+	expectedSockets := []types.Socket{
 		{
 			DeviceID: fmt.Sprintf(defaultDeviceIDTemplate, 0),
 			ID:       fmt.Sprintf(defaultIDTemplate, 0),

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -152,26 +152,26 @@ func (impl *VCImpl) AddDevice(ctx context.Context, sandboxID string, info config
 }
 
 // AddInterface implements the VC function of the same name.
-func (impl *VCImpl) AddInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func (impl *VCImpl) AddInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	return AddInterface(ctx, sandboxID, inf)
 }
 
 // RemoveInterface implements the VC function of the same name.
-func (impl *VCImpl) RemoveInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func (impl *VCImpl) RemoveInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	return RemoveInterface(ctx, sandboxID, inf)
 }
 
 // ListInterfaces implements the VC function of the same name.
-func (impl *VCImpl) ListInterfaces(ctx context.Context, sandboxID string) ([]*types.Interface, error) {
+func (impl *VCImpl) ListInterfaces(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error) {
 	return ListInterfaces(ctx, sandboxID)
 }
 
 // UpdateRoutes implements the VC function of the same name.
-func (impl *VCImpl) UpdateRoutes(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error) {
+func (impl *VCImpl) UpdateRoutes(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	return UpdateRoutes(ctx, sandboxID, routes)
 }
 
 // ListRoutes implements the VC function of the same name.
-func (impl *VCImpl) ListRoutes(ctx context.Context, sandboxID string) ([]*types.Route, error) {
+func (impl *VCImpl) ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error) {
 	return ListRoutes(ctx, sandboxID)
 }

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -107,7 +108,7 @@ func (impl *VCImpl) StopContainer(ctx context.Context, sandboxID, containerID st
 }
 
 // EnterContainer implements the VC function of the same name.
-func (impl *VCImpl) EnterContainer(ctx context.Context, sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error) {
+func (impl *VCImpl) EnterContainer(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (VCSandbox, VCContainer, *Process, error) {
 	return EnterContainer(ctx, sandboxID, containerID, cmd)
 }
 

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -48,11 +48,11 @@ type VC interface {
 
 	AddDevice(ctx context.Context, sandboxID string, info config.DeviceInfo) (api.Device, error)
 
-	AddInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error)
-	RemoveInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error)
-	ListInterfaces(ctx context.Context, sandboxID string) ([]*types.Interface, error)
-	UpdateRoutes(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error)
-	ListRoutes(ctx context.Context, sandboxID string) ([]*types.Route, error)
+	AddInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	RemoveInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	ListInterfaces(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error)
+	UpdateRoutes(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error)
+	ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error)
 }
 
 // VCSandbox is the Sandbox interface
@@ -93,11 +93,11 @@ type VCSandbox interface {
 
 	AddDevice(info config.DeviceInfo) (api.Device, error)
 
-	AddInterface(inf *types.Interface) (*types.Interface, error)
-	RemoveInterface(inf *types.Interface) (*types.Interface, error)
-	ListInterfaces() ([]*types.Interface, error)
-	UpdateRoutes(routes []*types.Route) ([]*types.Route, error)
-	ListRoutes() ([]*types.Route, error)
+	AddInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	RemoveInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	ListInterfaces() ([]*vcTypes.Interface, error)
+	UpdateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error)
+	ListRoutes() ([]*vcTypes.Route, error)
 }
 
 // VCContainer is the Container interface

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -35,7 +36,7 @@ type VC interface {
 
 	CreateContainer(ctx context.Context, sandboxID string, containerConfig ContainerConfig) (VCSandbox, VCContainer, error)
 	DeleteContainer(ctx context.Context, sandboxID, containerID string) (VCContainer, error)
-	EnterContainer(ctx context.Context, sandboxID, containerID string, cmd Cmd) (VCSandbox, VCContainer, *Process, error)
+	EnterContainer(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (VCSandbox, VCContainer, *Process, error)
 	KillContainer(ctx context.Context, sandboxID, containerID string, signal syscall.Signal, all bool) error
 	StartContainer(ctx context.Context, sandboxID, containerID string) (VCContainer, error)
 	StatusContainer(ctx context.Context, sandboxID, containerID string) (ContainerStatus, error)
@@ -83,7 +84,7 @@ type VCSandbox interface {
 	StatsContainer(containerID string) (ContainerStats, error)
 	PauseContainer(containerID string) error
 	ResumeContainer(containerID string) error
-	EnterContainer(containerID string, cmd Cmd) (VCContainer, *Process, error)
+	EnterContainer(containerID string, cmd types.Cmd) (VCContainer, *Process, error)
 	UpdateContainer(containerID string, resources specs.LinuxResources) error
 	ProcessListContainer(containerID string, options ProcessListOptions) (ProcessList, error)
 	WaitProcess(containerID, processID string) (int32, error)

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -27,6 +27,7 @@ import (
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	opentracing "github.com/opentracing/opentracing-go"
 
@@ -151,7 +152,7 @@ func (k *kataAgent) generateVMSocket(id string, c KataAgentConfig) error {
 			return err
 		}
 
-		k.vmSocket = Socket{
+		k.vmSocket = types.Socket{
 			DeviceID: defaultKataDeviceID,
 			ID:       defaultKataID,
 			HostPath: kataSock,
@@ -201,7 +202,7 @@ func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config interface
 
 func (k *kataAgent) agentURL() (string, error) {
 	switch s := k.vmSocket.(type) {
-	case Socket:
+	case types.Socket:
 		return s.HostPath, nil
 	case kataVSOCK:
 		return s.String(), nil
@@ -233,7 +234,7 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 	}
 
 	switch s := k.vmSocket.(type) {
-	case Socket:
+	case types.Socket:
 		err := h.addDevice(s, serialPortDev)
 		if err != nil {
 			return err
@@ -266,7 +267,7 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 
 	// Create shared directory and add the shared volume if filesystem sharing is supported.
 	// This volume contains all bind mounted container bundles.
-	sharedVolume := Volume{
+	sharedVolume := types.Volume{
 		MountTag: mountGuest9pTag,
 		HostPath: sharePath,
 	}
@@ -285,7 +286,7 @@ func (k *kataAgent) createSandbox(sandbox *Sandbox) error {
 	return k.configure(sandbox.hypervisor, sandbox.id, k.getSharePath(sandbox.id), k.proxyBuiltIn, nil)
 }
 
-func cmdToKataProcess(cmd Cmd) (process *grpc.Process, err error) {
+func cmdToKataProcess(cmd types.Cmd) (process *grpc.Process, err error) {
 	var i uint64
 	var extraGids []uint32
 
@@ -351,7 +352,7 @@ func cmdToKataProcess(cmd Cmd) (process *grpc.Process, err error) {
 	return process, nil
 }
 
-func cmdEnvsToStringSlice(ev []EnvVar) []string {
+func cmdEnvsToStringSlice(ev []types.EnvVar) []string {
 	var env []string
 
 	for _, e := range ev {
@@ -362,7 +363,7 @@ func cmdEnvsToStringSlice(ev []EnvVar) []string {
 	return env
 }
 
-func (k *kataAgent) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error) {
+func (k *kataAgent) exec(sandbox *Sandbox, c Container, cmd types.Cmd) (*Process, error) {
 	span, _ := k.trace("exec")
 	defer span.Finish()
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -398,7 +398,7 @@ func (k *kataAgent) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, erro
 		k.state.URL, cmd, []ns.NSType{}, enterNSList)
 }
 
-func (k *kataAgent) updateInterface(ifc *types.Interface) (*types.Interface, error) {
+func (k *kataAgent) updateInterface(ifc *vcTypes.Interface) (*vcTypes.Interface, error) {
 	// send update interface request
 	ifcReq := &grpc.UpdateInterfaceRequest{
 		Interface: k.convertToKataAgentInterface(ifc),
@@ -410,13 +410,13 @@ func (k *kataAgent) updateInterface(ifc *types.Interface) (*types.Interface, err
 			"resulting-interface": fmt.Sprintf("%+v", resultingInterface),
 		}).WithError(err).Error("update interface request failed")
 	}
-	if resultInterface, ok := resultingInterface.(*types.Interface); ok {
+	if resultInterface, ok := resultingInterface.(*vcTypes.Interface); ok {
 		return resultInterface, err
 	}
 	return nil, err
 }
 
-func (k *kataAgent) updateInterfaces(interfaces []*types.Interface) error {
+func (k *kataAgent) updateInterfaces(interfaces []*vcTypes.Interface) error {
 	for _, ifc := range interfaces {
 		if _, err := k.updateInterface(ifc); err != nil {
 			return err
@@ -425,7 +425,7 @@ func (k *kataAgent) updateInterfaces(interfaces []*types.Interface) error {
 	return nil
 }
 
-func (k *kataAgent) updateRoutes(routes []*types.Route) ([]*types.Route, error) {
+func (k *kataAgent) updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	if routes != nil {
 		routesReq := &grpc.UpdateRoutesRequest{
 			Routes: &grpc.Routes{
@@ -448,7 +448,7 @@ func (k *kataAgent) updateRoutes(routes []*types.Route) ([]*types.Route, error) 
 	return nil, nil
 }
 
-func (k *kataAgent) listInterfaces() ([]*types.Interface, error) {
+func (k *kataAgent) listInterfaces() ([]*vcTypes.Interface, error) {
 	req := &grpc.ListInterfacesRequest{}
 	resultingInterfaces, err := k.sendReq(req)
 	if err != nil {
@@ -461,7 +461,7 @@ func (k *kataAgent) listInterfaces() ([]*types.Interface, error) {
 	return nil, err
 }
 
-func (k *kataAgent) listRoutes() ([]*types.Route, error) {
+func (k *kataAgent) listRoutes() ([]*vcTypes.Route, error) {
 	req := &grpc.ListRoutesRequest{}
 	resultingRoutes, err := k.sendReq(req)
 	if err != nil {
@@ -1664,7 +1664,7 @@ func (k *kataAgent) convertToIPFamily(ipFamily aTypes.IPFamily) int {
 	return netlink.FAMILY_V4
 }
 
-func (k *kataAgent) convertToKataAgentIPAddresses(ipAddrs []*types.IPAddress) (aIPAddrs []*aTypes.IPAddress) {
+func (k *kataAgent) convertToKataAgentIPAddresses(ipAddrs []*vcTypes.IPAddress) (aIPAddrs []*aTypes.IPAddress) {
 	for _, ipAddr := range ipAddrs {
 		if ipAddr == nil {
 			continue
@@ -1682,13 +1682,13 @@ func (k *kataAgent) convertToKataAgentIPAddresses(ipAddrs []*types.IPAddress) (a
 	return aIPAddrs
 }
 
-func (k *kataAgent) convertToIPAddresses(aIPAddrs []*aTypes.IPAddress) (ipAddrs []*types.IPAddress) {
+func (k *kataAgent) convertToIPAddresses(aIPAddrs []*aTypes.IPAddress) (ipAddrs []*vcTypes.IPAddress) {
 	for _, aIPAddr := range aIPAddrs {
 		if aIPAddr == nil {
 			continue
 		}
 
-		ipAddr := &types.IPAddress{
+		ipAddr := &vcTypes.IPAddress{
 			Family:  k.convertToIPFamily(aIPAddr.Family),
 			Address: aIPAddr.Address,
 			Mask:    aIPAddr.Mask,
@@ -1700,7 +1700,7 @@ func (k *kataAgent) convertToIPAddresses(aIPAddrs []*aTypes.IPAddress) (ipAddrs 
 	return ipAddrs
 }
 
-func (k *kataAgent) convertToKataAgentInterface(iface *types.Interface) *aTypes.Interface {
+func (k *kataAgent) convertToKataAgentInterface(iface *vcTypes.Interface) *aTypes.Interface {
 	if iface == nil {
 		return nil
 	}
@@ -1715,13 +1715,13 @@ func (k *kataAgent) convertToKataAgentInterface(iface *types.Interface) *aTypes.
 	}
 }
 
-func (k *kataAgent) convertToInterfaces(aIfaces []*aTypes.Interface) (ifaces []*types.Interface) {
+func (k *kataAgent) convertToInterfaces(aIfaces []*aTypes.Interface) (ifaces []*vcTypes.Interface) {
 	for _, aIface := range aIfaces {
 		if aIface == nil {
 			continue
 		}
 
-		iface := &types.Interface{
+		iface := &vcTypes.Interface{
 			Device:      aIface.Device,
 			Name:        aIface.Name,
 			IPAddresses: k.convertToIPAddresses(aIface.IPAddresses),
@@ -1736,7 +1736,7 @@ func (k *kataAgent) convertToInterfaces(aIfaces []*aTypes.Interface) (ifaces []*
 	return ifaces
 }
 
-func (k *kataAgent) convertToKataAgentRoutes(routes []*types.Route) (aRoutes []*aTypes.Route) {
+func (k *kataAgent) convertToKataAgentRoutes(routes []*vcTypes.Route) (aRoutes []*aTypes.Route) {
 	for _, route := range routes {
 		if route == nil {
 			continue
@@ -1756,13 +1756,13 @@ func (k *kataAgent) convertToKataAgentRoutes(routes []*types.Route) (aRoutes []*
 	return aRoutes
 }
 
-func (k *kataAgent) convertToRoutes(aRoutes []*aTypes.Route) (routes []*types.Route) {
+func (k *kataAgent) convertToRoutes(aRoutes []*aTypes.Route) (routes []*vcTypes.Route) {
 	for _, aRoute := range aRoutes {
 		if aRoute == nil {
 			continue
 		}
 
-		route := &types.Route{
+		route := &vcTypes.Route{
 			Dest:    aRoute.Dest,
 			Gateway: aRoute.Gateway,
 			Device:  aRoute.Device,

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 )
 
 var (
@@ -817,7 +817,7 @@ func TestAgentNetworkOperation(t *testing.T) {
 	_, err = k.listInterfaces()
 	assert.Nil(err)
 
-	_, err = k.updateRoutes([]*types.Route{})
+	_, err = k.updateRoutes([]*vcTypes.Route{})
 	assert.Nil(err)
 
 	_, err = k.listRoutes()

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -32,6 +32,7 @@ import (
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 var (
@@ -637,7 +638,7 @@ func TestAgentPathAPI(t *testing.T) {
 
 	err = k1.generateVMSocket(id, c)
 	assert.Nil(err)
-	_, ok := k1.vmSocket.(Socket)
+	_, ok := k1.vmSocket.(types.Socket)
 	assert.True(ok)
 
 	c.UseVSock = true
@@ -676,9 +677,9 @@ func TestAgentConfigure(t *testing.T) {
 func TestCmdToKataProcess(t *testing.T) {
 	assert := assert.New(t)
 
-	cmd := Cmd{
+	cmd := types.Cmd{
 		Args:         strings.Split("foo", " "),
-		Envs:         []EnvVar{},
+		Envs:         []types.EnvVar{},
 		WorkDir:      "/",
 		User:         "1000",
 		PrimaryGroup: "1000",
@@ -738,7 +739,7 @@ func TestAgentCreateContainer(t *testing.T) {
 		id:        "barfoo",
 		sandboxID: "foobar",
 		sandbox:   sandbox,
-		state: State{
+		state: types.State{
 			Fstype: "xfs",
 		},
 		config: &ContainerConfig{

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -1196,18 +1196,18 @@ func deleteNetNS(netNSPath string) error {
 	return nil
 }
 
-func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*types.Interface, []*types.Route, error) {
+func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*vcTypes.Interface, []*vcTypes.Route, error) {
 
 	if networkNS.NetNsPath == "" {
 		return nil, nil, nil
 	}
 
-	var routes []*types.Route
-	var ifaces []*types.Interface
+	var routes []*vcTypes.Route
+	var ifaces []*vcTypes.Interface
 
 	for _, endpoint := range networkNS.Endpoints {
 
-		var ipAddresses []*types.IPAddress
+		var ipAddresses []*vcTypes.IPAddress
 		for _, addr := range endpoint.Properties().Addrs {
 			// Skip IPv6 because not supported
 			if addr.IP.To4() == nil {
@@ -1223,14 +1223,14 @@ func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*types.Interface
 				continue
 			}
 			netMask, _ := addr.Mask.Size()
-			ipAddress := types.IPAddress{
+			ipAddress := vcTypes.IPAddress{
 				Family:  netlink.FAMILY_V4,
 				Address: addr.IP.String(),
 				Mask:    fmt.Sprintf("%d", netMask),
 			}
 			ipAddresses = append(ipAddresses, &ipAddress)
 		}
-		ifc := types.Interface{
+		ifc := vcTypes.Interface{
 			IPAddresses: ipAddresses,
 			Device:      endpoint.Name(),
 			Name:        endpoint.Name(),
@@ -1242,7 +1242,7 @@ func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*types.Interface
 		ifaces = append(ifaces, &ifc)
 
 		for _, route := range endpoint.Properties().Routes {
-			var r types.Route
+			var r vcTypes.Route
 
 			if route.Dst != nil {
 				r.Dest = route.Dst.String()

--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 )
@@ -161,16 +161,16 @@ func TestGenerateInterfacesAndRoutes(t *testing.T) {
 	//
 	// Build expected results:
 	//
-	expectedAddresses := []*types.IPAddress{
+	expectedAddresses := []*vcTypes.IPAddress{
 		{Family: netlink.FAMILY_V4, Address: "172.17.0.2", Mask: "16"},
 		{Family: netlink.FAMILY_V4, Address: "182.17.0.2", Mask: "16"},
 	}
 
-	expectedInterfaces := []*types.Interface{
+	expectedInterfaces := []*vcTypes.Interface{
 		{Device: "eth0", Name: "eth0", IPAddresses: expectedAddresses, Mtu: 1500, HwAddr: "02:00:ca:fe:00:04"},
 	}
 
-	expectedRoutes := []*types.Route{
+	expectedRoutes := []*vcTypes.Route{
 		{Dest: "", Gateway: "172.17.0.1", Device: "eth0", Source: "", Scope: uint32(254)},
 		{Dest: "172.17.0.0/16", Gateway: "172.17.0.1", Device: "eth0", Source: "172.17.0.2"},
 	}

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/kata-containers/agent/protocols/grpc"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
 )
@@ -96,22 +96,22 @@ func (n *noopAgent) onlineCPUMem(cpus uint32, cpuOnly bool) error {
 }
 
 // updateInterface is the Noop agent Interface update implementation. It does nothing.
-func (n *noopAgent) updateInterface(inf *types.Interface) (*types.Interface, error) {
+func (n *noopAgent) updateInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	return nil, nil
 }
 
 // listInterfaces is the Noop agent Interfaces list implementation. It does nothing.
-func (n *noopAgent) listInterfaces() ([]*types.Interface, error) {
+func (n *noopAgent) listInterfaces() ([]*vcTypes.Interface, error) {
 	return nil, nil
 }
 
 // updateRoutes is the Noop agent Routes update implementation. It does nothing.
-func (n *noopAgent) updateRoutes(routes []*types.Route) ([]*types.Route, error) {
+func (n *noopAgent) updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	return nil, nil
 }
 
 // listRoutes is the Noop agent Routes list implementation. It does nothing.
-func (n *noopAgent) listRoutes() ([]*types.Route, error) {
+func (n *noopAgent) listRoutes() ([]*vcTypes.Route, error) {
 	return nil, nil
 }
 

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kata-containers/agent/protocols/grpc"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
 )
@@ -46,7 +47,7 @@ func (n *noopAgent) disconnect() error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(sandbox *Sandbox, c Container, cmd Cmd) (*Process, error) {
+func (n *noopAgent) exec(sandbox *Sandbox, c Container, cmd types.Cmd) (*Process, error) {
 	return nil, nil
 }
 

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +46,7 @@ func TestNoopAgentInit(t *testing.T) {
 
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
-	cmd := Cmd{}
+	cmd := types.Cmd{}
 	sandbox, container, err := testCreateNoopContainer()
 	if err != nil {
 		t.Fatal(err)

--- a/virtcontainers/noop_resource_storage.go
+++ b/virtcontainers/noop_resource_storage.go
@@ -7,6 +7,7 @@ package virtcontainers
 
 import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 type noopResourceStorage struct{}
@@ -35,8 +36,8 @@ func (n *noopResourceStorage) fetchSandboxConfig(sandboxID string) (SandboxConfi
 	return SandboxConfig{}, nil
 }
 
-func (n *noopResourceStorage) fetchSandboxState(sandboxID string) (State, error) {
-	return State{}, nil
+func (n *noopResourceStorage) fetchSandboxState(sandboxID string) (types.State, error) {
+	return types.State{}, nil
 }
 
 func (n *noopResourceStorage) fetchSandboxNetwork(sandboxID string) (NetworkNamespace, error) {
@@ -83,8 +84,8 @@ func (n *noopResourceStorage) fetchContainerConfig(sandboxID, containerID string
 	return ContainerConfig{}, nil
 }
 
-func (n *noopResourceStorage) fetchContainerState(sandboxID, containerID string) (State, error) {
-	return State{}, nil
+func (n *noopResourceStorage) fetchContainerState(sandboxID, containerID string) (types.State, error) {
+	return types.State{}, nil
 }
 
 func (n *noopResourceStorage) fetchContainerProcess(sandboxID, containerID string) (Process, error) {

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	dockershimAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations/dockershim"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 type annotationContainerType struct {
@@ -146,7 +147,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 	ociLog = logger.WithFields(fields)
 }
 
-func cmdEnvs(spec CompatOCISpec, envs []vc.EnvVar) []vc.EnvVar {
+func cmdEnvs(spec CompatOCISpec, envs []types.EnvVar) []types.EnvVar {
 	for _, env := range spec.Process.Env {
 		kv := strings.Split(env, "=")
 		if len(kv) < 2 {
@@ -154,7 +155,7 @@ func cmdEnvs(spec CompatOCISpec, envs []vc.EnvVar) []vc.EnvVar {
 		}
 
 		envs = append(envs,
-			vc.EnvVar{
+			types.EnvVar{
 				Var:   kv[0],
 				Value: kv[1],
 			})
@@ -248,9 +249,9 @@ func containerDeviceInfos(spec CompatOCISpec) ([]config.DeviceInfo, error) {
 	return devices, nil
 }
 
-func containerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
+func containerCapabilities(s CompatOCISpec) (types.LinuxCapabilities, error) {
 	capabilities := s.Process.Capabilities
-	var c vc.LinuxCapabilities
+	var c types.LinuxCapabilities
 
 	// In spec v1.0.0-rc4, capabilities was a list of strings. This was changed
 	// to an object with v1.0.0-rc5.
@@ -289,7 +290,7 @@ func containerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
 			list = append(list, str.(string))
 		}
 
-		c = vc.LinuxCapabilities{
+		c = types.LinuxCapabilities{
 			Bounding:    list,
 			Effective:   list,
 			Inheritable: list,
@@ -307,9 +308,9 @@ func containerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
 }
 
 // ContainerCapabilities return a LinuxCapabilities for virtcontainer
-func ContainerCapabilities(s CompatOCISpec) (vc.LinuxCapabilities, error) {
+func ContainerCapabilities(s CompatOCISpec) (types.LinuxCapabilities, error) {
 	if s.Process == nil {
-		return vc.LinuxCapabilities{}, fmt.Errorf("ContainerCapabilities, Process is nil")
+		return types.LinuxCapabilities{}, fmt.Errorf("ContainerCapabilities, Process is nil")
 	}
 	return containerCapabilities(s)
 }
@@ -516,9 +517,9 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 	}
 	ociLog.Debugf("container rootfs: %s", rootfs)
 
-	cmd := vc.Cmd{
+	cmd := types.Cmd{
 		Args:            ocispec.Process.Args,
-		Envs:            cmdEnvs(ocispec, []vc.EnvVar{}),
+		Envs:            cmdEnvs(ocispec, []types.EnvVar{}),
 		WorkDir:         ocispec.Process.Cwd,
 		User:            strconv.FormatUint(uint64(ocispec.Process.User.UID), 10),
 		PrimaryGroup:    strconv.FormatUint(uint64(ocispec.Process.User.GID), 10),
@@ -539,7 +540,7 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 	}
 
 	if ocispec.Process != nil {
-		caps, ok := ocispec.Process.Capabilities.(vc.LinuxCapabilities)
+		caps, ok := ocispec.Process.Capabilities.(types.LinuxCapabilities)
 		if !ok {
 			return vc.ContainerConfig{}, fmt.Errorf("Unexpected format for capabilities: %v", ocispec.Process.Capabilities)
 		}
@@ -609,15 +610,15 @@ func StatusToOCIState(status vc.ContainerStatus) spec.State {
 }
 
 // StateToOCIState translates a virtcontainers container state into an OCI one.
-func StateToOCIState(state vc.State) string {
+func StateToOCIState(state types.State) string {
 	switch state.State {
-	case vc.StateReady:
+	case types.StateReady:
 		return StateCreated
-	case vc.StateRunning:
+	case types.StateRunning:
 		return StateRunning
-	case vc.StateStopped:
+	case types.StateStopped:
 		return StateStopped
-	case vc.StatePaused:
+	case types.StatePaused:
 		return StatePaused
 	default:
 		return ""
@@ -626,8 +627,8 @@ func StateToOCIState(state vc.State) string {
 
 // EnvVars converts an OCI process environment variables slice
 // into a virtcontainers EnvVar slice.
-func EnvVars(envs []string) ([]vc.EnvVar, error) {
-	var envVars []vc.EnvVar
+func EnvVars(envs []string) ([]types.EnvVar, error) {
+	var envVars []types.EnvVar
 
 	envDelimiter := "="
 	expectedEnvLen := 2
@@ -636,17 +637,17 @@ func EnvVars(envs []string) ([]vc.EnvVar, error) {
 		envSlice := strings.SplitN(env, envDelimiter, expectedEnvLen)
 
 		if len(envSlice) < expectedEnvLen {
-			return []vc.EnvVar{}, fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q",
+			return []types.EnvVar{}, fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q",
 				env, expectedEnvLen, envDelimiter)
 		}
 
 		if envSlice[0] == "" {
-			return []vc.EnvVar{}, fmt.Errorf("Environment variable cannot be empty")
+			return []types.EnvVar{}, fmt.Errorf("Environment variable cannot be empty")
 		}
 
 		envSlice[1] = strings.Trim(envSlice[1], "' ")
 
-		envVar := vc.EnvVar{
+		envVar := types.EnvVar{
 			Var:   envSlice[0],
 			Value: envSlice[1],
 		}

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -24,6 +24,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 const (
@@ -114,9 +115,9 @@ func TestMinimalSandboxConfig(t *testing.T) {
 
 	capList := []string{"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"}
 
-	expectedCmd := vc.Cmd{
+	expectedCmd := types.Cmd{
 		Args: []string{"sh"},
-		Envs: []vc.EnvVar{
+		Envs: []types.EnvVar{
 			{
 				Var:   "PATH",
 				Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -133,7 +134,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 		Interactive:         true,
 		Console:             consolePath,
 		NoNewPrivileges:     true,
-		Capabilities: vc.LinuxCapabilities{
+		Capabilities: types.LinuxCapabilities{
 			Bounding:    capList,
 			Effective:   capList,
 			Inheritable: capList,
@@ -271,8 +272,8 @@ func TestStatusToOCIStateSuccessfulWithReadyState(t *testing.T) {
 	testPID := 12345
 	testRootFs := "testRootFs"
 
-	state := vc.State{
-		State: vc.StateReady,
+	state := types.State{
+		State: types.StateReady,
 	}
 
 	containerAnnotations := map[string]string{
@@ -307,8 +308,8 @@ func TestStatusToOCIStateSuccessfulWithRunningState(t *testing.T) {
 	testPID := 12345
 	testRootFs := "testRootFs"
 
-	state := vc.State{
-		State: vc.StateRunning,
+	state := types.State{
+		State: types.StateRunning,
 	}
 
 	containerAnnotations := map[string]string{
@@ -342,8 +343,8 @@ func TestStatusToOCIStateSuccessfulWithStoppedState(t *testing.T) {
 	testPID := 12345
 	testRootFs := "testRootFs"
 
-	state := vc.State{
-		State: vc.StateStopped,
+	state := types.State{
+		State: types.StateStopped,
 	}
 
 	containerAnnotations := map[string]string{
@@ -403,28 +404,28 @@ func TestStatusToOCIStateSuccessfulWithNoState(t *testing.T) {
 }
 
 func TestStateToOCIState(t *testing.T) {
-	var state vc.State
+	var state types.State
 
 	if ociState := StateToOCIState(state); ociState != "" {
 		t.Fatalf("Expecting \"created\" state, got \"%s\"", ociState)
 	}
 
-	state.State = vc.StateReady
+	state.State = types.StateReady
 	if ociState := StateToOCIState(state); ociState != "created" {
 		t.Fatalf("Expecting \"created\" state, got \"%s\"", ociState)
 	}
 
-	state.State = vc.StateRunning
+	state.State = types.StateRunning
 	if ociState := StateToOCIState(state); ociState != "running" {
 		t.Fatalf("Expecting \"created\" state, got \"%s\"", ociState)
 	}
 
-	state.State = vc.StateStopped
+	state.State = types.StateStopped
 	if ociState := StateToOCIState(state); ociState != "stopped" {
 		t.Fatalf("Expecting \"created\" state, got \"%s\"", ociState)
 	}
 
-	state.State = vc.StatePaused
+	state.State = types.StatePaused
 	if ociState := StateToOCIState(state); ociState != "paused" {
 		t.Fatalf("Expecting \"paused\" state, got \"%s\"", ociState)
 	}
@@ -432,7 +433,7 @@ func TestStateToOCIState(t *testing.T) {
 
 func TestEnvVars(t *testing.T) {
 	envVars := []string{"foo=bar", "TERM=xterm", "HOME=/home/foo", "TERM=\"bar\"", "foo=\"\""}
-	expectecVcEnvVars := []vc.EnvVar{
+	expectecVcEnvVars := []types.EnvVar{
 		{
 			Var:   "foo",
 			Value: "bar",

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -173,7 +174,7 @@ func (m *VCMock) StopContainer(ctx context.Context, sandboxID, containerID strin
 }
 
 // EnterContainer implements the VC function of the same name.
-func (m *VCMock) EnterContainer(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+func (m *VCMock) EnterContainer(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 	if m.EnterContainerFunc != nil {
 		return m.EnterContainerFunc(ctx, sandboxID, containerID, cmd)
 	}

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -23,7 +23,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -254,7 +254,7 @@ func (m *VCMock) AddDevice(ctx context.Context, sandboxID string, info config.De
 }
 
 // AddInterface implements the VC function of the same name.
-func (m *VCMock) AddInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func (m *VCMock) AddInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	if m.AddInterfaceFunc != nil {
 		return m.AddInterfaceFunc(ctx, sandboxID, inf)
 	}
@@ -263,7 +263,7 @@ func (m *VCMock) AddInterface(ctx context.Context, sandboxID string, inf *types.
 }
 
 // RemoveInterface implements the VC function of the same name.
-func (m *VCMock) RemoveInterface(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error) {
+func (m *VCMock) RemoveInterface(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	if m.RemoveInterfaceFunc != nil {
 		return m.RemoveInterfaceFunc(ctx, sandboxID, inf)
 	}
@@ -272,7 +272,7 @@ func (m *VCMock) RemoveInterface(ctx context.Context, sandboxID string, inf *typ
 }
 
 // ListInterfaces implements the VC function of the same name.
-func (m *VCMock) ListInterfaces(ctx context.Context, sandboxID string) ([]*types.Interface, error) {
+func (m *VCMock) ListInterfaces(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error) {
 	if m.ListInterfacesFunc != nil {
 		return m.ListInterfacesFunc(ctx, sandboxID)
 	}
@@ -281,7 +281,7 @@ func (m *VCMock) ListInterfaces(ctx context.Context, sandboxID string) ([]*types
 }
 
 // UpdateRoutes implements the VC function of the same name.
-func (m *VCMock) UpdateRoutes(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error) {
+func (m *VCMock) UpdateRoutes(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	if m.UpdateRoutesFunc != nil {
 		return m.UpdateRoutesFunc(ctx, sandboxID, routes)
 	}
@@ -290,7 +290,7 @@ func (m *VCMock) UpdateRoutes(ctx context.Context, sandboxID string, routes []*t
 }
 
 // ListRoutes implements the VC function of the same name.
-func (m *VCMock) ListRoutes(ctx context.Context, sandboxID string) ([]*types.Route, error) {
+func (m *VCMock) ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error) {
 	if m.ListRoutesFunc != nil {
 		return m.ListRoutesFunc(ctx, sandboxID)
 	}

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -13,7 +13,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -748,7 +748,7 @@ func TestVCMockAddInterface(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.AddInterfaceFunc = func(ctx context.Context, sid string, inf *types.Interface) (*types.Interface, error) {
+	m.AddInterfaceFunc = func(ctx context.Context, sid string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 		return nil, nil
 	}
 
@@ -775,7 +775,7 @@ func TestVCMockRemoveInterface(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.RemoveInterfaceFunc = func(ctx context.Context, sid string, inf *types.Interface) (*types.Interface, error) {
+	m.RemoveInterfaceFunc = func(ctx context.Context, sid string, inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 		return nil, nil
 	}
 
@@ -802,7 +802,7 @@ func TestVCMockListInterfaces(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.ListInterfacesFunc = func(ctx context.Context, sid string) ([]*types.Interface, error) {
+	m.ListInterfacesFunc = func(ctx context.Context, sid string) ([]*vcTypes.Interface, error) {
 		return nil, nil
 	}
 
@@ -829,7 +829,7 @@ func TestVCMockUpdateRoutes(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.UpdateRoutesFunc = func(ctx context.Context, sid string, routes []*types.Route) ([]*types.Route, error) {
+	m.UpdateRoutesFunc = func(ctx context.Context, sid string, routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 		return nil, nil
 	}
 
@@ -856,7 +856,7 @@ func TestVCMockListRoutes(t *testing.T) {
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.ListRoutesFunc = func(ctx context.Context, sid string) ([]*types.Route, error) {
+	m.ListRoutesFunc = func(ctx context.Context, sid string) ([]*vcTypes.Route, error) {
 		return nil, nil
 	}
 

--- a/virtcontainers/pkg/vcmock/mock_test.go
+++ b/virtcontainers/pkg/vcmock/mock_test.go
@@ -14,6 +14,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -421,12 +422,12 @@ func TestVCMockEnterContainer(t *testing.T) {
 	assert.Nil(m.EnterContainerFunc)
 
 	ctx := context.Background()
-	cmd := vc.Cmd{}
+	cmd := types.Cmd{}
 	_, _, _, err := m.EnterContainer(ctx, testSandboxID, testContainerID, cmd)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
+	m.EnterContainerFunc = func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error) {
 		return &Sandbox{}, &Container{}, &vc.Process{}, nil
 	}
 

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -12,7 +12,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -188,26 +188,26 @@ func (s *Sandbox) AddDevice(info config.DeviceInfo) (api.Device, error) {
 }
 
 // AddInterface implements the VCSandbox function of the same name.
-func (s *Sandbox) AddInterface(inf *types.Interface) (*types.Interface, error) {
+func (s *Sandbox) AddInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	return nil, nil
 }
 
 // RemoveInterface implements the VCSandbox function of the same name.
-func (s *Sandbox) RemoveInterface(inf *types.Interface) (*types.Interface, error) {
+func (s *Sandbox) RemoveInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	return nil, nil
 }
 
 // ListInterfaces implements the VCSandbox function of the same name.
-func (s *Sandbox) ListInterfaces() ([]*types.Interface, error) {
+func (s *Sandbox) ListInterfaces() ([]*vcTypes.Interface, error) {
 	return nil, nil
 }
 
 // UpdateRoutes implements the VCSandbox function of the same name.
-func (s *Sandbox) UpdateRoutes(routes []*types.Route) ([]*types.Route, error) {
+func (s *Sandbox) UpdateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	return nil, nil
 }
 
 // ListRoutes implements the VCSandbox function of the same name.
-func (s *Sandbox) ListRoutes() ([]*types.Route, error) {
+func (s *Sandbox) ListRoutes() ([]*vcTypes.Route, error) {
 	return nil, nil
 }

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -143,7 +144,7 @@ func (s *Sandbox) Status() vc.SandboxStatus {
 }
 
 // EnterContainer implements the VCSandbox function of the same name.
-func (s *Sandbox) EnterContainer(containerID string, cmd vc.Cmd) (vc.VCContainer, *vc.Process, error) {
+func (s *Sandbox) EnterContainer(containerID string, cmd types.Cmd) (vc.VCContainer, *vc.Process, error) {
 	return &Container{}, &vc.Process{}, nil
 }
 

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -57,7 +58,7 @@ type VCMock struct {
 
 	CreateContainerFunc      func(ctx context.Context, sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error)
 	DeleteContainerFunc      func(ctx context.Context, sandboxID, containerID string) (vc.VCContainer, error)
-	EnterContainerFunc       func(ctx context.Context, sandboxID, containerID string, cmd vc.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error)
+	EnterContainerFunc       func(ctx context.Context, sandboxID, containerID string, cmd types.Cmd) (vc.VCSandbox, vc.VCContainer, *vc.Process, error)
 	KillContainerFunc        func(ctx context.Context, sandboxID, containerID string, signal syscall.Signal, all bool) error
 	StartContainerFunc       func(ctx context.Context, sandboxID, containerID string) (vc.VCContainer, error)
 	StatusContainerFunc      func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error)

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -12,7 +12,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -69,9 +69,9 @@ type VCMock struct {
 
 	AddDeviceFunc func(ctx context.Context, sandboxID string, info config.DeviceInfo) (api.Device, error)
 
-	AddInterfaceFunc    func(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error)
-	RemoveInterfaceFunc func(ctx context.Context, sandboxID string, inf *types.Interface) (*types.Interface, error)
-	ListInterfacesFunc  func(ctx context.Context, sandboxID string) ([]*types.Interface, error)
-	UpdateRoutesFunc    func(ctx context.Context, sandboxID string, routes []*types.Route) ([]*types.Route, error)
-	ListRoutesFunc      func(ctx context.Context, sandboxID string) ([]*types.Route, error)
+	AddInterfaceFunc    func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	RemoveInterfaceFunc func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	ListInterfacesFunc  func(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error)
+	UpdateRoutesFunc    func(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error)
+	ListRoutesFunc      func(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error)
 }

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	"golang.org/x/sys/unix"
 )
@@ -1207,9 +1208,9 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	defer span.Finish()
 
 	switch v := devInfo.(type) {
-	case Volume:
+	case types.Volume:
 		q.qemuConfig.Devices = q.arch.append9PVolume(q.qemuConfig.Devices, v)
-	case Socket:
+	case types.Socket:
 		q.qemuConfig.Devices = q.arch.appendSocket(q.qemuConfig.Devices, v)
 	case kataVSOCK:
 		q.fds = append(q.fds, v.vhostFd)

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -14,6 +14,7 @@ import (
 	govmmQemu "github.com/intel/govmm/qemu"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
 
@@ -71,10 +72,10 @@ type qemuArch interface {
 	appendBridges(devices []govmmQemu.Device, bridges []Bridge) []govmmQemu.Device
 
 	// append9PVolume appends a 9P volume to devices
-	append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device
+	append9PVolume(devices []govmmQemu.Device, volume types.Volume) []govmmQemu.Device
 
 	// appendSocket appends a socket to devices
-	appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device
+	appendSocket(devices []govmmQemu.Device, socket types.Socket) []govmmQemu.Device
 
 	// appendVSockPCI appends a vsock PCI to devices
 	appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOCK) []govmmQemu.Device
@@ -370,7 +371,7 @@ func (q *qemuArchBase) appendBridges(devices []govmmQemu.Device, bridges []Bridg
 	return devices
 }
 
-func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume Volume) []govmmQemu.Device {
+func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume types.Volume) []govmmQemu.Device {
 	if volume.MountTag == "" || volume.HostPath == "" {
 		return devices
 	}
@@ -395,7 +396,7 @@ func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume Volume)
 	return devices
 }
 
-func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket Socket) []govmmQemu.Device {
+func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket types.Socket) []govmmQemu.Device {
 	devID := socket.ID
 	if len(devID) > maxDevIDSize {
 		devID = devID[:maxDevIDSize]

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 const (
@@ -204,9 +205,9 @@ func testQemuArchBaseAppend(t *testing.T, structure interface{}, expected []govm
 	qemuArchBase := newQemuArchBase()
 
 	switch s := structure.(type) {
-	case Volume:
+	case types.Volume:
 		devices = qemuArchBase.append9PVolume(devices, s)
-	case Socket:
+	case types.Socket:
 		devices = qemuArchBase.appendSocket(devices, s)
 	case config.BlockDrive:
 		devices = qemuArchBase.appendBlockDevice(devices, s)
@@ -316,7 +317,7 @@ func TestQemuArchBaseAppend9PVolume(t *testing.T) {
 		},
 	}
 
-	volume := Volume{
+	volume := types.Volume{
 		MountTag: mountTag,
 		HostPath: hostPath,
 	}
@@ -341,7 +342,7 @@ func TestQemuArchBaseAppendSocket(t *testing.T) {
 		},
 	}
 
-	socket := Socket{
+	socket := types.Socket{
 		DeviceID: deviceID,
 		ID:       id,
 		HostPath: hostPath,

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -213,7 +214,7 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 		},
 	}
 
-	volume := Volume{
+	volume := types.Volume{
 		MountTag: mountTag,
 		HostPath: hostPath,
 	}
@@ -238,7 +239,7 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 		},
 	}
 
-	socket := Socket{
+	socket := types.Socket{
 		DeviceID: deviceID,
 		ID:       id,
 		HostPath: hostPath,

--- a/virtcontainers/resource_storage.go
+++ b/virtcontainers/resource_storage.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 // TypedDevice is used as an intermediate representation for marshalling
@@ -39,7 +40,7 @@ type resourceStorage interface {
 	storeSandboxResource(sandboxID string, resource sandboxResource, data interface{}) error
 	deleteSandboxResources(sandboxID string, resources []sandboxResource) error
 	fetchSandboxConfig(sandboxID string) (SandboxConfig, error)
-	fetchSandboxState(sandboxID string) (State, error)
+	fetchSandboxState(sandboxID string) (types.State, error)
 	fetchSandboxNetwork(sandboxID string) (NetworkNamespace, error)
 	storeSandboxNetwork(sandboxID string, networkNS NetworkNamespace) error
 	fetchSandboxDevices(sandboxID string) ([]api.Device, error)
@@ -57,7 +58,7 @@ type resourceStorage interface {
 	storeContainerResource(sandboxID, containerID string, resource sandboxResource, data interface{}) error
 	deleteContainerResources(sandboxID, containerID string, resources []sandboxResource) error
 	fetchContainerConfig(sandboxID, containerID string) (ContainerConfig, error)
-	fetchContainerState(sandboxID, containerID string) (State, error)
+	fetchContainerState(sandboxID, containerID string) (types.State, error)
 	fetchContainerProcess(sandboxID, containerID string) (Process, error)
 	storeContainerProcess(sandboxID, containerID string, process Process) error
 	fetchContainerMounts(sandboxID, containerID string) ([]Mount, error)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	deviceManager "github.com/kata-containers/runtime/virtcontainers/device/manager"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	"github.com/vishvananda/netlink"
 )
@@ -1094,7 +1094,7 @@ func (s *Sandbox) removeNetwork() error {
 	return s.network.remove(s, s.factory != nil)
 }
 
-func (s *Sandbox) generateNetInfo(inf *types.Interface) (NetworkInfo, error) {
+func (s *Sandbox) generateNetInfo(inf *vcTypes.Interface) (NetworkInfo, error) {
 	hw, err := net.ParseMAC(inf.HwAddr)
 	if err != nil {
 		return NetworkInfo{}, err
@@ -1125,7 +1125,7 @@ func (s *Sandbox) generateNetInfo(inf *types.Interface) (NetworkInfo, error) {
 }
 
 // AddInterface adds new nic to the sandbox.
-func (s *Sandbox) AddInterface(inf *types.Interface) (*types.Interface, error) {
+func (s *Sandbox) AddInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	netInfo, err := s.generateNetInfo(inf)
 	if err != nil {
 		return nil, err
@@ -1156,7 +1156,7 @@ func (s *Sandbox) AddInterface(inf *types.Interface) (*types.Interface, error) {
 }
 
 // RemoveInterface removes a nic of the sandbox.
-func (s *Sandbox) RemoveInterface(inf *types.Interface) (*types.Interface, error) {
+func (s *Sandbox) RemoveInterface(inf *vcTypes.Interface) (*vcTypes.Interface, error) {
 	for i, endpoint := range s.networkNS.Endpoints {
 		if endpoint.HardwareAddr() == inf.HwAddr {
 			s.Logger().WithField("endpoint-type", endpoint.Type()).Info("Hot detaching endpoint")
@@ -1174,17 +1174,17 @@ func (s *Sandbox) RemoveInterface(inf *types.Interface) (*types.Interface, error
 }
 
 // ListInterfaces lists all nics and their configurations in the sandbox.
-func (s *Sandbox) ListInterfaces() ([]*types.Interface, error) {
+func (s *Sandbox) ListInterfaces() ([]*vcTypes.Interface, error) {
 	return s.agent.listInterfaces()
 }
 
 // UpdateRoutes updates the sandbox route table (e.g. for portmapping support).
-func (s *Sandbox) UpdateRoutes(routes []*types.Route) ([]*types.Route, error) {
+func (s *Sandbox) UpdateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
 	return s.agent.updateRoutes(routes)
 }
 
 // ListRoutes lists all routes and their configurations in the sandbox.
-func (s *Sandbox) ListRoutes() ([]*types.Route, error) {
+func (s *Sandbox) ListRoutes() ([]*vcTypes.Route, error) {
 	return s.agent.listRoutes()
 }
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"golang.org/x/sys/unix"
 )
 
@@ -41,7 +42,7 @@ func newHypervisorConfig(kernelParams []Param, hParams []Param) HypervisorConfig
 func testCreateSandbox(t *testing.T, id string,
 	htype HypervisorType, hconfig HypervisorConfig, atype AgentType,
 	nmodel NetworkModel, nconfig NetworkConfig, containers []ContainerConfig,
-	volumes []Volume) (*Sandbox, error) {
+	volumes []types.Volume) (*Sandbox, error) {
 
 	sconfig := SandboxConfig{
 		ID:               id,
@@ -114,7 +115,7 @@ func TestCreateSandboxEmtpyID(t *testing.T) {
 	defer cleanUp()
 }
 
-func testSandboxStateTransition(t *testing.T, state stateString, newState stateString) error {
+func testSandboxStateTransition(t *testing.T, state types.StateString, newState types.StateString) error {
 	hConfig := newHypervisorConfig(nil, nil)
 
 	p, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NoopNetworkModel, NetworkConfig{}, nil, nil)
@@ -123,57 +124,57 @@ func testSandboxStateTransition(t *testing.T, state stateString, newState stateS
 	}
 	defer cleanUp()
 
-	p.state = State{
+	p.state = types.State{
 		State: state,
 	}
 
-	return p.state.validTransition(state, newState)
+	return p.state.ValidTransition(state, newState)
 }
 
 func TestSandboxStateReadyRunning(t *testing.T) {
-	err := testSandboxStateTransition(t, StateReady, StateRunning)
+	err := testSandboxStateTransition(t, types.StateReady, types.StateRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStateRunningPaused(t *testing.T) {
-	err := testSandboxStateTransition(t, StateRunning, StatePaused)
+	err := testSandboxStateTransition(t, types.StateRunning, types.StatePaused)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStatePausedRunning(t *testing.T) {
-	err := testSandboxStateTransition(t, StatePaused, StateRunning)
+	err := testSandboxStateTransition(t, types.StatePaused, types.StateRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStatePausedStopped(t *testing.T) {
-	err := testSandboxStateTransition(t, StatePaused, StateStopped)
+	err := testSandboxStateTransition(t, types.StatePaused, types.StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStateRunningStopped(t *testing.T) {
-	err := testSandboxStateTransition(t, StateRunning, StateStopped)
+	err := testSandboxStateTransition(t, types.StateRunning, types.StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStateReadyPaused(t *testing.T) {
-	err := testSandboxStateTransition(t, StateReady, StateStopped)
+	err := testSandboxStateTransition(t, types.StateReady, types.StateStopped)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSandboxStatePausedReady(t *testing.T) {
-	err := testSandboxStateTransition(t, StateStopped, StateReady)
+	err := testSandboxStateTransition(t, types.StateStopped, types.StateReady)
 	if err == nil {
 		t.Fatal("Invalid transition from Ready to Paused")
 	}
@@ -265,22 +266,22 @@ func TestSandboxFileNegative(t *testing.T) {
 	}
 }
 
-func testStateValid(t *testing.T, stateStr stateString, expected bool) {
-	state := &State{
+func testStateValid(t *testing.T, stateStr types.StateString, expected bool) {
+	state := &types.State{
 		State: stateStr,
 	}
 
-	ok := state.valid()
+	ok := state.Valid()
 	if ok != expected {
 		t.Fatal()
 	}
 }
 
 func TestStateValidSuccessful(t *testing.T) {
-	testStateValid(t, StateReady, true)
-	testStateValid(t, StateRunning, true)
-	testStateValid(t, StatePaused, true)
-	testStateValid(t, StateStopped, true)
+	testStateValid(t, types.StateReady, true)
+	testStateValid(t, types.StateRunning, true)
+	testStateValid(t, types.StatePaused, true)
+	testStateValid(t, types.StateStopped, true)
 }
 
 func TestStateValidFailing(t *testing.T) {
@@ -288,22 +289,22 @@ func TestStateValidFailing(t *testing.T) {
 }
 
 func TestValidTransitionFailingOldStateMismatch(t *testing.T) {
-	state := &State{
-		State: StateReady,
+	state := &types.State{
+		State: types.StateReady,
 	}
 
-	err := state.validTransition(StateRunning, StateStopped)
+	err := state.ValidTransition(types.StateRunning, types.StateStopped)
 	if err == nil {
 		t.Fatal()
 	}
 }
 
 func TestVolumesSetSuccessful(t *testing.T) {
-	volumes := &Volumes{}
+	volumes := &types.Volumes{}
 
 	volStr := "mountTag1:hostPath1 mountTag2:hostPath2"
 
-	expected := Volumes{
+	expected := types.Volumes{
 		{
 			MountTag: "mountTag1",
 			HostPath: "hostPath1",
@@ -325,7 +326,7 @@ func TestVolumesSetSuccessful(t *testing.T) {
 }
 
 func TestVolumesSetFailingTooFewArguments(t *testing.T) {
-	volumes := &Volumes{}
+	volumes := &types.Volumes{}
 
 	volStr := "mountTag1 mountTag2"
 
@@ -336,7 +337,7 @@ func TestVolumesSetFailingTooFewArguments(t *testing.T) {
 }
 
 func TestVolumesSetFailingTooManyArguments(t *testing.T) {
-	volumes := &Volumes{}
+	volumes := &types.Volumes{}
 
 	volStr := "mountTag1:hostPath1:Foo1 mountTag2:hostPath2:Foo2"
 
@@ -347,7 +348,7 @@ func TestVolumesSetFailingTooManyArguments(t *testing.T) {
 }
 
 func TestVolumesSetFailingVoidArguments(t *testing.T) {
-	volumes := &Volumes{}
+	volumes := &types.Volumes{}
 
 	volStr := ": : :"
 
@@ -358,7 +359,7 @@ func TestVolumesSetFailingVoidArguments(t *testing.T) {
 }
 
 func TestVolumesStringSuccessful(t *testing.T) {
-	volumes := &Volumes{
+	volumes := &types.Volumes{
 		{
 			MountTag: "mountTag1",
 			HostPath: "hostPath1",
@@ -378,11 +379,11 @@ func TestVolumesStringSuccessful(t *testing.T) {
 }
 
 func TestSocketsSetSuccessful(t *testing.T) {
-	sockets := &Sockets{}
+	sockets := &types.Sockets{}
 
 	sockStr := "devID1:id1:hostPath1:Name1 devID2:id2:hostPath2:Name2"
 
-	expected := Sockets{
+	expected := types.Sockets{
 		{
 			DeviceID: "devID1",
 			ID:       "id1",
@@ -408,7 +409,7 @@ func TestSocketsSetSuccessful(t *testing.T) {
 }
 
 func TestSocketsSetFailingWrongArgsAmount(t *testing.T) {
-	sockets := &Sockets{}
+	sockets := &types.Sockets{}
 
 	sockStr := "devID1:id1:hostPath1"
 
@@ -419,7 +420,7 @@ func TestSocketsSetFailingWrongArgsAmount(t *testing.T) {
 }
 
 func TestSocketsSetFailingVoidArguments(t *testing.T) {
-	sockets := &Sockets{}
+	sockets := &types.Sockets{}
 
 	sockStr := ":::"
 
@@ -430,7 +431,7 @@ func TestSocketsSetFailingVoidArguments(t *testing.T) {
 }
 
 func TestSocketsStringSuccessful(t *testing.T) {
-	sockets := &Sockets{
+	sockets := &types.Sockets{
 		{
 			DeviceID: "devID1",
 			ID:       "id1",
@@ -471,7 +472,7 @@ func TestSandboxEnterSuccessful(t *testing.T) {
 	}
 }
 
-func testCheckInitSandboxAndContainerStates(p *Sandbox, initialSandboxState State, c *Container, initialContainerState State) error {
+func testCheckInitSandboxAndContainerStates(p *Sandbox, initialSandboxState types.State, c *Container, initialContainerState types.State) error {
 	if p.state.State != initialSandboxState.State {
 		return fmt.Errorf("Expected sandbox state %v, got %v", initialSandboxState.State, p.state.State)
 	}
@@ -483,7 +484,7 @@ func testCheckInitSandboxAndContainerStates(p *Sandbox, initialSandboxState Stat
 	return nil
 }
 
-func testForceSandboxStateChangeAndCheck(t *testing.T, p *Sandbox, newSandboxState State) error {
+func testForceSandboxStateChangeAndCheck(t *testing.T, p *Sandbox, newSandboxState types.State) error {
 	// force sandbox state change
 	if err := p.setSandboxState(newSandboxState.State); err != nil {
 		t.Fatalf("Unexpected error: %v (sandbox %+v)", err, p)
@@ -497,7 +498,7 @@ func testForceSandboxStateChangeAndCheck(t *testing.T, p *Sandbox, newSandboxSta
 	return nil
 }
 
-func testForceContainerStateChangeAndCheck(t *testing.T, p *Sandbox, c *Container, newContainerState State) error {
+func testForceContainerStateChangeAndCheck(t *testing.T, p *Sandbox, c *Container, newContainerState types.State) error {
 	// force container state change
 	if err := c.setContainerState(newContainerState.State); err != nil {
 		t.Fatalf("Unexpected error: %v (sandbox %+v)", err, p)
@@ -511,7 +512,7 @@ func testForceContainerStateChangeAndCheck(t *testing.T, p *Sandbox, c *Containe
 	return nil
 }
 
-func testCheckSandboxOnDiskState(p *Sandbox, sandboxState State) error {
+func testCheckSandboxOnDiskState(p *Sandbox, sandboxState types.State) error {
 	// check on-disk state is correct
 	if p.state.State != sandboxState.State {
 		return fmt.Errorf("Expected state %v, got %v", sandboxState.State, p.state.State)
@@ -520,7 +521,7 @@ func testCheckSandboxOnDiskState(p *Sandbox, sandboxState State) error {
 	return nil
 }
 
-func testCheckContainerOnDiskState(c *Container, containerState State) error {
+func testCheckContainerOnDiskState(c *Container, containerState types.State) error {
 	// check on-disk state is correct
 	if c.state.State != containerState.State {
 		return fmt.Errorf("Expected state %v, got %v", containerState.State, c.state.State)
@@ -546,13 +547,13 @@ func TestSandboxSetSandboxAndContainerState(t *testing.T) {
 		t.Fatalf("Expected 1 container found %v", l)
 	}
 
-	initialSandboxState := State{
-		State: StateReady,
+	initialSandboxState := types.State{
+		State: types.StateReady,
 	}
 
 	// After a sandbox creation, a container has a READY state
-	initialContainerState := State{
-		State: StateReady,
+	initialContainerState := types.State{
+		State: types.StateReady,
 	}
 
 	c, err := p.findContainer(contID)
@@ -571,16 +572,16 @@ func TestSandboxSetSandboxAndContainerState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSandboxState := State{
-		State: StateRunning,
+	newSandboxState := types.State{
+		State: types.StateRunning,
 	}
 
 	if err := testForceSandboxStateChangeAndCheck(t, p, newSandboxState); err != nil {
 		t.Error(err)
 	}
 
-	newContainerState := State{
-		State: StateStopped,
+	newContainerState := types.State{
+		State: types.StateStopped,
 	}
 
 	if err := testForceContainerStateChangeAndCheck(t, p, c, newContainerState); err != nil {
@@ -625,7 +626,7 @@ func TestSandboxSetSandboxStateFailingStoreSandboxResource(t *testing.T) {
 		storage: fs,
 	}
 
-	err := sandbox.setSandboxState(StateReady)
+	err := sandbox.setSandboxState(types.StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -645,7 +646,7 @@ func TestSandboxSetContainersStateFailingEmptySandboxID(t *testing.T) {
 
 	sandbox.containers = containers
 
-	err := sandbox.setContainersState(StateReady)
+	err := sandbox.setContainersState(types.StateReady)
 	if err == nil {
 		t.Fatal()
 	}
@@ -970,7 +971,7 @@ func TestContainerSetStateBlockIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state := State{
+	state := types.State{
 		State:  "stopped",
 		Fstype: "vfs",
 	}
@@ -1011,7 +1012,7 @@ func TestContainerSetStateBlockIndex(t *testing.T) {
 		t.Fatal()
 	}
 
-	var res State
+	var res types.State
 	err = json.Unmarshal([]byte(string(fileData)), &res)
 	if err != nil {
 		t.Fatal(err)
@@ -1068,7 +1069,7 @@ func TestContainerStateSetFstype(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state := State{
+	state := types.State{
 		State:      "ready",
 		Fstype:     "vfs",
 		BlockIndex: 3,
@@ -1111,7 +1112,7 @@ func TestContainerStateSetFstype(t *testing.T) {
 		t.Fatal()
 	}
 
-	var res State
+	var res types.State
 	err = json.Unmarshal([]byte(string(fileData)), &res)
 	if err != nil {
 		t.Fatal(err)
@@ -1391,7 +1392,7 @@ func TestEnterContainer(t *testing.T) {
 	defer cleanUp()
 
 	contID := "999"
-	cmd := Cmd{}
+	cmd := types.Cmd{}
 	_, _, err = s.EnterContainer(contID, cmd)
 	assert.NotNil(t, err, "Entering non-existing container should fail")
 
@@ -1613,7 +1614,7 @@ func TestAttachBlockDevice(t *testing.T) {
 	err = device.Detach(sandbox)
 	assert.Nil(t, err)
 
-	container.state.State = StateReady
+	container.state.State = types.StateReady
 	err = device.Attach(sandbox)
 	assert.Nil(t, err)
 
@@ -1627,7 +1628,7 @@ func TestAttachBlockDevice(t *testing.T) {
 	err = device.Detach(sandbox)
 	assert.Nil(t, err)
 
-	container.state.State = StateReady
+	container.state.State = types.StateReady
 	err = device.Attach(sandbox)
 	assert.Nil(t, err)
 
@@ -1664,7 +1665,7 @@ func TestPreAddDevice(t *testing.T) {
 		id:        contID,
 		sandboxID: testSandboxID,
 	}
-	container.state.State = StateReady
+	container.state.State = types.StateReady
 
 	// create state file
 	path := filepath.Join(runStoragePath, testSandboxID, container.ID())
@@ -1756,7 +1757,7 @@ func TestStartNetworkMonitor(t *testing.T) {
 }
 
 func TestSandboxStopStopped(t *testing.T) {
-	s := &Sandbox{state: State{State: StateStopped}}
+	s := &Sandbox{state: types.State{State: types.StateStopped}}
 	err := s.Stop()
 
 	assert.Nil(t, err)

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
@@ -155,7 +156,7 @@ func stopShim(pid int) error {
 	return nil
 }
 
-func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cmd Cmd,
+func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cmd types.Cmd,
 	createNSList []ns.NSType, enterNSList []ns.Namespace) (*Process, error) {
 	process := &Process{
 		Token:     token,

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -10,26 +10,26 @@ import (
 	"strings"
 )
 
-// stateString is a string representing a sandbox state.
-type stateString string
+// StateString is a string representing a sandbox state.
+type StateString string
 
 const (
 	// StateReady represents a sandbox/container that's ready to be run
-	StateReady stateString = "ready"
+	StateReady StateString = "ready"
 
 	// StateRunning represents a sandbox/container that's currently running.
-	StateRunning stateString = "running"
+	StateRunning StateString = "running"
 
 	// StatePaused represents a sandbox/container that has been paused.
-	StatePaused stateString = "paused"
+	StatePaused StateString = "paused"
 
 	// StateStopped represents a sandbox/container that has been stopped.
-	StateStopped stateString = "stopped"
+	StateStopped StateString = "stopped"
 )
 
 // State is a sandbox state structure.
 type State struct {
-	State stateString `json:"state"`
+	State StateString `json:"state"`
 
 	BlockDeviceID string
 	// Index of the block device passed to hypervisor.
@@ -46,9 +46,9 @@ type State struct {
 	GuestMemoryBlockSizeMB uint32 `json:"guestMemoryBlockSize"`
 }
 
-// valid checks that the sandbox state is valid.
-func (state *State) valid() bool {
-	for _, validState := range []stateString{StateReady, StateRunning, StatePaused, StateStopped} {
+// Valid checks that the sandbox state is valid.
+func (state *State) Valid() bool {
+	for _, validState := range []StateString{StateReady, StateRunning, StatePaused, StateStopped} {
 		if state.State == validState {
 			return true
 		}
@@ -57,9 +57,9 @@ func (state *State) valid() bool {
 	return false
 }
 
-// validTransition returns an error if we want to move to
+// ValidTransition returns an error if we want to move to
 // an unreachable state.
-func (state *State) validTransition(oldState stateString, newState stateString) error {
+func (state *State) ValidTransition(oldState StateString, newState StateString) error {
 	if state.State != oldState {
 		return fmt.Errorf("Invalid state %s (Expecting %s)", state.State, oldState)
 	}

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// stateString is a string representing a sandbox state.
+type stateString string
+
+const (
+	// StateReady represents a sandbox/container that's ready to be run
+	StateReady stateString = "ready"
+
+	// StateRunning represents a sandbox/container that's currently running.
+	StateRunning stateString = "running"
+
+	// StatePaused represents a sandbox/container that has been paused.
+	StatePaused stateString = "paused"
+
+	// StateStopped represents a sandbox/container that has been stopped.
+	StateStopped stateString = "stopped"
+)
+
+// State is a sandbox state structure.
+type State struct {
+	State stateString `json:"state"`
+
+	BlockDeviceID string
+	// Index of the block device passed to hypervisor.
+	BlockIndex int `json:"blockIndex"`
+
+	// File system of the rootfs incase it is block device
+	Fstype string `json:"fstype"`
+
+	// Pid is the process id of the sandbox container which is the first
+	// container to be started.
+	Pid int `json:"pid"`
+
+	// GuestMemoryBlockSizeMB is the size of memory block of guestos
+	GuestMemoryBlockSizeMB uint32 `json:"guestMemoryBlockSize"`
+}
+
+// valid checks that the sandbox state is valid.
+func (state *State) valid() bool {
+	for _, validState := range []stateString{StateReady, StateRunning, StatePaused, StateStopped} {
+		if state.State == validState {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validTransition returns an error if we want to move to
+// an unreachable state.
+func (state *State) validTransition(oldState stateString, newState stateString) error {
+	if state.State != oldState {
+		return fmt.Errorf("Invalid state %s (Expecting %s)", state.State, oldState)
+	}
+
+	switch state.State {
+	case StateReady:
+		if newState == StateRunning || newState == StateStopped {
+			return nil
+		}
+
+	case StateRunning:
+		if newState == StatePaused || newState == StateStopped {
+			return nil
+		}
+
+	case StatePaused:
+		if newState == StateRunning || newState == StateStopped {
+			return nil
+		}
+
+	case StateStopped:
+		if newState == StateRunning {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Can not move from %s to %s",
+		state.State, newState)
+}
+
+// Volume is a shared volume between the host and the VM,
+// defined by its mount tag and its host path.
+type Volume struct {
+	// MountTag is a label used as a hint to the guest.
+	MountTag string
+
+	// HostPath is the host filesystem path for this volume.
+	HostPath string
+}
+
+// Volumes is a Volume list.
+type Volumes []Volume
+
+// Set assigns volume values from string to a Volume.
+func (v *Volumes) Set(volStr string) error {
+	if volStr == "" {
+		return fmt.Errorf("volStr cannot be empty")
+	}
+
+	volSlice := strings.Split(volStr, " ")
+	const expectedVolLen = 2
+	const volDelimiter = ":"
+
+	for _, vol := range volSlice {
+		volArgs := strings.Split(vol, volDelimiter)
+
+		if len(volArgs) != expectedVolLen {
+			return fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q",
+				vol, expectedVolLen, volDelimiter)
+		}
+
+		if volArgs[0] == "" || volArgs[1] == "" {
+			return fmt.Errorf("Volume parameters cannot be empty")
+		}
+
+		volume := Volume{
+			MountTag: volArgs[0],
+			HostPath: volArgs[1],
+		}
+
+		*v = append(*v, volume)
+	}
+
+	return nil
+}
+
+// String converts a Volume to a string.
+func (v *Volumes) String() string {
+	var volSlice []string
+
+	for _, volume := range *v {
+		volSlice = append(volSlice, fmt.Sprintf("%s:%s", volume.MountTag, volume.HostPath))
+	}
+
+	return strings.Join(volSlice, " ")
+}
+
+// Socket defines a socket to communicate between
+// the host and any process inside the VM.
+type Socket struct {
+	DeviceID string
+	ID       string
+	HostPath string
+	Name     string
+}
+
+// Sockets is a Socket list.
+type Sockets []Socket
+
+// Set assigns socket values from string to a Socket.
+func (s *Sockets) Set(sockStr string) error {
+	if sockStr == "" {
+		return fmt.Errorf("sockStr cannot be empty")
+	}
+
+	sockSlice := strings.Split(sockStr, " ")
+	const expectedSockCount = 4
+	const sockDelimiter = ":"
+
+	for _, sock := range sockSlice {
+		sockArgs := strings.Split(sock, sockDelimiter)
+
+		if len(sockArgs) != expectedSockCount {
+			return fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q", sock, expectedSockCount, sockDelimiter)
+		}
+
+		for _, a := range sockArgs {
+			if a == "" {
+				return fmt.Errorf("Socket parameters cannot be empty")
+			}
+		}
+
+		socket := Socket{
+			DeviceID: sockArgs[0],
+			ID:       sockArgs[1],
+			HostPath: sockArgs[2],
+			Name:     sockArgs[3],
+		}
+
+		*s = append(*s, socket)
+	}
+
+	return nil
+}
+
+// String converts a Socket to a string.
+func (s *Sockets) String() string {
+	var sockSlice []string
+
+	for _, sock := range *s {
+		sockSlice = append(sockSlice, fmt.Sprintf("%s:%s:%s:%s", sock.DeviceID, sock.ID, sock.HostPath, sock.Name))
+	}
+
+	return strings.Join(sockSlice, " ")
+}
+
+// EnvVar is a key/value structure representing a command
+// environment variable.
+type EnvVar struct {
+	Var   string
+	Value string
+}
+
+// LinuxCapabilities specify the capabilities to keep when executing
+// the process inside the container.
+type LinuxCapabilities struct {
+	// Bounding is the set of capabilities checked by the kernel.
+	Bounding []string
+	// Effective is the set of capabilities checked by the kernel.
+	Effective []string
+	// Inheritable is the capabilities preserved across execve.
+	Inheritable []string
+	// Permitted is the limiting superset for effective capabilities.
+	Permitted []string
+	// Ambient is the ambient set of capabilities that are kept.
+	Ambient []string
+}
+
+// Cmd represents a command to execute in a running container.
+type Cmd struct {
+	Args                []string
+	Envs                []EnvVar
+	SupplementaryGroups []string
+
+	// Note that these fields *MUST* remain as strings.
+	//
+	// The reason being that we want runtimes to be able to support CLI
+	// operations like "exec --user=". That option allows the
+	// specification of a user (either as a string username or a numeric
+	// UID), and may optionally also include a group (groupame or GID).
+	//
+	// Since this type is the interface to allow the runtime to specify
+	// the user and group the workload can run as, these user and group
+	// fields cannot be encoded as integer values since that would imply
+	// the runtime itself would need to perform a UID/GID lookup on the
+	// user-specified username/groupname. But that isn't practically
+	// possible given that to do so would require the runtime to access
+	// the image to allow it to interrogate the appropriate databases to
+	// convert the username/groupnames to UID/GID values.
+	//
+	// Note that this argument applies solely to the _runtime_ supporting
+	// a "--user=" option when running in a "standalone mode" - there is
+	// no issue when the runtime is called by a container manager since
+	// all the user and group mapping is handled by the container manager
+	// and specified to the runtime in terms of UID/GID's in the
+	// configuration file generated by the container manager.
+	User         string
+	PrimaryGroup string
+	WorkDir      string
+	Console      string
+	Capabilities LinuxCapabilities
+
+	Interactive     bool
+	Detach          bool
+	NoNewPrivileges bool
+}
+
+// Resources describes VM resources configuration.
+type Resources struct {
+	// Memory is the amount of available memory in MiB.
+	Memory      uint
+	MemorySlots uint8
+}


### PR DESCRIPTION
The types package holds all shared virtcontainers types.
With the separation of the virtcontainers code into separate packages,
we need a types one to not create circular dependencies.
    
This package holds sandbox related types and structures for now. It will
 grow as virtcontainers code is moved into their own internal packages.

Fixes #1095 