### PR TITLE
Reduce virtcontainers unit test noise

### DIFF
--- a/virtcontainers/cc_proxy.go
+++ b/virtcontainers/cc_proxy.go
@@ -16,7 +16,7 @@ func (p *ccProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", err
 	}
 
-	params.logger.Info("Starting cc proxy")
+	params.logger.Debug("Starting cc proxy")
 
 	// construct the socket path the proxy instance will use
 	proxyURL, err := defaultProxyURL(params.id, SocketTypeUNIX)

--- a/virtcontainers/filesystem_resource_storage_test.go
+++ b/virtcontainers/filesystem_resource_storage_test.go
@@ -32,6 +32,7 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 	}
 
 	sandbox := &Sandbox{
+		ctx:        context.Background(),
 		id:         testSandboxID,
 		storage:    fs,
 		config:     sandboxConfig,

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -245,7 +246,9 @@ func TestHyperSetProxy(t *testing.T) {
 
 	h := &hyper{}
 	p := &ccProxy{}
-	s := &Sandbox{storage: &filesystem{}}
+	s := &Sandbox{
+		storage: &filesystem{ctx: context.Background()},
+	}
 
 	err := h.setProxy(s, p, 0, "")
 	assert.Error(err)

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -73,6 +73,7 @@ func TestKataAgentConnect(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},
@@ -105,6 +106,7 @@ func TestKataAgentDisconnect(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},
@@ -294,6 +296,7 @@ func TestKataAgentSendReq(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},
@@ -722,7 +725,8 @@ func TestAgentCreateContainer(t *testing.T) {
 	assert := assert.New(t)
 
 	sandbox := &Sandbox{
-		id: "foobar",
+		ctx: context.Background(),
+		id:  "foobar",
 		config: &SandboxConfig{
 			ID:             "foobar",
 			HypervisorType: MockHypervisor,
@@ -736,6 +740,7 @@ func TestAgentCreateContainer(t *testing.T) {
 	}
 
 	container := &Container{
+		ctx:       sandbox.ctx,
 		id:        "barfoo",
 		sandboxID: "foobar",
 		sandbox:   sandbox,
@@ -768,6 +773,7 @@ func TestAgentCreateContainer(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},
@@ -807,6 +813,7 @@ func TestAgentNetworkOperation(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},
@@ -828,9 +835,14 @@ func TestAgentNetworkOperation(t *testing.T) {
 func TestKataAgentSetProxy(t *testing.T) {
 	assert := assert.New(t)
 
-	k := &kataAgent{}
+	k := &kataAgent{ctx: context.Background()}
 	p := &kataBuiltInProxy{}
-	s := &Sandbox{storage: &filesystem{}}
+	s := &Sandbox{
+		ctx: context.Background(),
+		storage: &filesystem{
+			ctx: context.Background(),
+		},
+	}
 
 	err := k.setProxy(s, p, 0, "")
 	assert.Error(err)
@@ -877,6 +889,7 @@ func TestKataCopyFile(t *testing.T) {
 	defer proxy.Stop()
 
 	k := &kataAgent{
+		ctx: context.Background(),
 		state: KataAgentState{
 			URL: testKataProxyURL,
 		},

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -52,7 +52,7 @@ func (p *kataBuiltInProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", fmt.Errorf("kata builtin proxy running for sandbox %s", params.id)
 	}
 
-	params.logger.Info("Starting builtin kata proxy")
+	params.logger.Debug("Starting builtin kata proxy")
 
 	p.sandboxID = params.id
 	err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -27,7 +27,7 @@ func (p *kataProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", err
 	}
 
-	params.logger.Info("Starting regular Kata proxy rather than built-in")
+	params.logger.Debug("Starting regular Kata proxy rather than built-in")
 
 	// construct the socket path the proxy instance will use
 	proxyURL, err := defaultProxyURL(params.id, SocketTypeUNIX)

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -28,7 +28,7 @@ func (p *noProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", fmt.Errorf("proxy logger is not set")
 	}
 
-	params.logger.Info("No proxy started because of no-proxy implementation")
+	params.logger.Debug("No proxy started because of no-proxy implementation")
 
 	if params.agentURL == "" {
 		return -1, "", fmt.Errorf("AgentURL cannot be empty")

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -200,6 +200,7 @@ func TestQemuMemoryTopology(t *testing.T) {
 
 func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {
 	q := &qemu{
+		ctx:  context.Background(),
 		arch: &qemuArchBase{},
 	}
 
@@ -286,7 +287,9 @@ func TestQemuAddDeviceKataVSOCK(t *testing.T) {
 }
 
 func TestQemuGetSandboxConsole(t *testing.T) {
-	q := &qemu{}
+	q := &qemu{
+		ctx: context.Background(),
+	}
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(RunVMStoragePath, sandboxID, consoleSocket)
 
@@ -302,6 +305,7 @@ func TestQemuGetSandboxConsole(t *testing.T) {
 
 func TestQemuCapabilities(t *testing.T) {
 	q := &qemu{
+		ctx:  context.Background(),
 		arch: &qemuArchBase{},
 	}
 
@@ -365,6 +369,7 @@ func TestHotplugUnsupportedDeviceType(t *testing.T) {
 	qemuConfig := newQemuConfig()
 	fs := &filesystem{}
 	q := &qemu{
+		ctx:     context.Background(),
 		config:  qemuConfig,
 		storage: fs,
 	}
@@ -394,6 +399,7 @@ func TestQemuCleanup(t *testing.T) {
 	assert := assert.New(t)
 
 	q := &qemu{
+		ctx:    context.Background(),
 		config: newQemuConfig(),
 	}
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1759,7 +1759,10 @@ func TestStartNetworkMonitor(t *testing.T) {
 }
 
 func TestSandboxStopStopped(t *testing.T) {
-	s := &Sandbox{state: types.State{State: types.StateStopped}}
+	s := &Sandbox{
+		ctx:   context.Background(),
+		state: types.State{State: types.StateStopped},
+	}
 	err := s.Stop()
 
 	assert.Nil(t, err)


### PR DESCRIPTION
Remove a bunch of useless and noisy logs and false positive errors in order to get a clean virtcontainers unit tests log.

Fixes #1211 