### PR TITLE
config: Make VMCache can work with vsock

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -940,9 +940,6 @@ func checkFactoryConfig(config oci.RuntimeConfig) error {
 		if config.AgentType != vc.KataContainersAgent {
 			return errors.New("VM cache just support kata agent")
 		}
-		if config.HypervisorConfig.UseVSock {
-			return errors.New("config vsock conflicts with VM cache, please disable one of them")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
After code check and test, found VMCache can work with vsock.
Remove the code that prohibit them from working together.

Fixes: #1400

Signed-off-by: Hui Zhu <teawater@hyper.sh>