### PR TITLE
linter: remove deadcode linter check for generic item

### DIFF
--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -52,9 +52,9 @@ const (
 	kernelPropertyCorrect = "Kernel property value correct"
 
 	// these refer to fields in the procCPUINFO file
-	genericCPUFlagsTag    = "flags"      // nolint: varcheck, unused
-	genericCPUVendorField = "vendor_id"  // nolint: varcheck, unused
-	genericCPUModelField  = "model name" // nolint: varcheck, unused
+	genericCPUFlagsTag    = "flags"      // nolint: varcheck, unused, deadcode
+	genericCPUVendorField = "vendor_id"  // nolint: varcheck, unused, deadcode
+	genericCPUModelField  = "model name" // nolint: varcheck, unused, deadcode
 )
 
 // variables rather than consts to allow tests to modify them

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -27,14 +27,14 @@ type testModuleData struct {
 	contents string
 }
 
-// nolint: structcheck, unused
+// nolint: structcheck, unused, deadcode
 type testCPUData struct {
 	vendorID    string
 	flags       string
 	expectError bool
 }
 
-// nolint: structcheck, unused
+// nolint: structcheck, unused, deadcode
 type testCPUDetail struct {
 	contents       string
 	expectedVendor string
@@ -147,7 +147,7 @@ func makeCPUInfoFile(path, vendorID, flags string) error {
 	return ioutil.WriteFile(path, contents.Bytes(), testFileMode)
 }
 
-// nolint: unused
+// nolint: unused, deadcode
 func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel string, validContents string, data []testCPUDetail) {
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -244,7 +244,7 @@ func getExpectedAgentDetails(config oci.RuntimeConfig) (AgentInfo, error) {
 	}, nil
 }
 
-// nolint: unused
+// nolint: unused, deadcode
 func genericGetExpectedHostDetails(tmpdir string, expectedVendor string, expectedModel string, expectedVMContainerCapable bool) (HostInfo, error) {
 	type filesToCreate struct {
 		file     string

--- a/virtcontainers/hypervisor_test.go
+++ b/virtcontainers/hypervisor_test.go
@@ -437,14 +437,14 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 	}
 }
 
-// nolint: unused
+// nolint: unused, deadcode
 type testNestedVMMData struct {
 	content     []byte
 	expectedErr bool
 	expected    bool
 }
 
-// nolint: unused,deadcode
+// nolint: unused, deadcode
 func genericTestRunningOnVMM(t *testing.T, data []testNestedVMMData) {
 	for _, d := range data {
 		f, err := ioutil.TempFile("", "cpuinfo")

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1425,7 +1425,7 @@ func (q *qemu) resizeMemory(reqMemMB uint32, memoryBlockSizeMB uint32) (uint32, 
 }
 
 // genericAppendBridges appends to devices the given bridges
-// nolint: unused
+// nolint: unused, deadcode
 func genericAppendBridges(devices []govmmQemu.Device, bridges []types.PCIBridge, machineType string) []govmmQemu.Device {
 	bus := defaultPCBridgeBus
 	switch machineType {
@@ -1457,7 +1457,7 @@ func genericAppendBridges(devices []govmmQemu.Device, bridges []types.PCIBridge,
 	return devices
 }
 
-// nolint: unused
+// nolint: unused, deadcode
 func genericBridges(number uint32, machineType string) []types.PCIBridge {
 	var bridges []types.PCIBridge
 	var bt types.PCIType
@@ -1490,7 +1490,7 @@ func genericBridges(number uint32, machineType string) []types.PCIBridge {
 	return bridges
 }
 
-// nolint: unused
+// nolint: unused, deadcode
 func genericMemoryTopology(memoryMb, hostMemoryMb uint64, slots uint8, memoryOffset uint32) govmmQemu.Memory {
 	// image NVDIMM device needs memory space 1024MB
 	// See https://github.com/clearcontainers/runtime/issues/380


### PR DESCRIPTION
ARM CI is failing.
Copy log from #1414:
```
18:09:54 func genericMemoryTopology(memoryMb, hostMemoryMb uint64, slots uint8, memoryOffset uint32) govmmQemu.Memory {
18:09:54      ^
18:09:54 cli/kata-check.go:55:2: `genericCPUFlagsTag` is unused (deadcode)
18:09:54 	genericCPUFlagsTag    = "flags"      // nolint: varcheck, unused
18:09:54 	^
18:09:54 cli/kata-check.go:56:2: `genericCPUVendorField` is unused (deadcode)
18:09:54 	genericCPUVendorField = "vendor_id"  // nolint: varcheck, unused
18:09:54 	^
18:09:54 cli/kata-check.go:57:2: `genericCPUModelField` is unused (deadcode)
18:09:54 	genericCPUModelField  = "model name" // nolint: varcheck, unused
18:09:54 	^
18:09:54 cli/kata-check_test.go:31:6: `testCPUData` is unused (deadcode)
18:09:54 type testCPUData struct {
18:09:54      ^
18:09:54 cli/kata-check_test.go:151:6: `genericTestGetCPUDetails` is unused (deadcode)
18:09:54 func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel string, validContents string, data []testCPUDetail) {
18:09:54      ^
18:10:07 Build step 'Execute shell' marked build as failure
```
After we switched golang linter to golangci-lint, we has extra `deadcode` linter check, and we need to remove this linter check for all `generic*` items.

Fixes: #1432

Signed-off-by: Penny Zheng <penny.zheng@arm.com>