### PR TITLE
pkg: reduce memory footprint

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -663,7 +663,7 @@ func updateRuntimeConfigShim(configPath string, tomlConf tomlConfig, config *oci
 // SetKernelParams adds the user-specified kernel parameters (from the
 // configuration file) to the defaults so that the former take priority.
 func SetKernelParams(runtimeConfig *oci.RuntimeConfig) error {
-	defaultKernelParams := GetKernelParamsFunc(needSystemd(runtimeConfig.HypervisorConfig))
+	defaultKernelParams := GetKernelParamsFunc(needSystemd(runtimeConfig.HypervisorConfig), runtimeConfig.Trace)
 
 	if runtimeConfig.HypervisorConfig.Debug {
 		strParams := vc.SerializeParams(defaultKernelParams, "=")

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -1401,7 +1401,7 @@ func TestUpdateRuntimeConfigurationInvalidKernelParams(t *testing.T) {
 		GetKernelParamsFunc = savedFunc
 	}()
 
-	GetKernelParamsFunc = func(needSystemd bool) []vc.Param {
+	GetKernelParamsFunc = func(needSystemd, trace bool) []vc.Param {
 		return []vc.Param{
 			{
 				Key:   "",

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -37,11 +37,72 @@ var systemdKernelParam = []vc.Param{
 	},
 }
 
-func getKernelParams(needSystemd bool) []vc.Param {
+// kernel params to improve memory footprint
+var noTraceKernelParam = []vc.Param{
+	// No logs: agent has its own logging system
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-journald.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-journald.socket",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-journal-flush.service",
+	},
+	// No udev events: agent implements udev events
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-udevd.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-udevd.socket",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-udev-trigger.service",
+	},
+	// No timesync: kata is able to setup the time and this service consume network
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-timesyncd.service",
+	},
+	// No update audit logs
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-update-utmp.service",
+	},
+	// No temporal files
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-tmpfiles-setup.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-tmpfiles-cleanup.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-tmpfiles-cleanup.timer",
+	},
+	// No mounts
+	{
+		Key:   "systemd.mask",
+		Value: "tmp.mount",
+	},
+}
+
+func getKernelParams(needSystemd, trace bool) []vc.Param {
 	p := []vc.Param{}
 
 	if needSystemd {
 		p = append(p, systemdKernelParam...)
+		if !trace {
+			p = append(p, noTraceKernelParam...)
+		}
 	}
 
 	return p


### PR DESCRIPTION
Reduce memory footprint ~7% by disabling some systemd services like
systemd-journald and systemd-udevd, those services are just consuming memory
and are not needed. For example kata-agent logs the errors through the proxy.

![screenshot from 2019-03-07 09-25-08](https://user-images.githubusercontent.com/13009432/53967533-08127480-40bb-11e9-9889-a4eb4451b2d4.png)


fixes #1339

Signed-off-by: Julio Montes <julio.montes@intel.com>