### PR TITLE
sandbox: Delete store artifacts if stopSandbox fails

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -970,7 +970,12 @@ func (s *Sandbox) stopVM() error {
 	}
 
 	s.Logger().Info("Stopping VM")
-	return s.hypervisor.stopSandbox()
+	if err := s.hypervisor.stopSandbox(); err != nil {
+		s.store.Delete()
+		return err
+	}
+
+	return nil
 }
 
 func (s *Sandbox) addContainer(c *Container) error {


### PR DESCRIPTION
If stopSandbox fails due to qmp/qemu issues,
atleast clean up store artifacts before returning
errors.

Fixes: #1266

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com