### PR TITLE
network: Make tcfilter model as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ifneq (,$(QEMUCMD))
 
     # qemu-specific options (all should be suffixed by "_QEMU")
     DEFBLOCKSTORAGEDRIVER_QEMU := virtio-scsi
-    DEFNETWORKMODEL_QEMU := macvtap
+    DEFNETWORKMODEL_QEMU := tcfilter
     KERNELNAME_QEMU = $(call MAKE_KERNEL_NAME,$(KERNELTYPE))
     KERNELPATH_QEMU = $(KERNELDIR)/$(KERNELNAME_QEMU)
 endif

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -112,7 +112,7 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 // DefaultNetInterworkingModel is a package level default
 // that determines how the VM should be connected to the
 // the container network interface
-var DefaultNetInterworkingModel = NetXConnectMacVtapModel
+var DefaultNetInterworkingModel = NetXConnectTCFilterModel
 
 // Introduces constants related to networking
 const (


### PR DESCRIPTION
tcfilter requires no changes to the interface provided by the network
plugin and supports a larger set of plugins.

Fixes #1501

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>