### PR TITLE
vc: change container rootfs to be a mount

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -128,7 +128,7 @@ func create(ctx context.Context, containerID, bundlePath, console, pidFilePath s
 	disableOutput := noNeedForOutput(detach, ociSpec.Process.Terminal)
 
 	//rootfs has been mounted by containerd shim
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	var process vc.Process
 	switch containerType {

--- a/containerd-shim-v2/create.go
+++ b/containerd-shim-v2/create.go
@@ -10,12 +10,13 @@ package containerdshim
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/containerd/typeurl"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/pkg/errors"
-	"os"
-	"path/filepath"
 
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 
@@ -31,7 +32,7 @@ import (
 )
 
 func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest, netns string) (*container, error) {
-	rootFs := vc.RootFs{Mounted: s.mount}
+	rootFs := vc.Mount{Mounted: s.mount}
 	if len(r.Rootfs) == 1 {
 		m := r.Rootfs[0]
 		rootFs.Source = m.Source

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -172,7 +172,7 @@ func SetEphemeralStorageType(ociSpec oci.CompatOCISpec) oci.CompatOCISpec {
 }
 
 // CreateSandbox create a sandbox container
-func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig, rootFs vc.RootFs,
+func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig, rootFs vc.Mount,
 	containerID, bundlePath, console string, disableOutput, systemdCgroup, builtIn bool) (vc.VCSandbox, vc.Process, error) {
 	span, ctx := Trace(ctx, "createSandbox")
 	defer span.Finish()
@@ -237,7 +237,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, ru
 }
 
 // CreateContainer create a container
-func CreateContainer(ctx context.Context, vci vc.VC, sandbox vc.VCSandbox, ociSpec oci.CompatOCISpec, rootFs vc.RootFs, containerID, bundlePath, console string, disableOutput, builtIn bool) (vc.Process, error) {
+func CreateContainer(ctx context.Context, vci vc.VC, sandbox vc.VCSandbox, ociSpec oci.CompatOCISpec, rootFs vc.Mount, containerID, bundlePath, console string, disableOutput, builtIn bool) (vc.Process, error) {
 	var c vc.VCContainer
 
 	span, ctx := Trace(ctx, "createContainer")

--- a/pkg/katautils/create_test.go
+++ b/pkg/katautils/create_test.go
@@ -306,7 +306,7 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 		Quota: &quota,
 	}
 
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	_, _, err = CreateSandbox(context.Background(), testingImpl, spec, runtimeConfig, rootFs, testContainerID, bundlePath, testConsole, true, true, false)
 	assert.Error(err)
@@ -342,7 +342,7 @@ func TestCreateSandboxFail(t *testing.T) {
 	spec, err := readOCIConfigFile(ociConfigFile)
 	assert.NoError(err)
 
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	_, _, err = CreateSandbox(context.Background(), testingImpl, spec, runtimeConfig, rootFs, testContainerID, bundlePath, testConsole, true, true, false)
 	assert.Error(err)
@@ -381,7 +381,7 @@ func TestCreateContainerContainerConfigFail(t *testing.T) {
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
 
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	for _, disableOutput := range []bool{true, false} {
 		_, err = CreateContainer(context.Background(), testingImpl, nil, spec, rootFs, testContainerID, bundlePath, testConsole, disableOutput, false)
@@ -424,7 +424,7 @@ func TestCreateContainerFail(t *testing.T) {
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
 
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	for _, disableOutput := range []bool{true, false} {
 		_, err = CreateContainer(context.Background(), testingImpl, nil, spec, rootFs, testContainerID, bundlePath, testConsole, disableOutput, false)
@@ -474,7 +474,7 @@ func TestCreateContainer(t *testing.T) {
 	err = writeOCIConfigFile(spec, ociConfigFile)
 	assert.NoError(err)
 
-	rootFs := vc.RootFs{Mounted: true}
+	rootFs := vc.Mount{Mounted: true}
 
 	for _, disableOutput := range []bool{true, false} {
 		_, err = CreateContainer(context.Background(), testingImpl, nil, spec, rootFs, testContainerID, bundlePath, testConsole, disableOutput, false)

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -601,7 +601,7 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 				State:       container.state,
 				PID:         container.process.Pid,
 				StartTime:   container.process.StartTime,
-				RootFs:      container.config.RootFs.Target,
+				RootFs:      container.config.RootFs.Destination,
 				Annotations: container.config.Annotations,
 			}, nil
 		}

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -62,7 +62,7 @@ func newTestSandboxConfigNoop() SandboxConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          containerID,
-		RootFs:      RootFs{Target: filepath.Join(testDir, testBundle), Mounted: true},
+		RootFs:      Mount{Destination: filepath.Join(testDir, testBundle), Mounted: true},
 		Cmd:         newBasicTestCmd(),
 		Annotations: containerAnnotations,
 	}
@@ -751,7 +751,7 @@ func newTestContainerConfigNoop(contID string) ContainerConfig {
 	// Define the container command and bundle.
 	container := ContainerConfig{
 		ID:          contID,
-		RootFs:      RootFs{Target: filepath.Join(testDir, testBundle), Mounted: true},
+		RootFs:      Mount{Destination: filepath.Join(testDir, testBundle), Mounted: true},
 		Cmd:         newBasicTestCmd(),
 		Annotations: containerAnnotations,
 	}

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -106,7 +106,7 @@ func TestContainerRemoveDrive(t *testing.T) {
 		id:      "testContainer",
 	}
 
-	container.state.Fstype = ""
+	container.rootFs.Type = ""
 	err = container.removeDrive()
 
 	// hotplugRemoveDevice for hypervisor should not be called.
@@ -131,8 +131,8 @@ func TestContainerRemoveDrive(t *testing.T) {
 	err = sandbox.storeSandboxDevices()
 	assert.Nil(t, err)
 
-	container.state.Fstype = "xfs"
-	container.state.BlockDeviceID = device.DeviceID()
+	container.rootFs.Type = "xfs"
+	container.rootFs.BlockDeviceID = device.DeviceID()
 	err = container.removeDrive()
 	assert.Nil(t, err, "remove drive should succeed")
 }
@@ -245,7 +245,7 @@ func TestContainerAddDriveDir(t *testing.T) {
 	container := Container{
 		sandbox: sandbox,
 		id:      contID,
-		rootFs:  RootFs{Target: fakeRootfs, Mounted: true},
+		rootFs:  Mount{Destination: fakeRootfs, Mounted: true},
 	}
 
 	containerStore, err := store.NewVCContainerStore(sandbox.ctx, sandbox.id, container.id)
@@ -272,14 +272,14 @@ func TestContainerAddDriveDir(t *testing.T) {
 		checkStorageDriver = savedFunc
 	}()
 
-	container.state.Fstype = ""
+	container.rootFs.Type = "xfs"
 
 	err = container.hotplugDrive()
 	if err != nil {
 		t.Fatalf("Error with hotplugDrive :%v", err)
 	}
 
-	if container.state.Fstype == "" {
+	if container.rootFs.Type == "" {
 		t.Fatal()
 	}
 }
@@ -315,7 +315,7 @@ func TestContainerRootfsPath(t *testing.T) {
 	container := Container{
 		id:           "rootfstestcontainerid",
 		sandbox:      sandbox,
-		rootFs:       RootFs{Target: fakeRootfs, Mounted: true},
+		rootFs:       Mount{Destination: fakeRootfs, Mounted: true},
 		rootfsSuffix: "rootfs",
 	}
 	cvcstore, err := store.NewVCContainerStore(context.Background(),
@@ -328,7 +328,7 @@ func TestContainerRootfsPath(t *testing.T) {
 	assert.Empty(t, container.rootfsSuffix)
 
 	// Reset the value to test the other case
-	container.rootFs = RootFs{Target: fakeRootfs + "/rootfs", Mounted: true}
+	container.rootFs = Mount{Destination: fakeRootfs + "/rootfs", Mounted: true}
 	container.rootfsSuffix = "rootfs"
 
 	container.hotplugDrive()

--- a/virtcontainers/example_pod_run_test.go
+++ b/virtcontainers/example_pod_run_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
-var containerRootfs = vc.RootFs{Target: "/var/lib/container/bundle/", Mounted: true}
+var containerRootfs = vc.Mount{Destination: "/var/lib/container/bundle/", Mounted: true}
 
 // This example creates and starts a single container sandbox,
 // using qemu as the hypervisor and kata as the VM agent.

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -735,9 +735,7 @@ func TestAgentCreateContainer(t *testing.T) {
 		id:        "barfoo",
 		sandboxID: "foobar",
 		sandbox:   sandbox,
-		state: types.ContainerState{
-			Fstype: "xfs",
-		},
+		state:     types.ContainerState{},
 		config: &ContainerConfig{
 			Annotations: map[string]string{},
 		},

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -304,7 +304,10 @@ func bindMountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID, cR
 
 // Mount describes a container mount.
 type Mount struct {
-	Source      string
+	// Mount source
+	Source string
+
+	// Mount destination in the guest
 	Destination string
 
 	// Type specifies the type of filesystem to mount.
@@ -316,13 +319,16 @@ type Mount struct {
 	// HostPath used to store host side bind mount path
 	HostPath string
 
-	// ReadOnly specifies if the mount should be read only or not
-	ReadOnly bool
-
 	// BlockDeviceID represents block device that is attached to the
 	// VM in case this mount is a block device file or a directory
 	// backed by a block device.
 	BlockDeviceID string
+
+	// ReadOnly specifies if the mount should be read only or not
+	ReadOnly bool
+
+	// Mounted specifies if the target has been mounted on the host
+	Mounted bool
 }
 
 func bindUnmountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID string) error {
@@ -341,7 +347,7 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 
 	for _, c := range sandbox.containers {
 		c.unmountHostMounts()
-		if c.state.Fstype == "" {
+		if c.rootFs.Type == "" {
 			// Need to check for error returned by this call.
 			// See: https://github.com/containers/virtcontainers/issues/295
 			bindUnmountContainerRootfs(c.ctx, sharedDir, sandbox.id, c.id)

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -31,9 +31,9 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 			state = v
 		}
 		state.State = string(cont.state.State)
-		state.Rootfs = persistapi.RootfsState{
-			BlockDeviceID: cont.state.BlockDeviceID,
-			FsType:        cont.state.Fstype,
+		state.Rootfs = persistapi.Mount{
+			BlockDeviceID: cont.rootFs.BlockDeviceID,
+			Type:          cont.rootFs.Type,
 		}
 		state.CgroupPath = cont.state.CgroupPath
 		cs[id] = state
@@ -152,10 +152,8 @@ func (c *Container) Restore() error {
 	}
 
 	c.state = types.ContainerState{
-		State:         types.StateString(cs[c.id].State),
-		BlockDeviceID: cs[c.id].Rootfs.BlockDeviceID,
-		Fstype:        cs[c.id].Rootfs.FsType,
-		CgroupPath:    cs[c.id].CgroupPath,
+		State:      types.StateString(cs[c.id].State),
+		CgroupPath: cs[c.id].CgroupPath,
 	}
 
 	return nil

--- a/virtcontainers/persist/api/container.go
+++ b/virtcontainers/persist/api/container.go
@@ -47,23 +47,16 @@ type Mount struct {
 	// HostPath used to store host side bind mount path
 	HostPath string
 
-	// ReadOnly specifies if the mount should be read only or not
-	ReadOnly bool
-
 	// BlockDeviceID represents block device that is attached to the
 	// VM in case this mount is a block device file or a directory
 	// backed by a block device.
 	BlockDeviceID string
-}
 
-// RootfsState saves state of container rootfs
-type RootfsState struct {
-	// BlockDeviceID represents container rootfs block device ID
-	// when backed by devicemapper
-	BlockDeviceID string
+	// ReadOnly specifies if the mount should be read only or not
+	ReadOnly bool
 
-	// RootFStype is file system of the rootfs incase it is block device
-	FsType string
+	// Mounted specifies if the target has been mounted on the host
+	Mounted bool
 }
 
 // Process gathers data related to a container process.
@@ -90,7 +83,7 @@ type ContainerState struct {
 	State string
 
 	// Rootfs contains information of container rootfs
-	Rootfs RootfsState
+	Rootfs Mount
 
 	// CgroupPath is the cgroup hierarchy where sandbox's processes
 	// including the hypervisor are placed.

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -183,6 +183,7 @@ func newMount(m spec.Mount) vc.Mount {
 		Destination: m.Destination,
 		Type:        m.Type,
 		Options:     m.Options,
+		Mounted:     true, // All OCI volumes are mounted on the host ATM.
 	}
 }
 
@@ -524,12 +525,12 @@ func ContainerConfig(ocispec CompatOCISpec, bundlePath, cid, console string, det
 		return vc.ContainerConfig{}, err
 	}
 
-	rootfs := vc.RootFs{Target: ocispec.Root.Path, Mounted: true}
-	if !filepath.IsAbs(rootfs.Target) {
-		rootfs.Target = filepath.Join(bundlePath, ocispec.Root.Path)
+	rootfs := vc.Mount{Destination: ocispec.Root.Path, Mounted: true}
+	if !filepath.IsAbs(rootfs.Destination) {
+		rootfs.Destination = filepath.Join(bundlePath, ocispec.Root.Path)
 	}
 
-	ociLog.Debugf("container rootfs: %s", rootfs.Target)
+	ociLog.Debugf("container rootfs: %s", rootfs.Destination)
 
 	cmd := types.Cmd{
 		Args:            ocispec.Process.Args,

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -150,6 +150,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 			Type:        "proc",
 			Options:     nil,
 			HostPath:    "",
+			Mounted:     true,
 		},
 		{
 			Source:      "tmpfs",
@@ -157,6 +158,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 			Type:        "tmpfs",
 			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 			HostPath:    "",
+			Mounted:     true,
 		},
 		{
 			Source:      "devpts",
@@ -164,6 +166,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 			Type:        "devpts",
 			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
 			HostPath:    "",
+			Mounted:     true,
 		},
 	}
 
@@ -200,7 +203,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 
 	expectedContainerConfig := vc.ContainerConfig{
 		ID:             containerID,
-		RootFs:         vc.RootFs{Target: path.Join(tempBundlePath, "rootfs"), Mounted: true},
+		RootFs:         vc.Mount{Destination: path.Join(tempBundlePath, "rootfs"), Mounted: true},
 		ReadonlyRootfs: true,
 		Cmd:            expectedCmd,
 		Annotations: map[string]string{

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -291,7 +291,7 @@ func (s *Sandbox) Status() SandboxStatus {
 	for _, c := range s.containers {
 		rootfs := c.config.RootFs.Source
 		if c.config.RootFs.Mounted {
-			rootfs = c.config.RootFs.Target
+			rootfs = c.config.RootFs.Destination
 		}
 
 		contStatusList = append(contStatusList, ContainerStatus{
@@ -1241,7 +1241,7 @@ func (s *Sandbox) StatusContainer(containerID string) (ContainerStatus, error) {
 	for id, c := range s.containers {
 		rootfs := c.config.RootFs.Source
 		if c.config.RootFs.Mounted {
-			rootfs = c.config.RootFs.Target
+			rootfs = c.config.RootFs.Destination
 		}
 		if id == containerID {
 			return ContainerStatus{

--- a/virtcontainers/types/container.go
+++ b/virtcontainers/types/container.go
@@ -9,11 +9,6 @@ package types
 type ContainerState struct {
 	State StateString `json:"state"`
 
-	BlockDeviceID string
-
-	// File system of the rootfs incase it is block device
-	Fstype string `json:"fstype"`
-
 	// CgroupPath is the cgroup hierarchy where sandbox's processes
 	// including the hypervisor are placed.
 	CgroupPath string `json:"cgroupPath,omitempty"`


### PR DESCRIPTION
We can use the same data structure to describe both of them.
So that we can handle them similarly.

Fixes: #1566
