### PR TITLE
Makefile: Change "GOPATH not set" to "No GO command"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,11 @@ for file in /etc/os-release /usr/lib/os-release; do \
     fi \
 done)
 
-HOST_ARCH=$(shell arch)
-ifeq ($(GOPATH),)
-    SKIP_GO_VERSION_CHECK=y
-else
-    SKIP_GO_VERSION_CHECK=
-endif
-
-ifeq ($(SKIP_GO_VERSION_CHECK),)
-    include golang.mk
-endif
+SKIP_GO_VERSION_CHECK=
+include golang.mk
 
 #Get ARCH.
-ifneq ($(GOPATH),)
+ifneq (,$(golang_version_raw))
     GOARCH=$(shell go env GOARCH)
     ifeq ($(ARCH),)
         ARCH = $(GOARCH)
@@ -608,7 +600,7 @@ show-footer:
 	@printf "\tBugs: $(PROJECT_BUG_URL)\n\n"
 
 show-summary: show-header
-ifneq ($(GOPATH),)
+ifneq (,$(golang_version_raw))
 	@printf "• architecture:\n"
 	@printf "\tHost: $(HOST_ARCH)\n"
 	@printf "\tgolang: $(GOARCH)\n"
@@ -618,7 +610,7 @@ ifneq ($(GOPATH),)
 	@printf "\t"
 	@go version
 else
-	@printf "• GOPATH not set:\n"
+	@printf "• No GO command or GOPATH not set:\n"
 	@printf "\tCan only install prebuilt binaries\n"
 endif
 	@printf "\n"

--- a/golang.mk
+++ b/golang.mk
@@ -6,49 +6,57 @@
 # Check that the system golang version is within the required version range
 # for this project.
 
-have_yq=$(shell if [ -x "$(GOPATH)/bin/yq" ]; then echo "true"; else echo ""; fi)
-ifeq (,$(have_yq))
-    $(info INFO: yq was not found, installing it)
-    install_yq=$(shell .ci/install-yq.sh)
-endif
-ifneq (,$(install_yq))
-    $(error "ERROR: install yq failed")
-endif
-golang_version_min=$(shell $(GOPATH)/bin/yq r versions.yaml languages.golang.version)
-
-ifeq (,$(golang_version_min))
-    $(error "ERROR: cannot determine minimum golang version")
-endif
-
-golang_version_min_fields=$(subst ., ,$(golang_version_min))
-
-golang_version_min_major=$(word 1,$(golang_version_min_fields))
-golang_version_min_minor=$(word 2,$(golang_version_min_fields))
-
-# for error messages
-golang_version_needed=$(golang_version_min_major).$(golang_version_min_minor)
-
 golang_version_raw=$(shell go version 2>/dev/null)
-
+not_check_version=
+ifeq (,$(GOPATH))
+    golang_version_raw=
+endif
 ifeq (,$(golang_version_raw))
-    $(error "ERROR: cannot determine golang version")
+    not_check_version=y
+endif
+ifneq (,$(SKIP_GO_VERSION_CHECK))
+    not_check_version=y
 endif
 
-# determine actual version of golang
-golang_version=$(subst go,,$(word 3,$(golang_version_raw)))
+ifeq (,$(not_check_version))
+    have_yq=$(shell if [ -x "$(GOPATH)/bin/yq" ]; then echo "true"; else echo ""; fi)
+    ifeq (,$(have_yq))
+        $(info INFO: yq was not found, installing it)
+        install_yq=$(shell .ci/install-yq.sh)
+    endif
+    ifneq (,$(install_yq))
+        $(error "ERROR: install yq failed")
+    endif
+    golang_version_min=$(shell $(GOPATH)/bin/yq r versions.yaml languages.golang.version)
 
-golang_version_fields=$(subst ., ,$(golang_version))
+    ifeq (,$(golang_version_min))
+        $(error "ERROR: cannot determine minimum golang version")
+    endif
 
-golang_version_major=$(word 1,$(golang_version_fields))
-golang_version_minor=$(word 2,$(golang_version_fields))
+    golang_version_min_fields=$(subst ., ,$(golang_version_min))
 
-golang_major_ok=$(shell test $(golang_version_major) -ge $(golang_version_min_major) && echo ok)
-golang_minor_ok=$(shell test $(golang_version_major) -eq $(golang_version_min_major) -a $(golang_version_minor) -ge $(golang_version_min_minor) && echo ok)
+    golang_version_min_major=$(word 1,$(golang_version_min_fields))
+    golang_version_min_minor=$(word 2,$(golang_version_min_fields))
 
-ifeq (,$(golang_major_ok))
-    $(error "ERROR: golang major version too old: got $(golang_version), need atleast $(golang_version_needed)")
-endif
+    # for error messages
+    golang_version_needed=$(golang_version_min_major).$(golang_version_min_minor)
 
-ifeq (,$(golang_minor_ok))
-    $(error "ERROR: golang minor version too old: got $(golang_version), need atleast $(golang_version_needed)")
+    # determine actual version of golang
+    golang_version=$(subst go,,$(word 3,$(golang_version_raw)))
+
+    golang_version_fields=$(subst ., ,$(golang_version))
+
+    golang_version_major=$(word 1,$(golang_version_fields))
+    golang_version_minor=$(word 2,$(golang_version_fields))
+
+    golang_major_ok=$(shell test $(golang_version_major) -ge $(golang_version_min_major) && echo ok)
+    golang_minor_ok=$(shell test $(golang_version_major) -eq $(golang_version_min_major) -a $(golang_version_minor) -ge $(golang_version_min_minor) && echo ok)
+
+    ifeq (,$(golang_major_ok))
+        $(error "ERROR: golang major version too old: got $(golang_version), need atleast $(golang_version_needed)")
+    endif
+
+    ifeq (,$(golang_minor_ok))
+        $(error "ERROR: golang minor version too old: got $(golang_version), need atleast $(golang_version_needed)")
+    endif
 endif


### PR DESCRIPTION
The cause that make "sudo make install" fail is not "GOPATH not set",
but no go command in path.
But the commit still keep the "GOPATH not set" because
execute "unset GOPATH; make" will fail because "go build" cannot work
without GOPATH.