### PR TITLE
support-vsock: load vhost_vsock module if it isn't built-in

### DIFF
--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	cpuFlagsTag        = genericCPUFlagsTag
-	archCPUVendorField = genericCPUVendorField
-	archCPUModelField  = genericCPUModelField
-	archGenuineIntel   = "GenuineIntel"
-	archAuthenticAMD   = "AuthenticAMD"
-	msgKernelVM        = "Kernel-based Virtual Machine"
-	msgKernelVirtio    = "Host kernel accelerator for virtio"
-	msgKernelVirtioNet = "Host kernel accelerator for virtio network"
+	cpuFlagsTag               = genericCPUFlagsTag
+	archCPUVendorField        = genericCPUVendorField
+	archCPUModelField         = genericCPUModelField
+	archGenuineIntel          = "GenuineIntel"
+	archAuthenticAMD          = "AuthenticAMD"
+	msgKernelVM               = "Kernel-based Virtual Machine"
+	msgKernelVirtio           = "Host kernel accelerator for virtio"
+	msgKernelVirtioNet        = "Host kernel accelerator for virtio network"
+	msgKernelVirtioVhostVsock = "Host Support for Linux VM Sockets"
 )
 
 // CPU types
@@ -75,17 +76,25 @@ func setCPUtype() error {
 		}
 		archRequiredKernelModules = map[string]kernelModule{
 			"kvm": {
-				desc: msgKernelVM,
+				desc:     msgKernelVM,
+				required: true,
 			},
 			"kvm_intel": {
 				desc:       "Intel KVM",
 				parameters: kvmIntelParams,
+				required:   true,
 			},
 			"vhost": {
-				desc: msgKernelVirtio,
+				desc:     msgKernelVirtio,
+				required: true,
 			},
 			"vhost_net": {
-				desc: msgKernelVirtioNet,
+				desc:     msgKernelVirtioNet,
+				required: true,
+			},
+			"vhost_vsock": {
+				desc:     msgKernelVirtioVhostVsock,
+				required: false,
 			},
 		}
 	} else if cpuType == cpuTypeAMD {
@@ -99,16 +108,24 @@ func setCPUtype() error {
 		}
 		archRequiredKernelModules = map[string]kernelModule{
 			"kvm": {
-				desc: msgKernelVM,
+				desc:     msgKernelVM,
+				required: true,
 			},
 			"kvm_amd": {
-				desc: "AMD KVM",
+				desc:     "AMD KVM",
+				required: true,
 			},
 			"vhost": {
-				desc: msgKernelVirtio,
+				desc:     msgKernelVirtio,
+				required: true,
 			},
 			"vhost_net": {
-				desc: msgKernelVirtioNet,
+				desc:     msgKernelVirtioNet,
+				required: true,
+			},
+			"vhost_vsock": {
+				desc:     msgKernelVirtioVhostVsock,
+				required: false,
 			},
 		}
 	}

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -171,6 +171,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 				"nested":             "Y",
 				"unrestricted_guest": "Y",
 			},
+			required: true,
 		},
 	}
 
@@ -255,6 +256,7 @@ func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 				"nested":             "Y",
 				"unrestricted_guest": "Y",
 			},
+			required: true,
 		},
 	}
 

--- a/cli/kata-check_arm64.go
+++ b/cli/kata-check_arm64.go
@@ -30,13 +30,20 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
 	},
 	"vhost": {
-		desc: "Host kernel accelerator for virtio",
+		desc:     "Host kernel accelerator for virtio",
+		required: true,
 	},
 	"vhost_net": {
-		desc: "Host kernel accelerator for virtio network",
+		desc:     "Host kernel accelerator for virtio network",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -42,10 +42,16 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
 	},
 	"kvm_hv": {
-		desc: "Kernel-based Virtual Machine hardware virtualization",
+		desc:     "Kernel-based Virtual Machine hardware virtualization",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_s390x.go
+++ b/cli/kata-check_s390x.go
@@ -33,7 +33,12 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -502,6 +502,7 @@ func TestCheckCheckKernelModules(t *testing.T) {
 		"foo": {
 			desc:       "desc",
 			parameters: map[string]string{},
+			required:   true,
 		},
 		"bar": {
 			desc: "desc",
@@ -511,6 +512,7 @@ func TestCheckCheckKernelModules(t *testing.T) {
 				"param3": "a",
 				"param4": ".",
 			},
+			required: true,
 		},
 	}
 
@@ -570,6 +572,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "wibble",
 			},
+			required: true,
 		},
 	}
 
@@ -617,6 +620,7 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "wibble",
 			},
+			required: true,
 		},
 	}
 
@@ -713,6 +717,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 		"foo": {
 			desc:       "desc",
 			parameters: map[string]string{},
+			required:   true,
 		},
 		"bar": {
 			desc: "desc",
@@ -720,6 +725,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 				"param1": "hello",
 				"param2": "world",
 			},
+			required: true,
 		},
 	}
 
@@ -731,6 +737,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "moo",
 			},
+			required: true,
 		},
 	}
 
@@ -740,6 +747,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "bar",
 			},
+			required: true,
 		},
 	}
 

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -719,13 +719,10 @@ func TestMinimalRuntimeConfigWithVsock(t *testing.T) {
 	[agent.kata]
 `
 	orgVHostVSockDevicePath := utils.VHostVSockDevicePath
-	orgVSockDevicePath := utils.VSockDevicePath
 	defer func() {
 		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
-		utils.VSockDevicePath = orgVSockDevicePath
 	}()
 	utils.VHostVSockDevicePath = "/dev/null"
-	utils.VSockDevicePath = "/dev/null"
 
 	configPath := path.Join(dir, "runtime.toml")
 	err = createConfig(configPath, runtimeMinimalConfig)
@@ -765,13 +762,10 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 	disableBlock := true
 	enableIOThreads := true
 	hotplugVFIOOnRootBus := true
-	orgVSockDevicePath := utils.VSockDevicePath
 	orgVHostVSockDevicePath := utils.VHostVSockDevicePath
 	defer func() {
-		utils.VSockDevicePath = orgVSockDevicePath
 		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
 	}()
-	utils.VSockDevicePath = "/dev/abc/xyz"
 	utils.VHostVSockDevicePath = "/dev/abc/xyz"
 
 	hypervisor := hypervisor{
@@ -808,7 +802,6 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	utils.VSockDevicePath = "/dev/null"
 	utils.VHostVSockDevicePath = "/dev/null"
 
 	// all paths exist now

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -29,9 +29,6 @@ const MibToBytesShift = 20
 // See unix(7).
 const MaxSocketPathLen = 107
 
-// VSockDevicePath path to vsock device
-var VSockDevicePath = "/dev/vsock"
-
 // VHostVSockDevicePath path to vhost-vsock device
 var VHostVSockDevicePath = "/dev/vhost-vsock"
 
@@ -234,10 +231,6 @@ func BuildSocketPath(elements ...string) (string, error) {
 
 // SupportsVsocks returns true if vsocks are supported, otherwise false
 func SupportsVsocks() bool {
-	if _, err := os.Stat(VSockDevicePath); err != nil {
-		return false
-	}
-
 	if _, err := os.Stat(VHostVSockDevicePath); err != nil {
 		return false
 	}

--- a/virtcontainers/utils/utils_test.go
+++ b/virtcontainers/utils/utils_test.go
@@ -298,23 +298,12 @@ func TestBuildSocketPath(t *testing.T) {
 func TestSupportsVsocks(t *testing.T) {
 	assert := assert.New(t)
 
-	orgVSockDevicePath := VSockDevicePath
 	orgVHostVSockDevicePath := VHostVSockDevicePath
 	defer func() {
-		VSockDevicePath = orgVSockDevicePath
 		VHostVSockDevicePath = orgVHostVSockDevicePath
 	}()
 
-	VSockDevicePath = "/abc/xyz/123"
 	VHostVSockDevicePath = "/abc/xyz/123"
-	assert.False(SupportsVsocks())
-
-	vSockDeviceFile, err := ioutil.TempFile("", "vsock")
-	assert.NoError(err)
-	defer os.Remove(vSockDeviceFile.Name())
-	defer vSockDeviceFile.Close()
-	VSockDevicePath = vSockDeviceFile.Name()
-
 	assert.False(SupportsVsocks())
 
 	vHostVSockFile, err := ioutil.TempFile("", "vhost-vsock")


### PR DESCRIPTION
# Description of problem
In a few host machines, when vhost_vsock isn't built-in, but could be loadable, value `SupportVoscks` from `kata-env` still outputs false.
We add `modprobe -i vhost_vsock` in func `SupportsVsocks` to try to avoid above scenario.

# Expected result
```
[Host]
  Kernel = "5.0.7"
  Architecture = "arm64"
  VMContainerCapable = true
  SupportVSocks = true
  [Host.Distro]
    Name = "Ubuntu"
    Version = "18.04"
  [Host.CPU]
    Vendor = "3rd Party Limited"
    Model = "v8"
```

# Actual result
```
[Host]
  Kernel = "5.0.7"
  Architecture = "arm64"
  VMContainerCapable = true
  SupportVSocks = false
  [Host.Distro]
    Name = "Ubuntu"
    Version = "18.04"
  [Host.CPU]
    Vendor = "3rd Party Limited"
    Model = "v8"
```
Related: #1195 #581