### PR TITLE
lint: Change go linter from gometalinter to golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 go_import_path: github.com/kata-containers/runtime
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 env:
   - target_branch=$TRAVIS_BRANCH

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -45,7 +45,7 @@ EXAMPLE:
 		}
 
 		args := context.Args()
-		if args.Present() == false {
+		if !args.Present() {
 			return fmt.Errorf("Missing container ID, should at least provide one")
 		}
 

--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -243,6 +243,7 @@ func checkKernelModules(modules map[string]kernelModule, handler kernelParamHand
 
 // genericHostIsVMContainerCapable checks to see if the host is theoretically capable
 // of creating a VM container.
+//nolint: unused,deadcode
 func genericHostIsVMContainerCapable(details vmContainerCapableDetails) error {
 	cpuinfo, err := getCPUInfo(details.cpuInfoFile)
 	if err != nil {

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -400,50 +400,50 @@ func TestArchKernelParamHandler(t *testing.T) {
 
 	type testData struct {
 		onVMM        bool
+		expectIgnore bool
 		fields       logrus.Fields
 		msg          string
-		expectIgnore bool
 	}
 
 	data := []testData{
-		{true, logrus.Fields{}, "", false},
-		{false, logrus.Fields{}, "", false},
+		{true, false, logrus.Fields{}, ""},
+		{false, false, logrus.Fields{}, ""},
 
 		{
+			false,
 			false,
 			logrus.Fields{
 				// wrong type
 				"parameter": 123,
 			},
 			"foo",
-			false,
 		},
 
 		{
+			false,
 			false,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
-			false,
 		},
 
 		{
+			true,
 			true,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
-			true,
 		},
 
 		{
 			false,
+			true,
 			logrus.Fields{
 				"parameter": "nested",
 			},
 			"",
-			true,
 		},
 	}
 

--- a/cli/kata-check_ppc64le_test.go
+++ b/cli/kata-check_ppc64le_test.go
@@ -124,50 +124,50 @@ func TestArchKernelParamHandler(t *testing.T) {
 
 	type testData struct {
 		onVMM        bool
+		expectIgnore bool
 		fields       logrus.Fields
 		msg          string
-		expectIgnore bool
 	}
 
 	data := []testData{
-		{true, logrus.Fields{}, "", false},
-		{false, logrus.Fields{}, "", false},
+		{true, false, logrus.Fields{}, ""},
+		{false, false, logrus.Fields{}, ""},
 
 		{
+			false,
 			false,
 			logrus.Fields{
 				// wrong type
 				"parameter": 123,
 			},
 			"foo",
-			false,
 		},
 
 		{
+			false,
 			false,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
-			false,
 		},
 
 		{
+			true,
 			true,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
-			true,
 		},
 
 		{
 			false,
+			true,
 			logrus.Fields{
 				"parameter": "nested",
 			},
 			"",
-			true,
 		},
 	}
 

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -46,7 +46,7 @@ EXAMPLE:
 		}
 
 		args := context.Args()
-		if args.Present() == false {
+		if !args.Present() {
 			return fmt.Errorf("Missing container ID")
 		}
 

--- a/cli/oci.go
+++ b/cli/oci.go
@@ -97,7 +97,7 @@ func validCreateParams(ctx context.Context, containerID, bundlePath string) (str
 	if err != nil {
 		return "", fmt.Errorf("Invalid bundle path '%s': %s", bundlePath, err)
 	}
-	if fileInfo.IsDir() == false {
+	if !fileInfo.IsDir() {
 		return "", fmt.Errorf("Invalid bundle path '%s', it should be a directory", bundlePath)
 	}
 

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -35,7 +35,7 @@ var psCLICommand = cli.Command{
 			return err
 		}
 
-		if context.Args().Present() == false {
+		if !context.Args().Present() {
 			return fmt.Errorf("Missing container ID, should at least provide one")
 		}
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -34,7 +34,7 @@ var startCLICommand = cli.Command{
 		}
 
 		args := context.Args()
-		if args.Present() == false {
+		if !args.Present() {
 			return fmt.Errorf("Missing container ID, should at least provide one")
 		}
 

--- a/cli/update.go
+++ b/cli/update.go
@@ -137,7 +137,7 @@ other options are ignored.
 		span, _ := katautils.Trace(ctx, "update")
 		defer span.Finish()
 
-		if context.Args().Present() == false {
+		if !context.Args().Present() {
 			return fmt.Errorf("Missing container ID, should at least provide one")
 		}
 

--- a/containerd-shim-v2/metrics.go
+++ b/containerd-shim-v2/metrics.go
@@ -42,9 +42,7 @@ func statsToMetrics(cgStats *vc.CgroupStats) *cgroups.Metrics {
 	}
 
 	var perCPU []uint64
-	for _, v := range cgStats.CPUStats.CPUUsage.PercpuUsage {
-		perCPU = append(perCPU, v)
-	}
+	perCPU = append(perCPU, cgStats.CPUStats.CPUUsage.PercpuUsage...)
 
 	metrics := &cgroups.Metrics{
 		Hugetlb: hugetlb,

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -592,7 +592,7 @@ func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (*ptypes.E
 	}
 
 	s.send(&eventstypes.TaskPaused{
-		c.id,
+		ContainerID: c.id,
 	})
 
 	return empty, err
@@ -620,7 +620,7 @@ func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (*ptypes
 	}
 
 	s.send(&eventstypes.TaskResumed{
-		c.id,
+		ContainerID: c.id,
 	})
 
 	return empty, err
@@ -838,8 +838,6 @@ func (s *service) checkProcesses(e exit) {
 		ExitStatus:  uint32(e.status),
 		ExitedAt:    e.timestamp,
 	})
-
-	return
 }
 
 func (s *service) getContainer(id string) (*container, error) {

--- a/containerd-shim-v2/utils.go
+++ b/containerd-shim-v2/utils.go
@@ -102,7 +102,7 @@ func validBundle(containerID, bundlePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Invalid bundle path '%s': %s", bundlePath, err)
 	}
-	if fileInfo.IsDir() == false {
+	if !fileInfo.IsDir() {
 		return "", fmt.Errorf("Invalid bundle path '%s', it should be a directory", bundlePath)
 	}
 

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -941,13 +941,13 @@ func TestHypervisorDefaults(t *testing.T) {
 	assert.Equal(h.defaultVCPUs(), uint32(numCPUs), "default vCPU number is wrong")
 
 	h.DefaultMaxVCPUs = 2
-	assert.Equal(h.defaultMaxVCPUs(), uint32(h.DefaultMaxVCPUs), "default max vCPU number is wrong")
+	assert.Equal(h.defaultMaxVCPUs(), uint32(2), "default max vCPU number is wrong")
 
 	h.DefaultMaxVCPUs = uint32(numCPUs) + 1
 	assert.Equal(h.defaultMaxVCPUs(), uint32(numCPUs), "default max vCPU number is wrong")
 
 	maxvcpus := vc.MaxQemuVCPUs()
-	h.DefaultMaxVCPUs = uint32(maxvcpus) + 1
+	h.DefaultMaxVCPUs = maxvcpus + 1
 	assert.Equal(h.defaultMaxVCPUs(), uint32(numCPUs), "default max vCPU number is wrong")
 
 	h.MemorySize = 1024
@@ -1368,7 +1368,7 @@ func TestUpdateRuntimeConfigurationVMConfig(t *testing.T) {
 		Hypervisor: map[string]hypervisor{
 			qemuHypervisorTableType: {
 				NumVCPUs:   int32(vcpus),
-				MemorySize: uint32(mem),
+				MemorySize: mem,
 				Path:       "/",
 				Kernel:     "/",
 				Image:      "/",
@@ -1556,18 +1556,18 @@ func TestCheckFactoryConfig(t *testing.T) {
 
 	type testData struct {
 		factoryEnabled bool
+		expectError    bool
 		imagePath      string
 		initrdPath     string
-		expectError    bool
 	}
 
 	data := []testData{
-		{false, "", "", false},
-		{false, "image", "", false},
-		{false, "", "initrd", false},
+		{false, false, "", ""},
+		{false, false, "image", ""},
+		{false, false, "", "initrd"},
 
-		{true, "", "initrd", false},
-		{true, "image", "", true},
+		{true, false, "", "initrd"},
+		{true, true, "image", ""},
 	}
 
 	for i, d := range data {
@@ -1596,19 +1596,19 @@ func TestCheckNetNsConfigShimTrace(t *testing.T) {
 	assert := assert.New(t)
 
 	type testData struct {
-		disableNetNs bool
 		networkModel vc.NetInterworkingModel
+		disableNetNs bool
 		shimTrace    bool
 		expectError  bool
 	}
 
 	data := []testData{
-		{false, vc.NetXConnectMacVtapModel, false, false},
-		{false, vc.NetXConnectMacVtapModel, true, true},
-		{true, vc.NetXConnectMacVtapModel, true, true},
-		{true, vc.NetXConnectMacVtapModel, false, true},
-		{true, vc.NetXConnectNoneModel, false, false},
-		{true, vc.NetXConnectNoneModel, true, false},
+		{vc.NetXConnectMacVtapModel, false, false, false},
+		{vc.NetXConnectMacVtapModel, false, true, true},
+		{vc.NetXConnectMacVtapModel, true, true, true},
+		{vc.NetXConnectMacVtapModel, true, false, true},
+		{vc.NetXConnectNoneModel, true, false, false},
+		{vc.NetXConnectNoneModel, true, true, false},
 	}
 
 	for i, d := range data {

--- a/versions.yaml
+++ b/versions.yaml
@@ -217,6 +217,11 @@ externals:
       .*/v?([\d\.]+)\.tar\.gz
     version: "v2.0.5"
 
+  golangci-lint:
+    description: "utility to run various golang linters"
+    url: "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
+    version: "v1.15.0"
+
   kubernetes:
     description: "Kubernetes project container manager"
     url: "https://github.com/kubernetes/kubernetes"

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -628,7 +628,7 @@ func newContainer(sandbox *Sandbox, contConfig ContainerConfig) (*Container, err
 	span, _ := sandbox.trace("newContainer")
 	defer span.Finish()
 
-	if contConfig.valid() == false {
+	if !contConfig.valid() {
 		return &Container{}, fmt.Errorf("Invalid container configuration")
 	}
 
@@ -1187,10 +1187,7 @@ func (c *Container) hotplugDrive() error {
 
 // isDriveUsed checks if a drive has been used for container rootfs
 func (c *Container) isDriveUsed() bool {
-	if c.state.Fstype == "" {
-		return false
-	}
-	return true
+	return !(c.state.Fstype == "")
 }
 
 func (c *Container) removeDrive() (err error) {

--- a/virtcontainers/device/drivers/generic_test.go
+++ b/virtcontainers/device/drivers/generic_test.go
@@ -13,20 +13,20 @@ import (
 
 func TestBumpAttachCount(t *testing.T) {
 	type testData struct {
-		attach      bool
 		attachCount uint
 		expectedAC  uint
+		attach      bool
 		expectSkip  bool
 		expectErr   bool
 	}
 
 	data := []testData{
-		{true, 0, 1, false, false},
-		{true, 1, 2, true, false},
-		{true, intMax, intMax, true, true},
-		{false, 0, 0, true, true},
-		{false, 1, 0, false, false},
-		{false, intMax, intMax - 1, true, false},
+		{0, 1, true, false, false},
+		{1, 2, true, true, false},
+		{intMax, intMax, true, true, true},
+		{0, 0, false, true, true},
+		{1, 0, false, false, false},
+		{intMax, intMax - 1, false, true, false},
 	}
 
 	dev := &GenericDevice{}

--- a/virtcontainers/device/manager/manager.go
+++ b/virtcontainers/device/manager/manager.go
@@ -191,7 +191,7 @@ func (dm *deviceManager) DetachDevice(id string, dr api.DeviceReceiver) error {
 	if !ok {
 		return ErrDeviceNotExist
 	}
-	if d.GetAttachCount() <= 0 {
+	if d.GetAttachCount() == 0 {
 		return ErrDeviceNotAttached
 	}
 

--- a/virtcontainers/device/manager/utils.go
+++ b/virtcontainers/device/manager/utils.go
@@ -33,9 +33,5 @@ func isVFIO(hostPath string) bool {
 
 // isBlock checks if the device is a block device.
 func isBlock(devInfo config.DeviceInfo) bool {
-	if devInfo.DevType == "b" {
-		return true
-	}
-
-	return false
+	return devInfo.DevType == "b"
 }

--- a/virtcontainers/example_pod_run_test.go
+++ b/virtcontainers/example_pod_run_test.go
@@ -68,6 +68,4 @@ func Example_createAndStartSandbox() {
 	if err != nil {
 		fmt.Printf("Could not run sandbox: %s", err)
 	}
-
-	return
 }

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -217,7 +217,7 @@ func (fc *firecracker) waitVMM(timeout int) error {
 			return nil
 		}
 
-		if int(time.Now().Sub(timeStart).Seconds()) > timeout {
+		if int(time.Since(timeStart).Seconds()) > timeout {
 			return fmt.Errorf("Failed to connect to firecrackerinstance (timeout %ds): %v", timeout, err)
 		}
 
@@ -624,7 +624,6 @@ func (fc *firecracker) addDevice(devInfo interface{}, devType deviceType) error 
 		return fc.fcAddVsock(v)
 	default:
 		fc.Logger().WithField("unknown-device-type", devInfo).Error("Adding device")
-		break
 	}
 
 	return nil

--- a/virtcontainers/hack/virtc/main.go
+++ b/virtcontainers/hack/virtc/main.go
@@ -140,17 +140,17 @@ func buildSandboxConfig(context *cli.Context) (vc.SandboxConfig, error) {
 	machineType := context.String("machine-type")
 	vmMemory := context.Uint("vm-memory")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
-	if ok != true {
+	if !ok {
 		return vc.SandboxConfig{}, fmt.Errorf("Could not convert agent type")
 	}
 
 	proxyType, ok := context.Generic("proxy").(*vc.ProxyType)
-	if ok != true {
+	if !ok {
 		return vc.SandboxConfig{}, fmt.Errorf("Could not convert proxy type")
 	}
 
 	shimType, ok := context.Generic("shim").(*vc.ShimType)
-	if ok != true {
+	if !ok {
 		return vc.SandboxConfig{}, fmt.Errorf("Could not convert shim type")
 	}
 

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -66,14 +66,8 @@ const (
 	// NetDev is the network device type.
 	netDev
 
-	// SerialDev is the serial device type.
-	serialDev // nolint: varcheck,unused
-
 	// BlockDev is the block device type.
 	blockDev
-
-	// ConsoleDev is the console device type.
-	consoleDev // nolint: varcheck,unused
 
 	// SerialPortDev is the serial port device type.
 	serialPortDev
@@ -407,11 +401,7 @@ func (conf *HypervisorConfig) assetPath(t types.AssetType) (string, error) {
 
 func (conf *HypervisorConfig) isCustomAsset(t types.AssetType) bool {
 	_, ok := conf.customAssets[t]
-	if ok {
-		return true
-	}
-
-	return false
+	return ok
 }
 
 // KernelAssetPath returns the guest kernel path
@@ -476,12 +466,12 @@ func SerializeParams(params []Param, delim string) []string {
 		if p.Key == "" && p.Value == "" {
 			continue
 		} else if p.Key == "" {
-			parameters = append(parameters, fmt.Sprintf("%s", p.Value))
+			parameters = append(parameters, fmt.Sprint(p.Value))
 		} else if p.Value == "" {
-			parameters = append(parameters, fmt.Sprintf("%s", p.Key))
+			parameters = append(parameters, fmt.Sprint(p.Key))
 		} else if delim == "" {
-			parameters = append(parameters, fmt.Sprintf("%s", p.Key))
-			parameters = append(parameters, fmt.Sprintf("%s", p.Value))
+			parameters = append(parameters, fmt.Sprint(p.Key))
+			parameters = append(parameters, fmt.Sprint(p.Value))
 		} else {
 			parameters = append(parameters, fmt.Sprintf("%s%s%s", p.Key, delim, p.Value))
 		}

--- a/virtcontainers/hypervisor_test.go
+++ b/virtcontainers/hypervisor_test.go
@@ -444,7 +444,7 @@ type testNestedVMMData struct {
 	expected    bool
 }
 
-// nolint: unused
+// nolint: unused,deadcode
 func genericTestRunningOnVMM(t *testing.T, data []testNestedVMMData) {
 	for _, d := range data {
 		f, err := ioutil.TempFile("", "cpuinfo")

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -801,7 +801,7 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec, systemdCgroup bool, passSeccomp boo
 
 	// Pass seccomp only if disable_guest_seccomp is set to false in
 	// configuration.toml and guest image is seccomp capable.
-	if passSeccomp == false {
+	if !passSeccomp {
 		grpcSpec.Linux.Seccomp = nil
 	}
 

--- a/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -261,7 +261,7 @@ func (h *Hyperstart) IsStarted() bool {
 
 	h.SetDeadline(time.Time{})
 
-	if ret == false {
+	if !ret {
 		h.CloseSockets()
 	}
 
@@ -423,7 +423,7 @@ func (h *Hyperstart) SendIoMessage(ttyMsg *TtyMessage) error {
 // CodeFromCmd translates a string command to its corresponding code.
 func (h *Hyperstart) CodeFromCmd(cmd string) (uint32, error) {
 	_, ok := CodeList[cmd]
-	if ok == false {
+	if !ok {
 		return math.MaxUint32, fmt.Errorf("unknown command '%s'", cmd)
 	}
 

--- a/virtcontainers/pkg/mock/mock.go
+++ b/virtcontainers/pkg/mock/mock.go
@@ -90,14 +90,14 @@ func StartShim(config ShimMockConfig) error {
 	}
 
 	// Print some traces to stdout
-	fmt.Fprintf(os.Stdout, ShimStdoutOutput)
+	fmt.Fprint(os.Stdout, ShimStdoutOutput)
 	os.Stdout.Close()
 
 	// Print some traces to stderr
-	fmt.Fprintf(os.Stderr, ShimStderrOutput)
+	fmt.Fprint(os.Stderr, ShimStderrOutput)
 	os.Stderr.Close()
 
-	fmt.Fprintf(f, "INFO: Shim exited properly\n")
+	fmt.Fprint(f, "INFO: Shim exited properly\n")
 
 	return nil
 }

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -80,7 +80,7 @@ const (
 // Refer to: https://github.com/opencontainers/runtime-spec/commit/37391fb
 type CompatOCIProcess struct {
 	spec.Process
-	Capabilities interface{} `json:"capabilities,omitempty" platform:"linux"`
+	Capabilities interface{} `json:"capabilities,omitempty" platform:"linux"` //nolint:govet
 }
 
 // CompatOCISpec is a structure inheriting from spec.Spec defined
@@ -90,7 +90,7 @@ type CompatOCIProcess struct {
 // Refer to: https://github.com/opencontainers/runtime-spec/commit/37391fb
 type CompatOCISpec struct {
 	spec.Spec
-	Process *CompatOCIProcess `json:"process,omitempty"`
+	Process *CompatOCIProcess `json:"process,omitempty"` //nolint:govet
 }
 
 // FactoryConfig is a structure to set the VM factory configuration.

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -122,11 +122,7 @@ func newQMPLogger() qmpLogger {
 }
 
 func (l qmpLogger) V(level int32) bool {
-	if level != 0 {
-		return true
-	}
-
-	return false
+	return level != 0
 }
 
 func (l qmpLogger) Infof(format string, v ...interface{}) {
@@ -615,7 +611,7 @@ func (q *qemu) waitSandbox(timeout int) error {
 			break
 		}
 
-		if int(time.Now().Sub(timeStart).Seconds()) > timeout {
+		if int(time.Since(timeStart).Seconds()) > timeout {
 			return fmt.Errorf("Failed to connect to QEMU instance (timeout %ds): %v", timeout, err)
 		}
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -287,9 +287,7 @@ func (q *qemuArchBase) appendConsole(devices []govmmQemu.Device, path string) []
 
 	devices = append(devices, serial)
 
-	var console govmmQemu.CharDevice
-
-	console = govmmQemu.CharDevice{
+	console := govmmQemu.CharDevice{
 		Driver:   govmmQemu.Console,
 		Backend:  govmmQemu.Socket,
 		DeviceID: "console0",

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -120,15 +120,15 @@ func TestQemuArchBaseKernelParameters(t *testing.T) {
 	qemuArchBase := newQemuArchBase()
 
 	// with debug params
-	expectedParams := []Param(qemuArchBaseKernelParams)
-	debugParams := []Param(qemuArchBaseKernelParamsDebug)
+	expectedParams := qemuArchBaseKernelParams
+	debugParams := qemuArchBaseKernelParamsDebug
 	expectedParams = append(expectedParams, debugParams...)
 	p := qemuArchBase.kernelParameters(true)
 	assert.Equal(expectedParams, p)
 
 	// with non-debug params
-	expectedParams = []Param(qemuArchBaseKernelParams)
-	nonDebugParams := []Param(qemuArchBaseKernelParamsNonDebug)
+	expectedParams = qemuArchBaseKernelParams
+	nonDebugParams := qemuArchBaseKernelParamsNonDebug
 	expectedParams = append(expectedParams, nonDebugParams...)
 	p = qemuArchBase.kernelParameters(false)
 	assert.Equal(expectedParams, p)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -205,7 +205,7 @@ func (s *Sandbox) Logger() *logrus.Entry {
 // Annotations returns any annotation that a user could have stored through the sandbox.
 func (s *Sandbox) Annotations(key string) (string, error) {
 	value, exist := s.config.Annotations[key]
-	if exist == false {
+	if !exist {
 		return "", fmt.Errorf("Annotations key %s does not exist", key)
 	}
 
@@ -492,7 +492,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	span, ctx := trace(ctx, "newSandbox")
 	defer span.Finish()
 
-	if sandboxConfig.valid() == false {
+	if !sandboxConfig.valid() {
 		return nil, fmt.Errorf("Invalid sandbox configuration")
 	}
 
@@ -1037,7 +1037,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	s.config.Containers = append(s.config.Containers, contConfig)
 
 	// Sandbox is reponsable to update VM resources needed by Containers
-	s.updateResources()
+	err = s.updateResources()
 	if err != nil {
 		return nil, err
 	}

--- a/virtcontainers/store/vc.go
+++ b/virtcontainers/store/vc.go
@@ -300,9 +300,5 @@ func ContainerRuntimeRootPath(sandboxID, containerID string) string {
 // VCSandboxStoreExists returns true if a sandbox store already exists.
 func VCSandboxStoreExists(ctx context.Context, sandboxID string) bool {
 	s := stores.findStore(SandboxConfigurationRoot(sandboxID))
-	if s != nil {
-		return true
-	}
-
-	return false
+	return s != nil
 }

--- a/virtcontainers/types.go
+++ b/virtcontainers/types.go
@@ -18,9 +18,5 @@ const (
 // IsSandbox determines if the container type can be considered as a sandbox.
 // We can consider a sandbox in case we have a PodSandbox or a RegularContainer.
 func (cType ContainerType) IsSandbox() bool {
-	if cType == PodSandbox {
-		return true
-	}
-
-	return false
+	return cType == PodSandbox
 }

--- a/virtcontainers/types/capabilities.go
+++ b/virtcontainers/types/capabilities.go
@@ -20,10 +20,7 @@ type Capabilities struct {
 
 // IsBlockDeviceSupported tells if an hypervisor supports block devices.
 func (caps *Capabilities) IsBlockDeviceSupported() bool {
-	if caps.flags&blockDeviceSupport != 0 {
-		return true
-	}
-	return false
+	return caps.flags&blockDeviceSupport != 0
 }
 
 // SetBlockDeviceSupport sets the block device support capability to true.
@@ -33,10 +30,7 @@ func (caps *Capabilities) SetBlockDeviceSupport() {
 
 // IsBlockDeviceHotplugSupported tells if an hypervisor supports hotplugging block devices.
 func (caps *Capabilities) IsBlockDeviceHotplugSupported() bool {
-	if caps.flags&blockDeviceHotplugSupport != 0 {
-		return true
-	}
-	return false
+	return caps.flags&blockDeviceHotplugSupport != 0
 }
 
 // SetBlockDeviceHotplugSupport sets the block device hotplugging capability to true.
@@ -46,10 +40,7 @@ func (caps *Capabilities) SetBlockDeviceHotplugSupport() {
 
 // IsMultiQueueSupported tells if an hypervisor supports device multi queue support.
 func (caps *Capabilities) IsMultiQueueSupported() bool {
-	if caps.flags&multiQueueSupport != 0 {
-		return true
-	}
-	return false
+	return caps.flags&multiQueueSupport != 0
 }
 
 // SetMultiQueueSupport sets the device multi queue capability to true.


### PR DESCRIPTION
gometalinter is being deprecated and will be archived April '19. Their suggestion is to switch to using golangci-lint.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>