### PR TITLE
travis: use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 #
 
 sudo: required
-dist: trusty
+dist: xenial
 
 language: go
 os:


### PR DESCRIPTION
We have hit an issue using trusty in travis and go 1.11.7
Using xenial the issue is fixed.

Fixes: #1492.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>