### PR TITLE
versions: Bump to kernel 4.19.24

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -133,7 +133,7 @@ assets:
   kernel:
     description: "Linux kernel optimised for virtual machines"
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
-    version: "v4.14.67"
+    version: "v4.19.24"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
We need to bump the kernel version from 4.14.67 to 4.19.24 in order
to follow the recent kernel config bump.

Fixes #618 
Fixes #1029

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>