### PR TITLE
unit test: Fix local test

### DIFF
--- a/virtcontainers/Makefile
+++ b/virtcontainers/Makefile
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 PREFIX := /usr
 BIN_DIR := $(PREFIX)/bin
 VC_BIN_DIR := $(BIN_DIR)/virtcontainers/bin
@@ -10,6 +16,7 @@ CC_SHIM_DIR := shim/mock/cc-shim
 CC_SHIM_BIN := cc-shim
 KATA_SHIM_DIR := shim/mock/kata-shim
 KATA_SHIM_BIN := kata-shim
+MK_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 #
 # Pretty printing
@@ -49,10 +56,10 @@ binaries: virtc hook cc-shim kata-shim
 check: check-go-static check-go-test
 
 check-go-static:
-	bash .ci/go-lint.sh
+	bash $(MK_DIR)/../.ci/go-lint.sh
 
 check-go-test:
-	bash .ci/go-test.sh \
+	bash $(MK_DIR)/../.ci/go-test.sh \
 		$(TEST_BIN_DIR)/$(CC_SHIM_BIN) \
 		$(TEST_BIN_DIR)/$(KATA_SHIM_BIN) \
 		$(TEST_BIN_DIR)/$(HOOK_BIN)

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -86,6 +86,8 @@ func newTestSandboxConfigNoop() SandboxConfig {
 		Containers: []ContainerConfig{container},
 
 		Annotations: sandboxAnnotations,
+
+		ProxyType: NoopProxyType,
 	}
 
 	return sandboxConfig
@@ -122,6 +124,8 @@ func newTestSandboxConfigHyperstartAgent() SandboxConfig {
 
 		Containers:  []ContainerConfig{container},
 		Annotations: sandboxAnnotations,
+
+		ProxyType: NoopProxyType,
 	}
 
 	return sandboxConfig
@@ -163,6 +167,8 @@ func newTestSandboxConfigHyperstartAgentDefaultNetwork() SandboxConfig {
 
 		Containers:  []ContainerConfig{container},
 		Annotations: sandboxAnnotations,
+
+		ProxyType: NoopProxyType,
 	}
 
 	return sandboxConfig
@@ -184,6 +190,8 @@ func newTestSandboxConfigKataAgent() SandboxConfig {
 		AgentType: KataContainersAgent,
 
 		Annotations: sandboxAnnotations,
+
+		ProxyType: NoopProxyType,
 	}
 
 	return sandboxConfig
@@ -2014,6 +2022,8 @@ func createNewSandboxConfig(hType HypervisorType, aType AgentType, aConfig inter
 		AgentConfig: aConfig,
 
 		NetworkConfig: netConfig,
+
+		ProxyType: NoopProxyType,
 	}
 }
 

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -109,6 +109,8 @@ func (pType *ProxyType) String() string {
 // newProxy returns a proxy from a proxy type.
 func newProxy(pType ProxyType) (proxy, error) {
 	switch pType {
+	case "":
+		return &kataBuiltInProxy{}, nil
 	case NoopProxyType:
 		return &noopProxy{}, nil
 	case NoProxyType:
@@ -120,7 +122,7 @@ func newProxy(pType ProxyType) (proxy, error) {
 	case KataBuiltInProxyType:
 		return &kataBuiltInProxy{}, nil
 	default:
-		return &noopProxy{}, nil
+		return &noopProxy{}, fmt.Errorf("Invalid proxy type: %s", pType)
 	}
 }
 

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -62,12 +62,7 @@ func setupProxy(h hypervisor, agent agent, config VMConfig, id string) (int, str
 		return -1, "", nil, err
 	}
 
-	// default to kata builtin proxy
-	proxyType := config.ProxyType
-	if len(proxyType.String()) == 0 {
-		proxyType = KataBuiltInProxyType
-	}
-	proxy, err := newProxy(proxyType)
+	proxy, err := newProxy(config.ProxyType)
 	if err != nil {
 		return -1, "", nil, err
 	}

--- a/virtcontainers/vm_test.go
+++ b/virtcontainers/vm_test.go
@@ -102,7 +102,7 @@ func TestSetupProxy(t *testing.T) {
 	agent := &noopAgent{}
 
 	// wrong proxy type
-	config.ProxyType = "invalidProxyType"
+	config.ProxyType = ProxyType("invalidProxyType")
 	_, _, _, err := setupProxy(hypervisor, agent, config, "foobar")
 	assert.NotNil(err)
 


### PR DESCRIPTION
- Simply empty string proxy type handling and cast string  ProxyType
- Allow run make check-go-test from virtcontainers directory 
Fixes: #1312