### PR TITLE
arm64: support NVDIMM

### DIFF
--- a/virtcontainers/qemu_arm64_test.go
+++ b/virtcontainers/qemu_arm64_test.go
@@ -125,3 +125,33 @@ func TestQemuArm64AppendBridges(t *testing.T) {
 
 	assert.Equal(expectedOut, devices)
 }
+
+func TestQemuArm64AppendImage(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+	arm64 := newTestQemu(QemuVirt)
+
+	f, err := ioutil.TempFile("", "img")
+	assert.NoError(err)
+	defer func() { _ = f.Close() }()
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	imageStat, err := f.Stat()
+	assert.NoError(err)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.Object{
+			Driver:   govmmQemu.NVDIMM,
+			Type:     govmmQemu.MemoryBackendFile,
+			DeviceID: "nv0",
+			ID:       "mem0",
+			MemPath:  f.Name(),
+			Size:     (uint64)(imageStat.Size()),
+		},
+	}
+
+	devices, err = arm64.appendImage(devices, f.Name())
+	assert.NoError(err)
+
+	assert.Equal(expectedOut, devices)
+}


### PR DESCRIPTION
As Arm64 is using the block device as the rootfs in guest. If we run two or more kata-container instances
on one host, we will get following error:
```
root@entos-thunderx2-desktop:~# docker run -dt --runtime kata-runtime ubuntu
7baf2c0f26100b0e642ad4122ce9ea1cb556fb3ed6cfcb454cb0586cbbe6194d
root@entos-thunderx2-desktop:~# docker run -dt --runtime kata-runtime ubuntu
2065fcf560c136091b5e69b6a12c95de94308309bb7fd5309df852503752203a
docker: Error response from daemon: OCI runtime create failed: qemu-system-aarch64: -device virtio-blk,drive=image-9f100592ac95eec6,scsi=off,config-wce=off: Failed to get "write" lock
Is another process using the image?: unknown.
```
Thanks to the new expanded IPA_SIZE feature in kernel 4.20 and Eric Auger's patch set [ARM virt: Initial RAM expansion and PCDIMM/NVDIMM support](https://www.mail-archive.com/qemu-devel@nongnu.org/msg599724.html) in qemu(which are still under upstream review), we could fully support nvdimm on arm64.
