### PR TITLE
katautils: Remove unused argument containerID of function SetKernelPa…

### DIFF
--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -85,7 +85,7 @@ func HandleFactory(ctx context.Context, vci vc.VC, runtimeConfig *oci.RuntimeCon
 
 // SetKernelParams adds the user-specified kernel parameters (from the
 // configuration file) to the defaults so that the former take priority.
-func SetKernelParams(containerID string, runtimeConfig *oci.RuntimeConfig) error {
+func SetKernelParams(runtimeConfig *oci.RuntimeConfig) error {
 	defaultKernelParams := GetKernelParamsFunc(needSystemd(runtimeConfig.HypervisorConfig))
 
 	if runtimeConfig.HypervisorConfig.Debug {
@@ -138,7 +138,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, ru
 	span, ctx := Trace(ctx, "createSandbox")
 	defer span.Finish()
 
-	err := SetKernelParams(containerID, &runtimeConfig)
+	err := SetKernelParams(&runtimeConfig)
 	if err != nil {
 		return nil, vc.Process{}, err
 	}

--- a/pkg/katautils/create_test.go
+++ b/pkg/katautils/create_test.go
@@ -201,7 +201,7 @@ func TestSetKernelParams(t *testing.T) {
 
 	assert.Empty(config.HypervisorConfig.KernelParams)
 
-	err := SetKernelParams(testContainerID, &config)
+	err := SetKernelParams(&config)
 	assert.NoError(err)
 
 	if needSystemd(config.HypervisorConfig) {
@@ -234,7 +234,7 @@ func TestSetKernelParamsUserOptionTakesPriority(t *testing.T) {
 
 	assert.NotEmpty(config.HypervisorConfig.KernelParams)
 
-	err := SetKernelParams(testContainerID, &config)
+	err := SetKernelParams(&config)
 	assert.NoError(err)
 
 	kernelParams := config.HypervisorConfig.KernelParams


### PR DESCRIPTION
…rams

Remove unused argument containerID of function SetKernelParams.

Fixes: #1097

Signed-off-by: Hui Zhu <teawater@hyper.sh>