### PR TITLE
qemu: Remove the storage directories if qemu get from the factory

### DIFF
--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -279,6 +279,10 @@ type HypervisorConfig struct {
 
 	// GuestHookPath is the path within the VM that will be used for 'drop-in' hooks
 	GuestHookPath string
+
+	// VMid is the id of the VM that create the hypervisor if the VM is created by the factory.
+	// VMid is "" if the hypervisor is not created by the factory.
+	VMid string
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -690,6 +690,17 @@ func (q *qemu) cleanupVM() error {
 		}
 	}
 
+	if q.config.VMid != "" {
+		dir = store.SandboxConfigurationRootPath(q.config.VMid)
+		if err := os.RemoveAll(dir); err != nil {
+			q.Logger().WithError(err).WithField("path", dir).Warnf("failed to remove vm path")
+		}
+		dir = store.SandboxRuntimeRootPath(q.config.VMid)
+		if err := os.RemoveAll(dir); err != nil {
+			q.Logger().WithError(err).WithField("path", dir).Warnf("failed to remove vm path")
+		}
+	}
+
 	return nil
 }
 

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -461,6 +461,7 @@ func (v *VM) assignSandbox(s *Sandbox) error {
 	}
 
 	s.hypervisor = v.hypervisor
+	s.config.HypervisorConfig.VMid = v.id
 
 	return nil
 }


### PR DESCRIPTION
Store related in directory /var/lib/vc/sbs and /run/vc/sbs if
vm template is enabled.
The cause is NewVM and NewVMFromGrpc will create vcStore with
VM's ID and set it as store of hypervisor if the factory is enabled.

This commit record the VM's ID to HypervisorConfig.VMid and remove
directories in qemu.cleanupVM to handle the issue.

Fixes: #1452

Signed-off-by: Hui Zhu <teawater@hyper.sh>