### PR TITLE
Makefile: Set ARCH in GOPATH not set mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,17 @@ ifeq ($(SKIP_GO_VERSION_CHECK),)
     include golang.mk
 endif
 
-GOARCH=$(shell go env GOARCH)
-ifeq ($(ARCH),)
-    ARCH = $(GOARCH)
+#Get ARCH.
+ifneq ($(GOPATH),)
+    GOARCH=$(shell go env GOARCH)
+    ifeq ($(ARCH),)
+        ARCH = $(GOARCH)
+    endif
+else
+    ARCH = $(shell uname -m)
+    ifeq ($(ARCH),x86_64)
+        ARCH = amd64
+    endif
 endif
 
 ARCH_DIR = arch


### PR DESCRIPTION
In GOPATH not set mode got:
make: go: Command not found
Makefile:38: arch/-options.mk: No such file or directory
make: go: Command not found
Makefile:237: *** "ERROR: No hypervisors known for architecture  (looked for: firecracker qemu)".  Stop.

The root cause is GOPATH not set mode is not set ARCH.
Set it to fix the issue.

Fixes: #1224

Signed-off-by: Hui Zhu <teawater@hyper.sh>