### PR TITLE
netmon: Fix bug in how routes are converted

### DIFF
--- a/netmon/netmon.go
+++ b/netmon/netmon.go
@@ -309,7 +309,7 @@ func convertRoutes(netRoutes []netlink.Route) []vcTypes.Route {
 		dst := ""
 		if netRoute.Dst != nil {
 			if netRoute.Dst.IP.To4() != nil {
-				dst = netRoute.Dst.IP.String()
+				dst = netRoute.Dst.String()
 			} else {
 				netmonLog.WithField("destination", netRoute.Dst.IP.String()).Warn("Not IPv4 format")
 			}

--- a/netmon/netmon_test.go
+++ b/netmon/netmon_test.go
@@ -213,7 +213,7 @@ func TestConvertRoutes(t *testing.T) {
 
 	expected := []vcTypes.Route{
 		{
-			Dest:    testIPAddress,
+			Dest:    testIPAddressWithMask,
 			Gateway: testIPAddress,
 			Source:  testIPAddress,
 			Scope:   uint32(testScope),


### PR DESCRIPTION
The agent expects a IP CIDR for the route destination
rather than an IP address. netmon was incorrectly
converting route dest to an IP address and hence
exiting with an error.

Fixes #1523

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>