### PR TITLE
Fix rootfs mount assumptions

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -276,6 +276,7 @@ type Container struct {
 	runPath       string
 	configPath    string
 	containerPath string
+	rootfsSuffix  string
 
 	state types.State
 
@@ -640,6 +641,7 @@ func newContainer(sandbox *Sandbox, contConfig ContainerConfig) (*Container, err
 		runPath:       store.ContainerRuntimeRootPath(sandbox.id, contConfig.ID),
 		configPath:    store.ContainerConfigurationRootPath(sandbox.id, contConfig.ID),
 		containerPath: filepath.Join(sandbox.id, contConfig.ID),
+		rootfsSuffix:  "rootfs",
 		state:         types.State{},
 		process:       Process{},
 		mounts:        contConfig.Mounts,
@@ -1129,6 +1131,10 @@ func (c *Container) hotplugDrive() error {
 
 	if !isDM {
 		return nil
+	}
+
+	if dev.mountPoint == c.rootFs {
+		c.rootfsSuffix = ""
 	}
 
 	// If device mapper device, then fetch the full path of the device

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -986,7 +986,7 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 
 	// This is the guest absolute root path for that container.
 	rootPathParent := filepath.Join(kataGuestSharedDir, c.id)
-	rootPath := filepath.Join(rootPathParent, rootfsDir)
+	rootPath := filepath.Join(rootPathParent, c.rootfsSuffix)
 
 	// In case the container creation fails, the following defer statement
 	// takes care of rolling back actions previously performed.


### PR DESCRIPTION
This patch fixes the issue where vrious version of snapshotters,
overlay, block based graphdriver, containerd-shim-v2 overlay, block
based snapshotters mount & create rootfs differently and kata should be
able to handle them all.

The current version of the code always assumes that a folder named
'rootfs' exists within the mount device and that is the path the
container should start at. This patch checks the existing mount point
and if it is the same as the rootFs passed to the container, we no
longer add a suffix to the container's rootfs path.

Fixes: #1325

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>
Co-Authored-by: Manohar Castelino <manohar.r.castelino@intel.com>