### PR TITLE
virtcontainers: ppc64le qemu does not have nvdimm capabilities yet

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -25,7 +25,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off,nvdimm"
+const defaultQemuMachineOptions = "accel=kvm,usb=off"
 
 const defaultPCBridgeBus = "pci.0"
 


### PR DESCRIPTION
Remove `nvdimm` from qemu command line
as the upstream qemu on ppc64le does not have
nvdimm capabilities yet.

Fixes: #1136

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com