### PR TITLE
Stable 1.5 backports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ ifneq (,$(QEMUCMD))
 
     # qemu-specific options (all should be suffixed by "_QEMU")
     DEFBLOCKSTORAGEDRIVER_QEMU := virtio-scsi
-    DEFNETWORKMODEL_QEMU := macvtap
+    DEFNETWORKMODEL_QEMU := tcfilter
     KERNELNAME_QEMU = $(call MAKE_KERNEL_NAME,$(KERNELTYPE))
     KERNELPATH_QEMU = $(KERNELDIR)/$(KERNELNAME_QEMU)
 endif

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -215,7 +215,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(count, uint32(0))
 
-	re := regexp.MustCompile(`\bwarning\b.*\bnested\b`)
+	re := regexp.MustCompile(`.*\bnested\b`)
 	matches := re.FindAllStringSubmatch(buf.String(), -1)
 	assert.NotEmpty(matches)
 }
@@ -309,7 +309,7 @@ func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(count, uint32(0))
 
-	re := regexp.MustCompile(`\bwarning\b.*\bunrestricted_guest\b`)
+	re := regexp.MustCompile(`.*\bunrestricted_guest\b`)
 	matches := re.FindAllStringSubmatch(buf.String(), -1)
 	assert.NotEmpty(matches)
 }

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -110,7 +110,7 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 // DefaultNetInterworkingModel is a package level default
 // that determines how the VM should be connected to the
 // the container network interface
-var DefaultNetInterworkingModel = NetXConnectMacVtapModel
+var DefaultNetInterworkingModel = NetXConnectTCFilterModel
 
 // Introduces constants related to networking
 const (


### PR DESCRIPTION
Backport fixes from master

## Patches pulled:
edc77a02 Merge pull request #1502 from amshinde/make-tc-default
38526822 network: Change the package level network default
33bae705 network: Make tcfilter model as default

da08b3af Merge pull request #1509 from bergwolf/kata-check
9ac68310 cli: fix kata-check test



## Patches not backported:

### Questionable:

This set has conflicts:
d5a759e1 Merge pull request #1526 from bergwolf/ut-non-root
9040f6a8 ut: fix UT failure due to incorrect cleanup
a0f49a91 ut: fix UT failure due to non-root

 c08976e1 Merge pull request #1494 from lifupan/fixstop
 f7223c6f shimv2: fix the issue of stop container failed

### Confidently Rejected

Not an issue with 1.5, as we don't provide host cgroups:
d99693a5 Merge pull request #1518 from lifupan/fixtop
1a1f93bc virtcontainers: add a kata specific prefix to host cgroups path

 5d875be2 (origin/master, origin/HEAD) Merge pull request #1409 from teawater/vmcache_templating
 343a0d35 factory: Make VMCache and VM templating can work together

168665b9 Merge pull request #1439 from YongjiXie/pass-correct-mount-type-for-ephemeral-volumes
2d422a84 agent: pass correct mount type to agent for ephemeral volumes

2b45f0b2 Merge pull request #1528 from bergwolf/grpc
f5125421 sandbox: return ErrNoSuchContainer when failing to find a container
8215a3ce shimv2: convert vc errors to grpc errors
cf907516 vc: export vc error types

ae022dc Merge pull request #1428 from gabibeyer/slashNburn
b08ab6ae vc: modify ioctl function to handle shim test
c4250790 vc: Deprecate CC proxy and shim
c6587708 vc: remove virtc api cli
d4ef9c05 vc: deprecate hyperstart agent

6e595783 Merge pull request #1530 from devimc/topic/virtcontainers/inheritParentCpuCgroup
59e39563 virtcontainers: inherit parent's CPU constraint

9b622b7e Merge pull request #1485 from awprice/k8s-empty-dir-local
76c4639a storage: create k8s emptyDir inside VM
228d1512 mount: Add check for k8s host empty directory
70c19313 mounts: Add check for system volumes

e15f3e49 Merge pull request #1337 from jongwu/bypass
98687a34 Template: enable template for arm64

dd5c6aa7 Merge pull request #1507 from bergwolf/state
c4145996 types: remove pid from sandbox state
03ee25d4 agent: treat container as shared pidns whenever it has pidns path
616f26cf types: split sandbox and container state

6d81e446 Merge pull request #1437 from teawater/vmcache_grpc
ace81155 factory: Make factory status can show status of VMCache server
f639787e factory: Make factory destroy can stop VMCache server
