### PR TITLE
kernel: Revert "versions: Bump to kernel 4.19.10"

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -128,7 +128,7 @@ assets:
   kernel:
     description: "Linux kernel optimised for virtual machines"
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
-    version: "v4.19.10"
+    version: "v4.14.67"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
This reverts commit 802bfa26c9d99f50dc6e0eb11f2d049487339f63.
Seems that we have some performance issues when
using this new kernel. Reverting to have a clean CI and
have a proper investigation about the degradation.

Fixes: #1100.