### PR TITLE
virtcontainers: improve security and mount the rootfs as read-only fs

### DIFF
--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -93,6 +93,11 @@ var noTraceKernelParam = []vc.Param{
 		Key:   "systemd.mask",
 		Value: "tmp.mount",
 	},
+	// No random seed
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-random-seed.service",
+	},
 }
 
 func getKernelParams(needSystemd, trace bool) []vc.Param {

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -32,7 +32,7 @@ var qemuPaths = map[string]string{
 
 var kernelRootParams = []Param{
 	{"root", "/dev/pmem0p1"},
-	{"rootflags", "dax,data=ordered,errors=remount-ro rw"},
+	{"rootflags", "dax,data=ordered,errors=remount-ro ro"},
 	{"rootfstype", "ext4"},
 }
 


### PR DESCRIPTION
Mounting the rootfs as read-only fs the binaries can't be modified.

fixes #1389

Signed-off-by: Julio Montes <julio.montes@intel.com>