### PR TITLE
Add crio and containerd details to collect script

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -343,6 +343,7 @@ show_container_mgr_details()
 		subheading "crio"
 		run_cmd_and_show_quoted_output "" "crio --version"
 		run_cmd_and_show_quoted_output "" "systemctl show crio"
+		run_cmd_and_show_quoted_output "" "cat /etc/crio/crio.conf"
 	fi
 
 	separator

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -346,6 +346,14 @@ show_container_mgr_details()
 		run_cmd_and_show_quoted_output "" "cat /etc/crio/crio.conf"
 	fi
 
+
+	if have_cmd "containerd"; then
+		subheading "containerd"
+		run_cmd_and_show_quoted_output "" "containerd --version"
+		run_cmd_and_show_quoted_output "" "systemctl show containerd"
+		run_cmd_and_show_quoted_output "" "cat /etc/containerd/config.toml"
+	fi
+
 	separator
 }
 

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -141,6 +141,13 @@ have_cmd()
 	[ $ret -eq 0 ]
 }
 
+have_service()
+{
+	local service="$1"
+
+	systemctl status "${service}" >/dev/null 2>&1
+}
+
 show_quoted_text()
 {
 	local language="$1"
@@ -593,7 +600,7 @@ show_throttler_details()
 		"kata-vc-throttler" \
 		"vc-throttler"
 	do
-		systemctl status "${unit}" >/dev/null 2>&1 && \
+		have_service "${unit}" && \
 			run_cmd_and_show_quoted_output "" "systemctl show ${unit}"
 	done
 }

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -337,11 +337,12 @@ show_container_mgr_details()
 		run_cmd_and_show_quoted_output "" "kubectl version"
 		run_cmd_and_show_quoted_output "" "kubectl config view"
 		run_cmd_and_show_quoted_output "" "systemctl show kubelet"
+	fi
 
-		if have_cmd "crio"; then
-			run_cmd_and_show_quoted_output "" "crio --version"
-			run_cmd_and_show_quoted_output "" "systemctl show crio"
-		fi
+	if have_cmd "crio"; then
+		subheading "crio"
+		run_cmd_and_show_quoted_output "" "crio --version"
+		run_cmd_and_show_quoted_output "" "systemctl show crio"
 	fi
 
 	separator


### PR DESCRIPTION
- Add details of the crio config to the data collection script.
- Add a new sub-section for containerd details.

Fixes #1349.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
 
This should help make diagnosing issues like https://github.com/kata-containers/documentation/issues/389 faster.

/cc @egernst, @chavafg.