### PR TITLE
s390x: root parameter is missing

### DIFF
--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -30,11 +30,13 @@ var qemuPaths = map[string]string{
 	QemuCCWVirtio: defaultQemuPath,
 }
 
-var kernelRootParams = []Param{}
-
 // Verify needed parameters
 var kernelParams = []Param{
 	{"console", "ttysclp0"},
+}
+
+var kernelRootParams = []Param{
+	{"root", "/dev/vda1"},
 }
 
 var supportedQemuMachines = []govmmQemu.Machine{


### PR DESCRIPTION
The parameter is needed when you want to use the image option

Fixes: #1140

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>