### PR TITLE
s390x: add bridges function

### DIFF
--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -80,6 +80,10 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 	return q
 }
 
+func (q *qemuS390x) bridges(number uint32) []types.PCIBridge {
+	return genericBridges(number, q.machineType)
+}
+
 // appendBridges appends to devices the given bridges
 func (q *qemuS390x) appendBridges(devices []govmmQemu.Device, bridges []types.PCIBridge) []govmmQemu.Device {
 	return genericAppendBridges(devices, bridges, q.machineType)


### PR DESCRIPTION
The bridges function was missing for s390x

Fixes: #1380

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>