### PR TITLE
virtcontainer: watch the qemu's console when proxy's debug enabled

### DIFF
--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -55,10 +55,13 @@ func (p *kataBuiltInProxy) start(params proxyParams) (int, string, error) {
 	params.logger.Debug("Starting builtin kata proxy")
 
 	p.sandboxID = params.id
-	err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
-	if err != nil {
-		p.sandboxID = ""
-		return -1, "", err
+
+	if params.debug {
+		err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
+		if err != nil {
+			p.sandboxID = ""
+			return -1, "", err
+		}
 	}
 
 	return -1, params.agentURL, nil

--- a/virtcontainers/kata_builtin_proxy_test.go
+++ b/virtcontainers/kata_builtin_proxy_test.go
@@ -17,7 +17,7 @@ func TestKataBuiltinProxy(t *testing.T) {
 
 	p := kataBuiltInProxy{}
 
-	params := proxyParams{}
+	params := proxyParams{debug: true}
 
 	err := p.validateParams(params)
 	assert.NotNil(err)


### PR DESCRIPTION
kata builtin proxy has always watched the qemu's console
whether proxy's debug is set or not, this is not aligned
with kata cli. This patch will change it and watch the
qemu's console only when proxy's debug is set in kata config.

Fixes: #1318

Signed-off-by: fupan <lifupan@gmail.com>