### PR TITLE
vsock: Pass info about vsock being used or not to the agent.

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -94,8 +94,9 @@ const (
 	qmpExecCatCmd                     = "exec:cat"
 	qmpMigrationWaitTimeout           = 5 * time.Second
 
-	scsiControllerID = "scsi0"
-	rngID            = "rng0"
+	scsiControllerID  = "scsi0"
+	rngID             = "rng0"
+	vsockKernelOption = "agent.use_vsock"
 )
 
 var qemuMajorVersion int
@@ -151,6 +152,11 @@ func (q *qemu) kernelParameters() string {
 
 	// set the maximum number of vCPUs
 	params = append(params, Param{"nr_cpus", fmt.Sprintf("%d", q.config.DefaultMaxVCPUs)})
+
+	// Add a kernel param to indicate if vsock is being used.
+	// This will be consumed by the agent to determine if it needs to listen on
+	// a serial or vsock channel
+	params = append(params, Param{vsockKernelOption, strconv.FormatBool(q.config.UseVSock)})
 
 	// add the params specified by the provided config. As the kernel
 	// honours the last parameter value set and since the config-provided

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -56,7 +56,7 @@ func testQemuKernelParameters(t *testing.T, kernelParams []Param, expected strin
 }
 
 func TestQemuKernelParameters(t *testing.T) {
-	expectedOut := fmt.Sprintf("panic=1 nr_cpus=%d foo=foo bar=bar", MaxQemuVCPUs())
+	expectedOut := fmt.Sprintf("panic=1 nr_cpus=%d agent.use_vsock=false foo=foo bar=bar", MaxQemuVCPUs())
 	params := []Param{
 		{
 			Key:   "foo",


### PR DESCRIPTION
Instead of the agent trying to determine if a serial
or vsock channel is used, pass this information explicitly
as a kernel command line option.

Fixes #1457

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>