### PR TITLE
revert kernel bump for 1.6.2 release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -162,7 +162,7 @@ assets:
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
     uscan-url: >-
       https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-(4\.19\..+)\.tar\.gz
-    version: "v4.19.34"
+    version: "v4.19.28"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
Need to figure out why CI didn't catch and address
package build failure.  In the meantime, unblock 1.6.2.

Fixes: #1571

Signed-off-by: Eric Ernst <eric.ernst@intel.com>