### PR TITLE
update: allow do update on ready.

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -165,8 +165,8 @@ other options are ignored.
 		span.SetTag("sandbox", sandboxID)
 
 		// container MUST be running
-		if status.State.State != types.StateRunning {
-			return fmt.Errorf("Container %s is not running", containerID)
+		if state := status.State.State; !(state == types.StateRunning || state == types.StateReady) {
+			return fmt.Errorf("Container %s is not running or Ready, the state is %s", containerID, state)
 		}
 
 		r := specs.LinuxResources{

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1029,8 +1029,8 @@ func (c *Container) update(resources specs.LinuxResources) error {
 		return err
 	}
 
-	if c.state.State != types.StateRunning {
-		return fmt.Errorf("Container not running, impossible to update")
+	if state := c.state.State; !(state == types.StateRunning || state == types.StateReady) {
+		return fmt.Errorf("Container(%s) not running or ready, impossible to update", state)
 	}
 
 	if c.config.Resources.CPU == nil {


### PR DESCRIPTION
Before, we would only allow for a container-update command
to proceed if the container was in the running state. So
long as the container is created, this should be allowed.

This was found using the `static` policy for Kubernetes CPU
manager[1]. Where the `update` command is called after the
`create` runtime command (when the container state is `ready`).

[1] https://github.com/kubernetes/community/blob/95a4a1/contributors/design-proposals/node/cpu-manager.md#example-scenarios-and-interactions

Fixes: #1083

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>