### PR TITLE
devices: fix attach count for vhost-user-blk

### DIFF
--- a/virtcontainers/device/drivers/vhost_user_blk.go
+++ b/virtcontainers/device/drivers/vhost_user_blk.go
@@ -56,7 +56,7 @@ func (device *VhostUserBlkDevice) Attach(devReceiver api.DeviceReceiver) (err er
 // Detach is standard interface of api.Device, it's used to remove device from some
 // DeviceReceiver
 func (device *VhostUserBlkDevice) Detach(devReceiver api.DeviceReceiver) error {
-	skip, err := device.bumpAttachCount(true)
+	skip, err := device.bumpAttachCount(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit affd6e3216cbcfe797c617f61138bda1a5e928b2 ("devices: add reference
count for devices.") introduced an attach count for devices.  The
vhost-user-blk device increments the counter instead of decrementing it
when detaching.

Fixes: #1259
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>