### PR TITLE
store: Add SetLogger API

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -48,6 +48,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 	virtLog = logger.WithFields(fields)
 
 	deviceApi.SetLogger(virtLog)
+	store.SetLogger(virtLog)
 }
 
 // CreateSandbox is the virtcontainers sandbox creation entry point.

--- a/virtcontainers/store/manager.go
+++ b/virtcontainers/store/manager.go
@@ -182,6 +182,13 @@ func DeleteAll() {
 
 var storeLog = logrus.WithField("source", "virtcontainers/store")
 
+// SetLogger sets the custom logger to be used by this package. If not called,
+// the package will create its own logger.
+func SetLogger(logger *logrus.Entry) {
+	fields := storeLog.Data
+	storeLog = logger.WithFields(fields)
+}
+
 // Logger returns a logrus logger appropriate for logging Store messages
 func (s *Store) Logger() *logrus.Entry {
 	return storeLog.WithFields(logrus.Fields{


### PR DESCRIPTION
Add a `store.SetLogger()` API to allow the store package to log with the standard set of fields (as expected by the log parser [1].

Fixes #1297.

---

[1] - https://github.com/kata-containers/tests/tree/master/cmd/log-parser#logfile-requirements

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>