### PR TITLE
virtcontainers: fix vCPU calculation errors

### DIFF
--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -105,6 +105,25 @@ func WriteToFile(path string, data []byte) error {
 	return nil
 }
 
+//CalculateMilliCPUs converts CPU quota and period to milli-CPUs
+func CalculateMilliCPUs(quota int64, period uint64) uint32 {
+
+	// If quota is -1, it means the CPU resource request is
+	// unconstrained.  In that case, we don't currently assign
+	// additional CPUs.
+	if quota >= 0 && period != 0 {
+		return uint32((uint64(quota) * 1000) / period)
+	}
+
+	return 0
+}
+
+//CalculateVCpusFromMilliCpus converts from mCPU to CPU, taking the ceiling
+// value when necessary
+func CalculateVCpusFromMilliCpus(mCPU uint32) uint32 {
+	return (mCPU + 999) / 1000
+}
+
 // ConstraintsToVCPUs converts CPU quota and period to vCPUs
 func ConstraintsToVCPUs(quota int64, period uint64) uint {
 	if quota != 0 && period != 0 {


### PR DESCRIPTION
We were grabbing a running total of quota and period for each container
and then calculating the number of resulting vCPUs. Summing period
doesn't make sense.  To simplify, let's just calculate mCPU per
container, keep a running total of mCPUs requested, and then translate
to sandbox vCPUs after.

Fixes: #1292

Signed-off-by: Eric Ernst <eric.ernst@intel.com>