### PR TITLE
Network: remove Physical field in VethEndpoint

### DIFF
--- a/virtcontainers/veth_endpoint.go
+++ b/virtcontainers/veth_endpoint.go
@@ -15,7 +15,6 @@ import (
 type VethEndpoint struct {
 	NetPair            NetworkInterfacePair
 	EndpointProperties NetworkInfo
-	Physical           bool
 	EndpointType       EndpointType
 	PCIAddr            string
 }


### PR DESCRIPTION
This a bool field. It is useless because veth endpoint is never a
physical endpoint. And it is never used.

Fixes #1343

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>