### PR TITLE
arm64: Fix static check error

### DIFF
--- a/cli/kata-check_arm64.go
+++ b/cli/kata-check_arm64.go
@@ -121,12 +121,12 @@ func normalizeArmModel(model string) string {
 	return model
 }
 
-func getCPUDetails() (vendor, model string, err error) {
-	if vendor, model, err := genericGetCPUDetails(); err == nil {
+func getCPUDetails() (string, string, error) {
+	vendor, model, err := genericGetCPUDetails()
+	if err == nil {
 		vendor = normalizeArmVendor(vendor)
 		model = normalizeArmModel(model)
-		return vendor, model, err
-	} else {
-		return vendor, model, err
 	}
+
+	return vendor, model, err
 }

--- a/cli/kata-check_arm64_test.go
+++ b/cli/kata-check_arm64_test.go
@@ -18,6 +18,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+type TestDataa struct {
+	contents       string
+	expectedVendor string
+	expectedModel  string
+	expectError    bool
+}
+
 func setupCheckHostIsVMContainerCapable(assert *assert.Assertions, cpuInfoFile string, moduleData []testModuleData) {
 	//For now, Arm64 only deal with module check
 	createModules(assert, cpuInfoFile, moduleData)

--- a/virtcontainers/qemu_arm64_test.go
+++ b/virtcontainers/qemu_arm64_test.go
@@ -25,6 +25,7 @@ func newTestQemu(machineType string) qemuArch {
 }
 
 func TestQemuArm64CPUModel(t *testing.T) {
+	virt := defaultQemuMachineType
 	assert := assert.New(t)
 	arm64 := newTestQemu(virt)
 
@@ -39,19 +40,21 @@ func TestQemuArm64CPUModel(t *testing.T) {
 }
 
 func TestQemuArm64MemoryTopology(t *testing.T) {
+	virt := defaultQemuMachineType
 	assert := assert.New(t)
 	arm64 := newTestQemu(virt)
 	memoryOffset := 1024
 
 	hostMem := uint64(1024)
 	mem := uint64(120)
+	slots := uint8(10)
 	expectedMemory := govmmQemu.Memory{
 		Size:   fmt.Sprintf("%dM", mem),
-		Slots:  defaultMemSlots,
+		Slots:  slots,
 		MaxMem: fmt.Sprintf("%dM", hostMem+uint64(memoryOffset)),
 	}
 
-	m := arm64.memoryTopology(mem, hostMem)
+	m := arm64.memoryTopology(mem, hostMem, slots)
 	assert.Equal(expectedMemory, m)
 }
 


### PR DESCRIPTION
Got following error:
```
/home/jenkins/workspace/kata-containers-runtime-ARM-18.04-PR/go/src/github.com/kata-containers/runtime/virtcontainers/utils
cli/kata-check_arm64.go:129:9:warning: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (golint)
cli/kata-check_test.go:141:113:warning: undeclared name: TestDataa (unused)
cli/kata-check_test.go:141:113:warning: unused variable or constant undeclared name: TestDataa (varcheck)
virtcontainers/qemu_arm64_test.go:43:23:warning: unused variable or constant undeclared name: virt (varcheck)
virtcontainers/qemu_arm64_test.go:50:11:warning: unused variable or constant undeclared name: defaultMemSlots (varcheck)
virtcontainers/qemu_arm64_test.go:54:40:warning: unused variable or constant too few arguments in call to arm64.memoryTopology (varcheck)
virtcontainers/qemu_arm64_test.go:29:23:warning: unused variable or constant undeclared name: virt (varcheck)
cli/kata-check_test.go:141:113:warning: undeclared name: TestDataa (staticcheck)
virtcontainers/qemu_arm64_test.go:43:23:warning: unused struct field undeclared name: virt (structcheck)
virtcontainers/qemu_arm64_test.go:50:11:warning: unused struct field undeclared name: defaultMemSlots (structcheck)
virtcontainers/qemu_arm64_test.go:54:40:warning: unused struct field too few arguments in call to arm64.memoryTopology (structcheck)
virtcontainers/qemu_arm64_test.go:29:23:warning: unused struct field undeclared name: virt (structcheck)
cli/kata-check_test.go:141:113:warning: unused struct field undeclared name: TestDataa (structcheck)
Build step 'Execute shell' marked build as failure
```

Fixes: #1206

Signed-off-by: Hui Zhu <teawater@hyper.sh>