### PR TITLE
fix ut failure due to incorrect cleanup and make it runnable with non-root

### DIFF
--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -137,6 +137,10 @@ func TestContainerRemoveDrive(t *testing.T) {
 }
 
 func testSetupFakeRootfs(t *testing.T) (testRawFile, loopDev, mntDir string, err error) {
+	if os.Geteuid() != 0 {
+		t.Skip(testDisabledAsNonRoot)
+	}
+
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)

--- a/virtcontainers/hyperstart_agent_test.go
+++ b/virtcontainers/hyperstart_agent_test.go
@@ -282,6 +282,12 @@ func TestHyperCopyFile(t *testing.T) {
 func TestHyperCleanupSandbox(t *testing.T) {
 	assert := assert.New(t)
 
+	defaultSharedDirSaved := defaultSharedDir
+	defaultSharedDir, _ = ioutil.TempDir("", "hyper-cleanup")
+	defer func() {
+		defaultSharedDir = defaultSharedDirSaved
+	}()
+
 	s := Sandbox{
 		id: "testFoo",
 	}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -935,6 +935,12 @@ func TestKataCopyFile(t *testing.T) {
 func TestKataCleanupSandbox(t *testing.T) {
 	assert := assert.New(t)
 
+	kataHostSharedDirSaved := kataHostSharedDir
+	kataHostSharedDir, _ = ioutil.TempDir("", "kata-cleanup")
+	defer func() {
+		kataHostSharedDir = kataHostSharedDirSaved
+	}()
+
 	s := Sandbox{
 		id: "testFoo",
 	}

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -53,12 +53,18 @@ func cleanUp() {
 		os.MkdirAll(dir, store.DirMode)
 	}
 
+	setup()
+}
+
+func setup() {
 	os.Mkdir(filepath.Join(testDir, testBundle), store.DirMode)
 
-	_, err := os.Create(filepath.Join(testDir, testImage))
-	if err != nil {
-		fmt.Println("Could not recreate test image:", err)
-		os.Exit(1)
+	for _, filename := range []string{testQemuKernelPath, testQemuInitrdPath, testQemuImagePath, testQemuPath} {
+		_, err := os.Create(filename)
+		if err != nil {
+			fmt.Printf("Could not recreate %s:%v", filename, err)
+			os.Exit(1)
+		}
 	}
 }
 
@@ -95,36 +101,7 @@ func TestMain(m *testing.M) {
 	testQemuImagePath = filepath.Join(testDir, testImage)
 	testQemuPath = filepath.Join(testDir, testHypervisor)
 
-	fmt.Printf("INFO: Creating virtcontainers test kernel %s\n", testQemuKernelPath)
-	_, err = os.Create(testQemuKernelPath)
-	if err != nil {
-		fmt.Println("Could not create test kernel:", err)
-		os.RemoveAll(testDir)
-		os.Exit(1)
-	}
-
-	fmt.Printf("INFO: Creating virtcontainers test image %s\n", testQemuImagePath)
-	_, err = os.Create(testQemuImagePath)
-	if err != nil {
-		fmt.Println("Could not create test image:", err)
-		os.RemoveAll(testDir)
-		os.Exit(1)
-	}
-
-	fmt.Printf("INFO: Creating virtcontainers test hypervisor %s\n", testQemuPath)
-	_, err = os.Create(testQemuPath)
-	if err != nil {
-		fmt.Println("Could not create test hypervisor:", err)
-		os.RemoveAll(testDir)
-		os.Exit(1)
-	}
-
-	err = os.Mkdir(filepath.Join(testDir, testBundle), store.DirMode)
-	if err != nil {
-		fmt.Println("Could not create test bundle directory:", err)
-		os.RemoveAll(testDir)
-		os.Exit(1)
-	}
+	setup()
 
 	// allow the tests to run without affecting the host system.
 	store.ConfigStoragePath = filepath.Join(testDir, store.StoragePathSuffix, "config")


### PR DESCRIPTION
1. fix ut failure as cleanup removes the initial test setup, as stated in #1525 
2. make ut runnable with non-root