### PR TITLE
Stable 1.5 backports

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -16,6 +16,9 @@ clone_tests_repo()
 	fi
 
 	go get -d -u "$tests_repo" || true
+	if [ -n "${TRAVIS_BRANCH:-}" ]; then
+		( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
+	fi
 }
 
 run_static_checks()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/kata-containers/runtime.svg?branch=master)](https://travis-ci.org/kata-containers/runtime)
-[![Build Status](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-16-04-master/badge/icon)](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-16-04-master/)
+[![Build Status](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/badge/icon)](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/runtime)](https://goreportcard.com/report/github.com/kata-containers/runtime)
 [![GoDoc](https://godoc.org/github.com/kata-containers/runtime?status.svg)](https://godoc.org/github.com/kata-containers/runtime)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the
 
 ## Architecture overview
 
-See the [architecture overview](https://github.com/kata-containers/documentation/blob/master/architecture.md)
+See the [architecture overview](https://github.com/kata-containers/documentation/blob/master/design/architecture.md)
 for details on the Kata Containers design.
 
 ## Configuration

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -359,12 +359,13 @@ func (h hypervisor) getInitrdAndImage() (initrd string, image string, err error)
 	return
 }
 
-func (p proxy) path() string {
-	if p.Path == "" {
-		return defaultProxyPath
+func (p proxy) path() (string, error) {
+	path := p.Path
+	if path == "" {
+		path = defaultProxyPath
 	}
 
-	return p.Path
+	return ResolvePath(path)
 }
 
 func (p proxy) debug() bool {
@@ -596,8 +597,13 @@ func updateRuntimeConfigProxy(configPath string, tomlConf tomlConfig, config *oc
 			config.ProxyType = vc.KataProxyType
 		}
 
+		path, err := proxy.path()
+		if err != nil {
+			return err
+		}
+
 		config.ProxyConfig = vc.ProxyConfig{
-			Path:  proxy.path(),
+			Path:  path,
 			Debug: proxy.debug(),
 		}
 	}

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -1110,13 +1110,43 @@ func TestHypervisorDefaultsGuestHookPath(t *testing.T) {
 }
 
 func TestProxyDefaults(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir(testDir, "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	testProxyPath := filepath.Join(tmpdir, "proxy")
+	testProxyLinkPath := filepath.Join(tmpdir, "proxy-link")
+
+	err = createEmptyFile(testProxyPath)
+	assert.NoError(err)
+
+	err = syscall.Symlink(testProxyPath, testProxyLinkPath)
+	assert.NoError(err)
+
+	savedProxyPath := defaultProxyPath
+
+	defer func() {
+		defaultProxyPath = savedProxyPath
+	}()
+
+	defaultProxyPath = testProxyPath
 	p := proxy{}
+	path, err := p.path()
+	assert.NoError(err)
+	assert.Equal(path, defaultProxyPath, "default proxy path wrong")
 
-	assert.Equal(t, p.path(), defaultProxyPath, "default proxy path wrong")
+	// test path resolution
+	defaultProxyPath = testProxyLinkPath
+	p = proxy{}
+	path, err = p.path()
+	assert.NoError(err)
+	assert.Equal(path, testProxyPath)
 
-	path := "/foo/bar/baz/proxy"
-	p.Path = path
-	assert.Equal(t, p.path(), path, "custom proxy path wrong")
+	assert.False(p.debug())
+	p.Debug = true
+	assert.True(p.debug())
 }
 
 func TestShimDefaults(t *testing.T) {

--- a/virtcontainers/Makefile
+++ b/virtcontainers/Makefile
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 PREFIX := /usr
 BIN_DIR := $(PREFIX)/bin
 VC_BIN_DIR := $(BIN_DIR)/virtcontainers/bin
@@ -10,6 +16,7 @@ CC_SHIM_DIR := shim/mock/cc-shim
 CC_SHIM_BIN := cc-shim
 KATA_SHIM_DIR := shim/mock/kata-shim
 KATA_SHIM_BIN := kata-shim
+MK_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 #
 # Pretty printing
@@ -49,10 +56,10 @@ binaries: virtc hook cc-shim kata-shim
 check: check-go-static check-go-test
 
 check-go-static:
-	bash .ci/go-lint.sh
+	bash $(MK_DIR)/../.ci/go-lint.sh
 
 check-go-test:
-	bash .ci/go-test.sh \
+	bash $(MK_DIR)/../.ci/go-test.sh \
 		$(TEST_BIN_DIR)/$(CC_SHIM_BIN) \
 		$(TEST_BIN_DIR)/$(KATA_SHIM_BIN) \
 		$(TEST_BIN_DIR)/$(HOOK_BIN)

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -106,7 +106,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		}
 	}()
 
-	if err := s.getAndStoreGuestDetails(); err != nil {
+	if err = s.getAndStoreGuestDetails(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -923,7 +923,7 @@ func (s *Sandbox) ListRoutes() ([]*vcTypes.Route, error) {
 }
 
 // startVM starts the VM.
-func (s *Sandbox) startVM() error {
+func (s *Sandbox) startVM() (err error) {
 	span, ctx := s.trace("startVM")
 	defer span.Finish()
 
@@ -953,6 +953,12 @@ func (s *Sandbox) startVM() error {
 	}); err != nil {
 		return err
 	}
+
+	defer func() {
+		if err != nil {
+			s.hypervisor.stopSandbox()
+		}
+	}()
 
 	// In case of vm factory, network interfaces are hotplugged
 	// after vm is started.


### PR DESCRIPTION
relevant backports since 1.6:
096fa04 qemu: fix qemu leak when failed to start container
fb64a3e doc: update architecture.md link
config: validate proxy path
virtcontainers: makefile fix .ci path