### PR TITLE
s390x: not set socketID and threadID

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1109,8 +1109,8 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		coreID := fmt.Sprintf("%d", hc.Properties.Core)
 		threadID := fmt.Sprintf("%d", hc.Properties.Thread)
 
-		// If CPU type is IBM pSeries, we do not set socketID and threadID
-		if machine.Type == "pseries" {
+		// If CPU type is IBM pSeries or Z, we do not set socketID and threadID
+		if machine.Type == "pseries" || machine.Type == "s390-ccw-virtio" {
 			socketID = ""
 			threadID = ""
 		}


### PR DESCRIPTION
For cpu hotplug, the options socketID and threadID are not used.

Fixes: #1448

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>