### PR TITLE
unit-test: fix undefined struct field SupportVSocks on arm64

### DIFF
--- a/cli/kata-env_amd64_test.go
+++ b/cli/kata-env_amd64_test.go
@@ -16,7 +16,8 @@ import (
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := "moi"
 	expectedModel := "awesome XI"
-	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel)
+	expectedVMContainerCapable := false
+	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }
 
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {

--- a/cli/kata-env_arm64_test.go
+++ b/cli/kata-env_arm64_test.go
@@ -6,92 +6,14 @@
 package main
 
 import (
-	"fmt"
-	"path/filepath"
-	goruntime "runtime"
 	"testing"
 )
 
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
-	type filesToCreate struct {
-		file     string
-		contents string
-	}
-
-	const expectedKernelVersion = "99.1"
-	const expectedArch = goruntime.GOARCH
-
-	expectedDistro := DistroInfo{
-		Name:    "Foo",
-		Version: "42",
-	}
-
-	expectedCPU := CPUInfo{
-		Vendor: "0x41",
-		Model:  "8",
-	}
-
-	expectedNormalizeCPU := CPUInfo{
-		Vendor: "ARM Limited",
-		Model:  "v8",
-	}
-
-	expectedHostDetails := HostInfo{
-		Kernel:             expectedKernelVersion,
-		Architecture:       expectedArch,
-		Distro:             expectedDistro,
-		CPU:                expectedNormalizeCPU,
-		VMContainerCapable: true,
-	}
-
-	testProcCPUInfo := filepath.Join(tmpdir, "cpuinfo")
-	testOSRelease := filepath.Join(tmpdir, "os-release")
-
-	// XXX: This file is *NOT* created by this function on purpose
-	// (to ensure the only file checked by the tests is
-	// testOSRelease). osReleaseClr handling is tested in
-	// utils_test.go.
-	testOSReleaseClr := filepath.Join(tmpdir, "os-release-clr")
-
-	testProcVersion := filepath.Join(tmpdir, "proc-version")
-
-	// override
-	procVersion = testProcVersion
-	osRelease = testOSRelease
-	osReleaseClr = testOSReleaseClr
-	procCPUInfo = testProcCPUInfo
-
-	procVersionContents := fmt.Sprintf("Linux version %s a b c",
-		expectedKernelVersion)
-
-	osReleaseContents := fmt.Sprintf(`
-NAME="%s"
-VERSION_ID="%s"
-`, expectedDistro.Name, expectedDistro.Version)
-
-	procCPUInfoContents := fmt.Sprintf(`
-%s      : %s
-%s      : %s
-`,
-		archCPUVendorField,
-		expectedCPU.Vendor,
-		archCPUModelField,
-		expectedCPU.Model)
-
-	data := []filesToCreate{
-		{procVersion, procVersionContents},
-		{osRelease, osReleaseContents},
-		{procCPUInfo, procCPUInfoContents},
-	}
-
-	for _, d := range data {
-		err := createFile(d.file, d.contents)
-		if err != nil {
-			return HostInfo{}, err
-		}
-	}
-
-	return expectedHostDetails, nil
+	expectedVendor := "0x41"
+	expectedModel := "8"
+	expectedVMContainerCapable := true
+	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }
 
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {

--- a/cli/kata-env_ppc64le_test.go
+++ b/cli/kata-env_ppc64le_test.go
@@ -10,7 +10,8 @@ import "testing"
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := ""
 	expectedModel := "POWER8"
-	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel)
+	expectedVMContainerCapable := false
+	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }
 
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -245,7 +245,7 @@ func getExpectedAgentDetails(config oci.RuntimeConfig) (AgentInfo, error) {
 }
 
 // nolint: unused
-func genericGetExpectedHostDetails(tmpdir string, expectedVendor string, expectedModel string) (HostInfo, error) {
+func genericGetExpectedHostDetails(tmpdir string, expectedVendor string, expectedModel string, expectedVMContainerCapable bool) (HostInfo, error) {
 	type filesToCreate struct {
 		file     string
 		contents string
@@ -269,7 +269,7 @@ func genericGetExpectedHostDetails(tmpdir string, expectedVendor string, expecte
 		Architecture:       expectedArch,
 		Distro:             expectedDistro,
 		CPU:                expectedCPU,
-		VMContainerCapable: false,
+		VMContainerCapable: expectedVMContainerCapable,
 		SupportVSocks:      vcUtils.SupportsVsocks(),
 	}
 
@@ -318,6 +318,11 @@ VERSION_ID="%s"
 		if err != nil {
 			return HostInfo{}, err
 		}
+	}
+
+	if goruntime.GOARCH == "arm64" {
+		expectedHostDetails.CPU.Vendor = "ARM Limited"
+		expectedHostDetails.CPU.Model = "v8"
 	}
 
 	return expectedHostDetails, nil


### PR DESCRIPTION
Since arch-specific func `getExpectedHostDetails` holds undefined struct field `SupportVSocks` on arm64, unit test `TestEnvGetEnvInfoSetsCPUType`, `TestEnvGetHostInfo` and so on failed.
I'm trying to use generic func `genericgetExpectedHostDetails` on arm64 to avoid similar issues.
