### PR TITLE
sandbox: make vm stop successful if vm exit unexpected

### DIFF
--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -52,11 +52,11 @@ func wait(s *service, c *container, execID string) (int32, error) {
 
 		if c.cType.IsSandbox() {
 			if err = s.sandbox.Stop(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to stop sandbox")
+				logrus.WithError(err).WithField("sandbox", s.sandbox.ID()).Error("failed to stop sandbox")
 			}
 
 			if err = s.sandbox.Delete(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
+				logrus.WithError(err).WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
 			}
 		} else {
 			if _, err = s.sandbox.StopContainer(c.id); err != nil {

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -16,6 +16,7 @@ import (
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
+	"github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
@@ -586,12 +587,7 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 				container.state.State == types.StatePaused) &&
 				container.process.Pid > 0 {
 
-				running, err := isShimRunning(container.process.Pid)
-				if err != nil {
-					return ContainerStatus{}, err
-				}
-
-				if !running {
+				if running, _ := utils.IsProcRunning(container.process.Pid); !running {
 					virtLog.WithFields(logrus.Fields{
 						"state": container.state.State,
 						"pid":   container.process.Pid}).

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -14,6 +14,7 @@ import (
 
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
 	"github.com/kata-containers/runtime/virtcontainers/types"
+	"github.com/kata-containers/runtime/virtcontainers/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
 )
@@ -227,23 +228,6 @@ func startShim(args []string, params ShimParams) (int, error) {
 	return cmd.Process.Pid, nil
 }
 
-func isShimRunning(pid int) (bool, error) {
-	if pid <= 0 {
-		return false, nil
-	}
-
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false, err
-	}
-
-	if err := process.Signal(syscall.Signal(0)); err != nil {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 // waitForShim waits for the end of the shim unless it reaches the timeout
 // first, returning an error in that case.
 func waitForShim(pid int) error {
@@ -253,7 +237,7 @@ func waitForShim(pid int) error {
 
 	tInit := time.Now()
 	for {
-		running, err := isShimRunning(pid)
+		running, err := utils.IsProcRunning(pid)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/shim_test.go
+++ b/virtcontainers/shim_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"syscall"
 	"testing"
+
+	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
 
 const (
@@ -213,7 +215,7 @@ func TestStopShimSuccessfulProcessRunning(t *testing.T) {
 }
 
 func testIsShimRunning(t *testing.T, pid int, expected bool) {
-	running, err := isShimRunning(pid)
+	running, err := utils.IsProcRunning(pid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 )
 
 // DefaultCgroupPath runtime-determined location in the cgroups hierarchy.
@@ -251,4 +252,22 @@ func ValidCgroupPath(path string) string {
 	// interpret the path relative to a runtime-determined location in the cgroups hierarchy.
 	// clean up path and return a new path relative to defaultCgroupPath
 	return filepath.Join(DefaultCgroupPath, filepath.Clean("/"+path))
+}
+
+// IsProcRunning check if the process is running
+func IsProcRunning(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
if vm exited unexpected, stop process should be successful

Fixes: #1539

Signed-off-by: Ace-Tang <aceapril@126.com>

re-produce step
```
1. run a kata container
# ctr  run -d docker.io/library/busybox:latest k1 top

2. kill vm
# ps -ef | grep kata
root     10924 10903 13 22:34 ?        00:00:00 /usr/local/libexec/qemu-kvm -name sandbox-k1 -uuid ce996b5c-3abd-4568-818d-9756239d9550 -machine q35,accel=kvm,kernel_irqchip,nvdimm,nosmm,nosmbus,nosata,nopit,static-prt,nofw -cpu host -qmp unix:/run/vc/vm/k1/qmp.sock,server,nowait -m 2048M,slots=10,maxmem=32457M -device pci-bridge,bus=pcie.0,id=pci-bridge-0,chassis_nr=1,shpc=on,addr=2,romfile= -device virtio-serial-pci,disable-modern=false,id=serial0,romfile= -device virtconsole,chardev=charconsole0,id=console0 -chardev socket,id=charconsole0,path=/run/vc/vm/k1/console.sock,server,nowait -device virtserialport,chardev=metricagent,id=channel10,name=metric.agent.channel.10 -chardev socket,id=metricagent,path=/run/vc/vm/k1/metric.agent.channel.sock,server,nowait -device nvdimm,id=nv0,memdev=mem0 -object memory-backend-file,id=mem0,mem-path=/usr/local/share/daishu/rootfs.img,size=235929600 -device virtserialport,chardev=charch0,id=channel0,name=agent.channel.0 -chardev socket,id=charch0,path=/run/vc/vm/k1/kata.sock,server,nowait -device virtio-9p-pci,disable-modern=false,fsdev=extra-9p-kataShared,mount_tag=kataShared,romfile= -fsdev local,id=extra-9p-kataShared,path=/run/kata-containers/shared/sandboxes/k1,security_model=none -global kvm-pit.lost_tick_policy=discard -vga none -no-user-config -nodefaults -nographic -daemonize -kernel /usr/local/share/daishu/vmlinux -append tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k console=hvc0 console=hvc1 iommu=off cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=8 init=/usr/lib/systemd/systemd systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket -pidfile /run/vc/vm/k1/pid -smp 1,cores=1,threads=1,sockets=1,maxcpus=8
root     10929 10903  0 22:34 pts/0    00:00:00 /usr/local/bin/kata-proxy -listen-socket unix:///run/vc/sbs/k1/proxy.sock -mux-socket /run/vc/vm/k1/kata.sock -sandbox k1
root     10940 10903  0 22:34 pts/0    00:00:00 /usr/local/bin/kata-shim -agent unix:///run/vc/sbs/k1/proxy.sock -container k1 -exec-id k1
root     10975 10866  0 22:34 pts/1    00:00:00 grep --color=auto kata
# kill 10924

3.  delete task 
# ctr t delete k1
ctr: failed to delete task: dial unix /run/vc/vm/k1/qmp.sock: connect: no such file or directory: unknown
```

kill vm is a easy way to re-produce the problem, I think when this happen, we should check if vm process is still running, if not , we can continue the delete process.
