### PR TITLE
virtcontainers: prepend a kata specific string to host cgroups path

### DIFF
--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -863,6 +863,11 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 	cleanUp()
 
 	config := newTestSandboxConfigNoop()
+	cgroupPath, err := renameCgroupPath(utils.DefaultCgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:        filepath.Join(testDir, testKernel),
 		ImagePath:         filepath.Join(testDir, testImage),
@@ -889,7 +894,7 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 				ID: containerID,
 				State: types.State{
 					State:      types.StateReady,
-					CgroupPath: utils.DefaultCgroupPath,
+					CgroupPath: cgroupPath,
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -922,6 +927,11 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 	cleanUp()
 
 	config := newTestSandboxConfigNoop()
+	cgroupPath, err := renameCgroupPath(utils.DefaultCgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:        filepath.Join(testDir, testKernel),
 		ImagePath:         filepath.Join(testDir, testImage),
@@ -948,7 +958,7 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 				ID: containerID,
 				State: types.State{
 					State:      types.StateRunning,
-					CgroupPath: utils.DefaultCgroupPath,
+					CgroupPath: cgroupPath,
 				},
 				PID:         0,
 				RootFs:      filepath.Join(testDir, testBundle),
@@ -1734,7 +1744,12 @@ func TestStatusContainerStateReady(t *testing.T) {
 
 	// (homage to a great album! ;)
 	contID := "101"
+
 	config := newTestSandboxConfigNoop()
+	cgroupPath, err := renameCgroupPath(utils.DefaultCgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx := context.Background()
 	p, err := CreateSandbox(ctx, config, nil)
@@ -1772,7 +1787,7 @@ func TestStatusContainerStateReady(t *testing.T) {
 		ID: contID,
 		State: types.State{
 			State:      types.StateReady,
-			CgroupPath: utils.DefaultCgroupPath,
+			CgroupPath: cgroupPath,
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),
@@ -1800,7 +1815,12 @@ func TestStatusContainerStateRunning(t *testing.T) {
 
 	// (homage to a great album! ;)
 	contID := "101"
+
 	config := newTestSandboxConfigNoop()
+	cgroupPath, err := renameCgroupPath(utils.DefaultCgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx := context.Background()
 	p, err := CreateSandbox(ctx, config, nil)
@@ -1848,7 +1868,7 @@ func TestStatusContainerStateRunning(t *testing.T) {
 		ID: contID,
 		State: types.State{
 			State:      types.StateRunning,
-			CgroupPath: utils.DefaultCgroupPath,
+			CgroupPath: cgroupPath,
 		},
 		PID:         0,
 		RootFs:      filepath.Join(testDir, testBundle),

--- a/virtcontainers/cgroups.go
+++ b/virtcontainers/cgroups.go
@@ -29,6 +29,12 @@ type cgroupPather interface {
 // where path is defined by the containers manager
 const cgroupKataPath = "/kata/"
 
+// prepend a kata specific string to oci cgroup path to
+// form a different cgroup path, thus cAdvisor couldn't
+// find kata containers cgroup path on host to prevent it
+// from grabbing the stats data.
+const cgroupKataPrefix = "kata"
+
 var cgroupsLoadFunc = cgroups.Load
 var cgroupsNewFunc = cgroups.New
 
@@ -354,4 +360,15 @@ func validCPUResources(cpuSpec *specs.LinuxCPU) *specs.LinuxCPU {
 	}
 
 	return &cpu
+}
+
+func renameCgroupPath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("Cgroup path is empty")
+	}
+
+	cgroupPathDir := filepath.Dir(path)
+	cgroupPathName := fmt.Sprintf("%s_%s", cgroupKataPrefix, filepath.Base(path))
+	return filepath.Join(cgroupPathDir, cgroupPathName), nil
+
 }

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1297,7 +1297,7 @@ func (c *Container) detachDevices() error {
 }
 
 // creates a new cgroup and return the cgroups path
-func (c *Container) newCgroups() error {
+func (c *Container) newCgroups() (err error) {
 	ann := c.GetAnnotations()
 
 	config, ok := ann[annotations.ConfigJSONKey]
@@ -1319,7 +1319,12 @@ func (c *Container) newCgroups() error {
 		resources.CPU = validCPUResources(spec.Linux.Resources.CPU)
 	}
 
-	c.state.CgroupPath = utils.ValidCgroupPath(spec.Linux.CgroupsPath)
+	cgroupPath := utils.ValidCgroupPath(spec.Linux.CgroupsPath)
+	c.state.CgroupPath, err = renameCgroupPath(cgroupPath)
+	if err != nil {
+		return err
+	}
+
 	cgroup, err := cgroupsNewFunc(cgroups.V1,
 		cgroups.StaticPath(c.state.CgroupPath), &resources)
 	if err != nil {


### PR DESCRIPTION
prepend a kata specific string to oci cgroup path to form a different cgroup path, thus cAdvisor couldn't find kata containers cgroup path on host to prevent it from grabbing the stats data.

Fixes:#1488

Signed-off-by: lifupan <lifupan@gmail.com>