### PR TITLE
Makefile: Fix aarch64 fail in No GO command or GOPATH not set mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ else
     ifeq ($(ARCH),x86_64)
         ARCH = amd64
     endif
+    ifeq ($(ARCH),aarch64)
+        ARCH = arm64
+    endif
 endif
 
 ARCH_DIR = arch


### PR DESCRIPTION
Got aarch64 fail in No GO command or GOPATH not set mode:
Makefile:38: arch/aarch64-options.mk: No such file or directory
Makefile:237: *** "ERROR: No hypervisors known for architecture aarch64 (looked for: firecracker qemu)".  Stop.

The cause is the machine hardware name of aarch64 is aarch64 but
runtime's arch make file's name is arm64-options.mk.

This commit convert aarch64 to arm64 to fix the issue.

Fixes: #1320

Signed-off-by: Hui Zhu <teawater@hyper.sh>