### PR TITLE
runtime: Fix TestCCCheckCLIFunction on P9 system

### DIFF
--- a/cli/kata-check_data_ppc64le_test.go
+++ b/cli/kata-check_data_ppc64le_test.go
@@ -5,110 +5,20 @@
 
 package main
 
-const testCPUInfoTemplate = `
-processor	: 0
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
+import (
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+)
 
-processor	: 8
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
+var testCPUInfoTemplate = setTestCPUInfoTemplate()
 
-processor	: 16
-cpu		: POWER8E (raw), altivec supported
-clock		: 2360.000000MHz
-revision	: 2.1 (pvr 004b 0201)
+func setTestCPUInfoTemplate() string {
 
-processor	: 24
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
+	var kataLog *logrus.Entry
+	content, err := ioutil.ReadFile("/proc/cpuinfo")
 
-processor	: 32
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 40
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 48
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 56
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 64
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 72
-cpu		: POWER8E (raw), altivec supported
-clock		: 3059.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 80
-cpu		: POWER8E (raw), altivec supported
-clock		: 2693.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 88
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 96
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 104
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 112
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 120
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 128
-cpu		: POWER8E (raw), altivec supported
-clock		: 3690.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 136
-cpu		: POWER8E (raw), altivec supported
-clock		: 2061.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 144
-cpu		: POWER8E (raw), altivec supported
-clock		: 2294.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-processor	: 152
-cpu		: POWER8E (raw), altivec supported
-clock		: 2560.000000MHz
-revision	: 2.1 (pvr 004b 0201)
-
-timebase	: 512000000
-platform	: PowerNV
-model		: 8247-22L
-machine		: PowerNV 8247-22L
-firmware	: OPAL v3
-`
+	if err != nil {
+		kataLog.WithError(err).Error("failed to read file /proc/cpuinfo")
+	}
+	return string(content)
+}

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/kata-containers/runtime/pkg/katautils"
 	"github.com/sirupsen/logrus"
+	"regexp"
+	"strconv"
 )
 
 const (
@@ -69,7 +71,14 @@ func hostIsVMContainerCapable(details vmContainerCapableDetails) error {
 		return err
 	}
 
-	if strings.Contains(text, "POWER8") {
+	ae := regexp.MustCompile("[0-9]+")
+	re := regexp.MustCompile("POWER[0-9]")
+	powerProcessor, err := strconv.Atoi(ae.FindString(re.FindString(text)))
+	if err != nil {
+		kataLog.WithError(err).Error("Failed to find Power Processor number from ", details.cpuInfoFile)
+	}
+
+	if powerProcessor <= 8 {
 		if !isSMTOff() {
 			return fmt.Errorf("SMT is not Off. %s", failMessage)
 		}


### PR DESCRIPTION
IBM P9 systems can support virtualization with SMT
on. Make sure TestCCCheckCLIFunction passes on P8
(works only with SMT=off) and P9 as well.

Fixes: #1114

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com