### PR TITLE
qemu: Cleanup Vm paths irrespective of Sandbox stop pass/fail

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -642,6 +642,7 @@ func (q *qemu) stopSandbox() error {
 	span, _ := q.trace("stopSandbox")
 	defer span.Finish()
 
+	defer q.cleanupVM()
 	q.Logger().Info("Stopping Sandbox")
 
 	err := q.qmpSetup()
@@ -654,6 +655,11 @@ func (q *qemu) stopSandbox() error {
 		q.Logger().WithError(err).Error("Fail to execute qmp QUIT")
 		return err
 	}
+
+	return nil
+}
+
+func (q *qemu) cleanupVM() error {
 
 	// cleanup vm path
 	dir := filepath.Join(store.RunVMStoragePath, q.id)


### PR DESCRIPTION
Sometimes qemu/qmp commands error out and VM files
get left behind on the host filesystem. Clen them up
irrespective of `stopSandbox` succeeds or fails.

Fixes: #1246

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com