### PR TITLE
VMCache: check if vm_cache_endpoint file exists before VMCache server…

### DIFF
--- a/cli/factory.go
+++ b/cli/factory.go
@@ -79,7 +79,10 @@ func getUnixListener(path string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = unix.Unlink(path); err != nil && !os.IsNotExist(err) {
+	_, err = os.Stat(path)
+	if err == nil {
+		return nil, fmt.Errorf("%s already exist.  Please stop running VMCache server and remove %s", path, path)
+	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
 	l, err := net.Listen("unix", path)


### PR DESCRIPTION
… runs

There is an issue that more than one VMCache server can run with same
vm_cache_endpoint file together.
The cause is factory try to remove vm_cache_endpoint file before VMCache
server runs.
Change it to check if vm_cache_endpoint file exists before VMCache server
runs to handle the issue.

Fixes: #1385

Signed-off-by: Hui Zhu <teawater@hyper.sh>