### PR TITLE
Update collect script for dax nvdimm images

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -14,6 +14,7 @@ typeset -r script_version="@VERSION@ (commit @COMMIT@)"
 typeset -r unknown="unknown"
 
 typeset -r osbuilder_file="/var/lib/osbuilder/osbuilder.yaml"
+typeset -r dax_header_size_bytes=$((2 * 1024 * 1024))
 
 # Maximum number of errors to show for a single system component
 # (such as runtime or proxy).
@@ -400,24 +401,34 @@ get_image_details()
 	local contents
 	local expected
 
-	loop_device=$(loopmount_image "$img")
-	if [ -z "$loop_device" ]; then
-		echo "$unknown"
-		return
-	fi
+	local found_valid_image=0
 
-	partitions=$(get_partitions "$loop_device")
-	if [ -z "$partitions" ]; then
-		release_device "$loop_device"
-		continue
-	fi
+	# Newer images contain a dax header, but check for both types.
+	for use_dax_offset in true false
+	do
+		loop_device=$(loopmount_image "$img" "$use_dax_offset")
+		[ -z "$loop_device" ] && continue
 
-	count=$(echo "$partitions"|wc -l)
+		partitions=$(get_partitions "$loop_device")
+		if [ -z "$partitions" ]; then
+			release_device "$loop_device"
+			continue
+		fi
 
-	expected=1
+		count=$(echo "$partitions"|wc -l)
 
-	if [ "$count" -ne "$expected" ]; then
-		release_device "$loop_device"
+		expected=1
+
+		if [ "$count" -ne "$expected" ]; then
+			release_device "$loop_device"
+			continue
+		fi
+
+		found_valid_image=1
+		break
+	done
+
+	if [ "$found_valid_image" = 0 ]; then
 		echo "$unknown"
 		return
 	fi
@@ -439,7 +450,8 @@ get_image_details()
 	unmount_partition "$mountpoint"
 	release_device "$loop_device"
 
-	echo "$contents"
+	# Supplement the output with details of whether the header was found
+	printf -- "%s\ndax-nvdimm-header: \"%s\"\n" "${contents}" "$use_dax_offset"
 }
 
 # Parameter 1: Path to the initrd file.
@@ -514,10 +526,16 @@ loopmount_image()
 {
 	local img="$1"
 	[ -n "$img" ] || die "need image file"
+	local use_dax_offset="$2"
+	[ -n "$use_dax_offset" ] || die "need dax offset value"
 
 	local device_path
 
-	losetup -fP "$img"
+	local offset=0
+
+	[ "$use_dax_offset" = true ] && offset="$dax_header_size_bytes"
+
+	losetup -fP -o "$offset" "$img"
 
 	device_path=$(losetup -j "$img" |\
 		cut -d: -f1 |\

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017-2018 Intel Corporation
+# Copyright (c) 2017-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -407,6 +407,11 @@ get_image_details()
 	fi
 
 	partitions=$(get_partitions "$loop_device")
+	if [ -z "$partitions" ]; then
+		release_device "$loop_device"
+		continue
+	fi
+
 	count=$(echo "$partitions"|wc -l)
 
 	expected=1


### PR DESCRIPTION
osbuilder recently added the ability to create images with a DAX/NVDIMM header [1], however this change broke the data collection script. Update that script to handle images with and without this header.

The data collection script will now assume a header is present. However, if it fails to find the required partition data, it will try again, this time assuming the image does not have a DAX/NVDIMM header.

Fixes #1404.

[1] - https://github.com/kata-containers/osbuilder/pull/236

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>