### PR TITLE
volumes: Handle k8s empty-dirs of "default" medium type

### DIFF
--- a/pkg/katautils/utils.go
+++ b/pkg/katautils/utils.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	vc "github.com/kata-containers/runtime/virtcontainers"
 )
 
 const (
@@ -43,7 +45,9 @@ func IsEphemeralStorage(path string) bool {
 	if len(splitSourceSlice) > 1 {
 		storageType := splitSourceSlice[len(splitSourceSlice)-2]
 		if storageType == k8sEmptyDir {
-			return true
+			if _, fsType, _ := vc.GetDevicePathAndFsType(path); fsType == "tmpfs" {
+				return true
+			}
 		}
 	}
 	return false

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1138,7 +1138,7 @@ func (c *Container) hotplugDrive() error {
 	}
 
 	// If device mapper device, then fetch the full path of the device
-	devicePath, fsType, err := getDevicePathAndFsType(dev.mountPoint)
+	devicePath, fsType, err := GetDevicePathAndFsType(dev.mountPoint)
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -164,7 +164,9 @@ const (
 	procTypeIndex
 )
 
-func getDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err error) {
+// GetDevicePathAndFsType gets the device for the mount point and the file system type
+// of the mount.
+func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err error) {
 	if mountPoint == "" {
 		err = fmt.Errorf("Mount point cannot be empty")
 		return

--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -238,7 +238,7 @@ func TestGetDeviceForPathBindMount(t *testing.T) {
 }
 
 func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
-	_, _, err := getDevicePathAndFsType("")
+	_, _, err := GetDevicePathAndFsType("")
 
 	if err == nil {
 		t.Fatal()
@@ -246,7 +246,7 @@ func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
 }
 
 func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
-	path, fstype, err := getDevicePathAndFsType("/proc")
+	path, fstype, err := GetDevicePathAndFsType("/proc")
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We were considering all empty-dir k8s volumes as backed by tmpfs.
However they can be backed by a host directory as well.
Pass those as 9p volumes, while tmpfs volumes are handled as before,
namely creating a tmpfs directory inside the guest.
The only way to detect "Memory" empty-dirs is to actually check if the
volume is mounted as a tmpfs mount, since any information of k8s
"medium" is lost at the OCI layer.

Fixes #1341