### PR TITLE
qemu: fix qemu leak when failed to start container

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -108,7 +108,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		}
 	}()
 
-	if err := s.getAndStoreGuestDetails(); err != nil {
+	if err = s.getAndStoreGuestDetails(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -908,7 +908,7 @@ func (s *Sandbox) ListRoutes() ([]*vcTypes.Route, error) {
 }
 
 // startVM starts the VM.
-func (s *Sandbox) startVM() error {
+func (s *Sandbox) startVM() (err error) {
 	span, ctx := s.trace("startVM")
 	defer span.Finish()
 
@@ -938,6 +938,12 @@ func (s *Sandbox) startVM() error {
 	}); err != nil {
 		return err
 	}
+
+	defer func() {
+		if err != nil {
+			s.hypervisor.stopSandbox()
+		}
+	}()
 
 	// In case of vm factory, network interfaces are hotplugged
 	// after vm is started.


### PR DESCRIPTION
add vm cleanup before startVM()

Fixes: #1426

Signed-off-by: Ace-Tang <aceapril@126.com>