### PR TITLE
cgroups: remove duplicate fields from state

### DIFF
--- a/virtcontainers/cgroups.go
+++ b/virtcontainers/cgroups.go
@@ -281,36 +281,36 @@ func (s *Sandbox) cpuResources() *specs.LinuxCPU {
 			continue
 		}
 
-		if c.state.Resources.CPU == nil {
+		if c.config.Resources.CPU == nil {
 			continue
 		}
 
-		if c.state.Resources.CPU.Shares != nil {
-			shares = uint64(math.Max(float64(*c.state.Resources.CPU.Shares), float64(shares)))
+		if c.config.Resources.CPU.Shares != nil {
+			shares = uint64(math.Max(float64(*c.config.Resources.CPU.Shares), float64(shares)))
 		}
 
-		if c.state.Resources.CPU.Quota != nil {
-			quota += *c.state.Resources.CPU.Quota
+		if c.config.Resources.CPU.Quota != nil {
+			quota += *c.config.Resources.CPU.Quota
 		}
 
-		if c.state.Resources.CPU.Period != nil {
-			period = uint64(math.Max(float64(*c.state.Resources.CPU.Period), float64(period)))
+		if c.config.Resources.CPU.Period != nil {
+			period = uint64(math.Max(float64(*c.config.Resources.CPU.Period), float64(period)))
 		}
 
-		if c.state.Resources.CPU.Cpus != "" {
-			cpu.Cpus += c.state.Resources.CPU.Cpus + ","
+		if c.config.Resources.CPU.Cpus != "" {
+			cpu.Cpus += c.config.Resources.CPU.Cpus + ","
 		}
 
-		if c.state.Resources.CPU.RealtimeRuntime != nil {
-			realtimeRuntime += *c.state.Resources.CPU.RealtimeRuntime
+		if c.config.Resources.CPU.RealtimeRuntime != nil {
+			realtimeRuntime += *c.config.Resources.CPU.RealtimeRuntime
 		}
 
-		if c.state.Resources.CPU.RealtimePeriod != nil {
-			realtimePeriod += *c.state.Resources.CPU.RealtimePeriod
+		if c.config.Resources.CPU.RealtimePeriod != nil {
+			realtimePeriod += *c.config.Resources.CPU.RealtimePeriod
 		}
 
-		if c.state.Resources.CPU.Mems != "" {
-			cpu.Mems += c.state.Resources.CPU.Mems + ","
+		if c.config.Resources.CPU.Mems != "" {
+			cpu.Mems += c.config.Resources.CPU.Mems + ","
 		}
 	}
 

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1295,7 +1295,7 @@ func (c *Container) newCgroups() error {
 		return fmt.Errorf("Could not create cgroup for %v: %v", c.state.CgroupPath, err)
 	}
 
-	c.state.Resources = resources
+	c.config.Resources = resources
 
 	// Add shim into cgroup
 	if c.process.Pid > 0 {
@@ -1359,8 +1359,8 @@ func (c *Container) updateCgroups(resources specs.LinuxResources) error {
 	}
 
 	// store new resources
-	c.state.Resources = r
-	if err := c.store.Store(store.State, c.state); err != nil {
+	c.config.Resources = r
+	if err := c.storeContainer(); err != nil {
 		return err
 	}
 

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -8,8 +8,6 @@ package types
 import (
 	"fmt"
 	"strings"
-
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // StateString is a string representing a sandbox state.
@@ -50,12 +48,6 @@ type State struct {
 	// CgroupPath is the cgroup hierarchy where sandbox's processes
 	// including the hypervisor are placed.
 	CgroupPath string `json:"cgroupPath,omitempty"`
-
-	// Resources contains the resources assigned to the container.
-	// When a container is created resources specified in the config json
-	// are used, those resources change when a container is updated but
-	// the config json is not updated.
-	Resources specs.LinuxResources `json:"resources,omitempty"`
 }
 
 // Valid checks that the sandbox state is valid.


### PR DESCRIPTION
Fixes: #1415

Container resources have been saved to ContainerConfig so there's no
need to save it again in state.json.

Signed-off-by: Wei Zhang <zhangwei555@huawei.com>