### PR TITLE
delete: force: Do not fail on non exiting container

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -71,6 +71,10 @@ func delete(ctx context.Context, containerID string, force bool) error {
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(ctx, containerID)
 	if err != nil {
+		if force {
+			kataLog.Warnf("Failed to get container, force will not fail: %s", err)
+			return nil
+		}
 		return err
 	}
 

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -65,6 +65,10 @@ func TestDeleteInvalidContainer(t *testing.T) {
 	err = delete(context.Background(), testContainerID, false)
 	assert.Error(err)
 	assert.False(vcmock.IsMockError(err))
+
+	// Force to delete missing container
+	err = delete(context.Background(), "non-existing-test", true)
+	assert.NoError(err)
 }
 
 func TestDeleteMissingContainerTypeAnnotation(t *testing.T) {


### PR DESCRIPTION
When a container does not exist, runc does not fail.  Lets mimic this
behavior, sometimes kuberentes will try to force delete containers that
could not be created and gets confused if delete --force fails.

Fixes: #1219