### PR TITLE
cgroups: fix failed to remove sandbox cgroup

### DIFF
--- a/virtcontainers/cgroups.go
+++ b/virtcontainers/cgroups.go
@@ -125,11 +125,11 @@ func cgroupNoConstraintsPath(path string) string {
 }
 
 // return the parent cgroup for the given path
-func parentCgroup(path string) (cgroups.Cgroup, error) {
+func parentCgroup(hierarchy cgroups.Hierarchy, path string) (cgroups.Cgroup, error) {
 	// append '/' just in case CgroupsPath doesn't start with it
 	parent := filepath.Dir("/" + path)
 
-	parentCgroup, err := cgroupsLoadFunc(cgroups.V1,
+	parentCgroup, err := cgroupsLoadFunc(hierarchy,
 		cgroups.StaticPath(parent))
 	if err != nil {
 		return nil, fmt.Errorf("Could not load parent cgroup %v: %v", parent, err)
@@ -186,7 +186,7 @@ func (s *Sandbox) deleteCgroups() error {
 	}
 
 	// move running process here, that way cgroup can be removed
-	parent, err := parentCgroup(path)
+	parent, err := parentCgroup(V1NoConstraints, path)
 	if err != nil {
 		// parent cgroup doesn't exist, that means there are no process running
 		// and the no constraints cgroup was removed.

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1315,7 +1315,7 @@ func (c *Container) deleteCgroups() error {
 	}
 
 	// move running process here, that way cgroup can be removed
-	parent, err := parentCgroup(c.state.CgroupPath)
+	parent, err := parentCgroup(cgroups.V1, c.state.CgroupPath)
 	if err != nil {
 		// parent cgroup doesn't exist, that means there are no process running
 		// and the container cgroup was removed.


### PR DESCRIPTION
sandbox cgroup use V1NoConstraints, this only create memory subsystem,
but when delete, load parent cgroup always use `cgroups.V1`, so other
subsystem path can not be find, sandbox cgroup can not be deleted.

Fixes: #1263

Signed-off-by: Ace-Tang <aceapril@126.com>