### PR TITLE
Update golang to 1.12.3

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -269,7 +269,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.11.1"
+      newest-version: "1.12.3"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
This commit bumps the golang version to remove the go modules hash mismatch between 1.11 and 1.12.

Reasoned by https://github.com/cri-o/cri-o/pull/2247
Fixes #1520