### PR TITLE
cli: fix kata-check test

### DIFF
--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -215,7 +215,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(count, uint32(0))
 
-	re := regexp.MustCompile(`\bwarning\b.*\bnested\b`)
+	re := regexp.MustCompile(`.*\bnested\b`)
 	matches := re.FindAllStringSubmatch(buf.String(), -1)
 	assert.NotEmpty(matches)
 }
@@ -309,7 +309,7 @@ func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(count, uint32(0))
 
-	re := regexp.MustCompile(`\bwarning\b.*\bunrestricted_guest\b`)
+	re := regexp.MustCompile(`.*\bunrestricted_guest\b`)
 	matches := re.FindAllStringSubmatch(buf.String(), -1)
 	assert.NotEmpty(matches)
 }


### PR DESCRIPTION
We don't really require nested nor unrestricted_guest to run. And there
is no point validating host cpu properties in UT.

Fixes: #1508
