### PR TITLE
Allow data collection to be hidden

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -672,8 +672,27 @@ read_osbuilder_file()
 	cat "$file"
 }
 
+show_header()
+{
+	cat <<EOT
+<details>
+<summary>Show <tt>$script_name</tt> details</summary>
+<p>
+EOT
+}
+
+show_footer()
+{
+	cat <<EOT
+</p>
+</details>
+EOT
+}
+
 show_details()
 {
+	show_header
+
 	show_meta
 	show_runtime
 	show_runtime_configs
@@ -683,6 +702,8 @@ show_details()
 	show_log_details
 	show_container_mgr_details
 	show_package_versions
+
+	show_footer
 }
 
 main()

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -672,6 +672,19 @@ read_osbuilder_file()
 	cat "$file"
 }
 
+show_details()
+{
+	show_meta
+	show_runtime
+	show_runtime_configs
+	show_throttler_details
+	show_image_details
+	show_initrd_details
+	show_log_details
+	show_container_mgr_details
+	show_package_versions
+}
+
 main()
 {
 	args=$(getopt \
@@ -711,15 +724,7 @@ main()
 	[ $(id -u) -eq 0 ] || die "Need to run as root"
 	[ -n "$runtime" ] || die "cannot find runtime '$runtime_name'"
 
-	show_meta
-	show_runtime
-	show_runtime_configs
-	show_throttler_details
-	show_image_details
-	show_initrd_details
-	show_log_details
-	show_container_mgr_details
-	show_package_versions
+	show_details
 }
 
 main "$@"


### PR DESCRIPTION
Use a clever HTML trick to allow the output of the data collection script to be hidden / unhidden in the github.com interface.

See the example at the top of https://github.com/kata-containers/runtime/issues/1347.

Fixes #1386.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>