### PR TITLE
cli: set config options before showing config paths

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -250,6 +250,8 @@ func beforeSubcommands(c *cli.Context) error {
 	var runtimeConfig oci.RuntimeConfig
 	var err error
 
+	katautils.SetConfigOptions(name, defaultRuntimeConfiguration, defaultSysConfRuntimeConfiguration)
+
 	handleShowConfig(c)
 
 	if userWantsUsage(c) || (c.NArg() == 1 && (c.Args()[0] == checkCmd)) {
@@ -301,8 +303,6 @@ func beforeSubcommands(c *cli.Context) error {
 		// simply report the logging setup
 		ignoreLogging = true
 	}
-
-	katautils.SetConfigOptions(name, defaultRuntimeConfiguration, defaultSysConfRuntimeConfiguration)
 
 	configFile, runtimeConfig, err = katautils.LoadConfiguration(c.GlobalString(configFilePathOption), ignoreLogging, false)
 	if err != nil {


### PR DESCRIPTION
Config paths are set correctly but they must be set before handleShowConfig

fixes #1185

cc @jodh-intel 

Signed-off-by: Julio Montes <julio.montes@intel.com>