### PR TITLE
Versions: Add firecracker version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -60,6 +60,11 @@ assets:
   hypervisor:
     description: "Component used to create virtual machines"
 
+    firecracker:
+      description: "Firecracker micro-Hypervisor"
+      url: "https://github.com/firecracker-microvm/firecracker"
+      version: "v0.12.0"
+
     nemu:
       description: "Modern Hypervisor for the Cloud"
       url: "https://github.com/intel/nemu"


### PR DESCRIPTION
Add firecracker version to versions.yaml. This allows kata
packaging to build and package firecracker.

Fixes: #1103

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>