### PR TITLE
[WIP] [DNM]: virtcontainers: Jailer: Add jailer support for firecracker

### DIFF
--- a/pkg/katautils/config-settings.go
+++ b/pkg/katautils/config-settings.go
@@ -9,6 +9,7 @@
 package katautils
 
 var defaultHypervisorPath = "/usr/bin/qemu-lite-system-x86_64"
+var defaultJailerPath = "/usr/bin/jailer"
 var defaultImagePath = "/usr/share/kata-containers/kata-containers.img"
 var defaultKernelPath = "/usr/share/kata-containers/vmlinuz.container"
 var defaultInitrdPath = "/usr/share/kata-containers/kata-containers-initrd.img"

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -82,6 +82,7 @@ type factory struct {
 
 type hypervisor struct {
 	Path                    string `toml:"path"`
+	JailerPath              string `toml:"jailer_path"`
 	Kernel                  string `toml:"kernel"`
 	Initrd                  string `toml:"initrd"`
 	Image                   string `toml:"image"`
@@ -147,6 +148,16 @@ func (h hypervisor) path() (string, error) {
 
 	if h.Path == "" {
 		p = defaultHypervisorPath
+	}
+
+	return ResolvePath(p)
+}
+
+func (h hypervisor) jailerPath() (string, error) {
+	p := h.JailerPath
+
+	if h.JailerPath == "" {
+		p = defaultJailerPath
 	}
 
 	return ResolvePath(p)
@@ -411,6 +422,11 @@ func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		return vc.HypervisorConfig{}, err
 	}
 
+	jailer, err := h.jailerPath()
+	if err != nil {
+		return vc.HypervisorConfig{}, err
+	}
+
 	kernel, err := h.kernel()
 	if err != nil {
 		return vc.HypervisorConfig{}, err
@@ -439,6 +455,7 @@ func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 
 	return vc.HypervisorConfig{
 		HypervisorPath:        hypervisor,
+		JailerPath:            jailer,
 		KernelPath:            kernel,
 		InitrdPath:            initrd,
 		ImagePath:             image,
@@ -720,6 +737,7 @@ func initConfig() (config oci.RuntimeConfig, err error) {
 
 	defaultHypervisorConfig := vc.HypervisorConfig{
 		HypervisorPath:          defaultHypervisorPath,
+		JailerPath:              defaultJailerPath,
 		KernelPath:              defaultKernelPath,
 		ImagePath:               defaultImagePath,
 		InitrdPath:              defaultInitrdPath,

--- a/virtcontainers/filesystem_resource_storage.go
+++ b/virtcontainers/filesystem_resource_storage.go
@@ -113,6 +113,11 @@ var runStoragePath = filepath.Join("/run", storagePathSuffix, sandboxPathSuffix)
 // It will contain all guest vm sockets and shared mountpoints.
 var RunVMStoragePath = filepath.Join("/run", storagePathSuffix, vmPathSuffix)
 
+// AltRunVMStoragePath is the vm directory when suid permissions are required
+// "/run" it typically tmpfs with nosuid.
+// It will contain all guest vm sockets and shared mountpoints.
+var AltRunVMStoragePath = filepath.Join("/var/lib", storagePathSuffix, vmPathSuffix)
+
 // filesystem is a resourceStorage interface implementation for a local filesystem.
 type filesystem struct {
 	ctx context.Context

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -198,6 +198,9 @@ type HypervisorConfig struct {
 	// HypervisorPath is the hypervisor executable host path.
 	HypervisorPath string
 
+	// JailerPath is the jailer executable host path.
+	JailerPath string
+
 	// BlockDeviceDriver specifies the driver to be used for block device
 	// either VirtioSCSI or VirtioBlock with the default driver being defaultBlockDriver
 	BlockDeviceDriver string
@@ -397,6 +400,8 @@ func (conf *HypervisorConfig) assetPath(t types.AssetType) (string, error) {
 		return conf.InitrdPath, nil
 	case types.HypervisorAsset:
 		return conf.HypervisorPath, nil
+	case types.JailerAsset:
+		return conf.JailerPath, nil
 	case types.FirmwareAsset:
 		return conf.FirmwarePath, nil
 	default:
@@ -446,6 +451,11 @@ func (conf *HypervisorConfig) CustomInitrdAsset() bool {
 // HypervisorAssetPath returns the VM hypervisor path
 func (conf *HypervisorConfig) HypervisorAssetPath() (string, error) {
 	return conf.assetPath(types.HypervisorAsset)
+}
+
+// JailerAssetPath returns the VM Jailer path
+func (conf *HypervisorConfig) JailerAssetPath() (string, error) {
+	return conf.assetPath(types.JailerAsset)
 }
 
 // CustomHypervisorAsset returns true if the hypervisor asset is a custom one, false otherwise.
@@ -591,7 +601,7 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 // hypervisor is the virtcontainers hypervisor interface.
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
-	createSandbox(ctx context.Context, id string, hypervisorConfig *HypervisorConfig, storage resourceStorage) error
+	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, storage resourceStorage) error
 	startSandbox(timeout int) error
 	stopSandbox() error
 	pauseSandbox() error

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -23,7 +23,7 @@ func (m *mockHypervisor) hypervisorConfig() HypervisorConfig {
 	return HypervisorConfig{}
 }
 
-func (m *mockHypervisor) createSandbox(ctx context.Context, id string, hypervisorConfig *HypervisorConfig, storage resourceStorage) error {
+func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, storage resourceStorage) error {
 	err := hypervisorConfig.valid()
 	if err != nil {
 		return err

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -20,6 +20,9 @@ const (
 	// HypervisorPath is a sandbox annotation for passing a per container path pointing at the hypervisor that will run the container VM.
 	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
 
+	// JailerPath is a sandbox annotation for passing a per container path pointing at the jailer that will constrain the container VM.
+	JailerPath = vcAnnotationsPrefix + "JailerPath"
+
 	// FirmwarePath is a sandbox annotation for passing a per container path pointing at the guest firmware that will run the container VM.
 	FirmwarePath = vcAnnotationsPrefix + "FirmwarePath"
 
@@ -34,6 +37,9 @@ const (
 
 	// HypervisorHash is an sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
 	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"
+
+	// JailerHash is an sandbox annotation for passing a jailer binary SHA-512 hash value.
+	JailerHash = vcAnnotationsPrefix + "JailerHash"
 
 	// FirmwareHash is an sandbox annotation for passing a container guest firmware SHA-512 hash value.
 	FirmwareHash = vcAnnotationsPrefix + "FirmwareHash"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -416,7 +416,7 @@ func (q *qemu) setupTemplate(knobs *govmmQemu.Knobs, memory *govmmQemu.Memory) g
 }
 
 // createSandbox is the Hypervisor sandbox creation implementation for govmmQemu.
-func (q *qemu) createSandbox(ctx context.Context, id string, hypervisorConfig *HypervisorConfig, storage resourceStorage) error {
+func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, storage resourceStorage) error {
 	// Save the tracing context
 	q.ctx = ctx
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -597,7 +597,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		}
 	}()
 
-	if err = s.hypervisor.createSandbox(ctx, s.id, &sandboxConfig.HypervisorConfig, s.storage); err != nil {
+	if err = s.hypervisor.createSandbox(ctx, s.id, s.networkNS, &sandboxConfig.HypervisorConfig, s.storage); err != nil {
 		return nil, err
 	}
 
@@ -929,7 +929,12 @@ func (s *Sandbox) startVM() error {
 
 	s.Logger().Info("Starting VM")
 
-	if err := s.network.run(s.networkNS.NetNsPath, func() error {
+	netNsPath := s.networkNS.NetNsPath
+	if s.config.HypervisorConfig.JailerPath == "" {
+		netNsPath = ""
+	}
+
+	if err := s.network.run(netNsPath, func() error {
 		if s.factory != nil {
 			vm, err := s.factory.GetVM(ctx, VMConfig{
 				HypervisorType:   s.config.HypervisorType,

--- a/virtcontainers/types/asset.go
+++ b/virtcontainers/types/asset.go
@@ -29,6 +29,8 @@ func (t AssetType) Annotations() (string, string, error) {
 		return annotations.InitrdPath, annotations.InitrdHash, nil
 	case HypervisorAsset:
 		return annotations.HypervisorPath, annotations.HypervisorHash, nil
+	case JailerAsset:
+		return annotations.JailerPath, annotations.JailerHash, nil
 	case FirmwareAsset:
 		return annotations.FirmwarePath, annotations.FirmwareHash, nil
 	}
@@ -48,6 +50,9 @@ const (
 
 	// HypervisorAsset is an hypervisor asset.
 	HypervisorAsset AssetType = "hypervisor"
+
+	// JailerAsset is an jailer asset.
+	JailerAsset AssetType = "jailer"
 
 	// FirmwareAsset is a firmware asset.
 	FirmwareAsset AssetType = "firmware"
@@ -84,6 +89,8 @@ func (a *Asset) Valid() bool {
 	case InitrdAsset:
 		return true
 	case HypervisorAsset:
+		return true
+	case JailerAsset:
 		return true
 	case FirmwareAsset:
 		return true

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -118,7 +118,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 		}
 	}()
 
-	if err = hypervisor.createSandbox(ctx, id, &config.HypervisorConfig, &filesystem{}); err != nil {
+	if err = hypervisor.createSandbox(ctx, id, NetworkNamespace{}, &config.HypervisorConfig, &filesystem{}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Firecracker provides a jailer to constrain the VMM. Use this
jailer to launch the firecracker VMM instead of launching it
directly from the kata-runtime.

The jailer will ensure that the firecracker VMM will run
in its own network and mount namespace. All assets required
by the VMM have to be present within these namespaces.

This also means that more sandbox context needs to be made
available to the hypervisor/jailer.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>