### PR TITLE
travis: Change dist to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 #
 
 sudo: required
-dist: trusty
+dist: xenial
 
 language: go
 os:


### PR DESCRIPTION
travis meet golang build issue in trusty.
Change dist to xenial to handle the issue.

Fixes: #1492

Signed-off-by: Hui Zhu <teawater@hyper.sh>