### PR TITLE
katautils: fix the issue of missing proxy debug config

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -598,6 +598,9 @@ func updateRuntimeConfigHypervisor(configPath string, tomlConf tomlConfig, confi
 func updateRuntimeConfigProxy(configPath string, tomlConf tomlConfig, config *oci.RuntimeConfig, builtIn bool) error {
 	if builtIn {
 		config.ProxyType = vc.KataBuiltInProxyType
+		config.ProxyConfig = vc.ProxyConfig{
+			Debug: config.Debug,
+		}
 		return nil
 	}
 


### PR DESCRIPTION
When used builtin proxy, it's better to config the proxy
debug based on setting in kata configuration.

Fixes:#1495

Signed-off-by: lifupan <lifupan@gmail.com>