### PR TITLE
newstore:  removing deprecated files when use new store driver

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -591,8 +591,8 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 
 				if !running {
 					virtLog.WithFields(logrus.Fields{
-						"state":       container.state.State,
-						"process pid": container.process.Pid}).
+						"state": container.state.State,
+						"pid":   container.process.Pid}).
 						Info("container isn't running")
 					if err := container.stop(); err != nil {
 						return ContainerStatus{}, err

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -590,6 +590,10 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 				}
 
 				if !running {
+					virtLog.WithFields(logrus.Fields{
+						"state":       container.state.State,
+						"process pid": container.process.Pid}).
+						Info("container isn't running")
 					if err := container.stop(); err != nil {
 						return ContainerStatus{}, err
 					}

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -392,7 +392,7 @@ func (c *Container) GetAnnotations() map[string]string {
 // storeContainer stores a container config.
 func (c *Container) storeContainer() error {
 	if c.sandbox.supportNewStore() {
-		if err := c.sandbox.newStore.ToDisk(); err != nil {
+		if err := c.sandbox.Save(); err != nil {
 			return err
 		}
 	}
@@ -447,7 +447,7 @@ func (c *Container) setContainerState(state types.StateString) error {
 
 	if c.sandbox.supportNewStore() {
 		// flush data to storage
-		if err := c.sandbox.newStore.ToDisk(); err != nil {
+		if err := c.sandbox.Save(); err != nil {
 			return err
 		}
 	} else {

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -94,6 +94,7 @@ func TestContainerRemoveDrive(t *testing.T) {
 		ctx:        context.Background(),
 		id:         "sandbox",
 		devManager: manager.NewDeviceManager(manager.VirtioSCSI, nil),
+		config:     &SandboxConfig{},
 	}
 
 	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -45,28 +45,37 @@ type DeviceReceiver interface {
 type Device interface {
 	Attach(DeviceReceiver) error
 	Detach(DeviceReceiver) error
+
 	// ID returns device identifier
 	DeviceID() string
+
 	// DeviceType indicates which kind of device it is
 	// e.g. block, vfio or vhost user
 	DeviceType() config.DeviceType
+
 	// GetMajorMinor returns major and minor numbers
 	GetMajorMinor() (int64, int64)
+
 	// GetDeviceInfo returns device specific data used for hotplugging by hypervisor
 	// Caller could cast the return value to device specific struct
 	// e.g. Block device returns *config.BlockDrive and
 	// vfio device returns []*config.VFIODev
 	GetDeviceInfo() interface{}
+
 	// GetAttachCount returns how many times the device has been attached
 	GetAttachCount() uint
 
 	// Reference adds one reference to device then returns final ref count
 	Reference() uint
+
 	// Dereference removes one reference to device then returns final ref count
 	Dereference() uint
 
-	// Persist convert and return data in persist format
-	Dump() persistapi.DeviceState
+	// Save converts Device to DeviceState
+	Save() persistapi.DeviceState
+
+	// Load loads DeviceState and converts it to specific device
+	Load(persistapi.DeviceState)
 }
 
 // DeviceManager can be used to create a new device, this can be used as single
@@ -79,4 +88,5 @@ type DeviceManager interface {
 	IsDeviceAttached(string) bool
 	GetDeviceByID(string) Device
 	GetAllDevices() []Device
+	LoadDevices([]persistapi.DeviceState)
 }

--- a/virtcontainers/device/drivers/block.go
+++ b/virtcontainers/device/drivers/block.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2018 Intel Corporation
-// Copyright (c) 2018 Huawei Corporation
+// Copyright (c) 2018-2019 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -147,9 +147,9 @@ func (device *BlockDevice) GetDeviceInfo() interface{} {
 	return device.BlockDrive
 }
 
-// Dump convert and return data in persist format
-func (device *BlockDevice) Dump() persistapi.DeviceState {
-	ds := device.GenericDevice.Dump()
+// Save converts Device to DeviceState
+func (device *BlockDevice) Save() persistapi.DeviceState {
+	ds := device.GenericDevice.Save()
 	ds.Type = string(device.DeviceType())
 
 	drive := device.BlockDrive
@@ -167,6 +167,28 @@ func (device *BlockDevice) Dump() persistapi.DeviceState {
 		}
 	}
 	return ds
+}
+
+// Load loads DeviceState and converts it to specific device
+func (device *BlockDevice) Load(ds persistapi.DeviceState) {
+	device.GenericDevice = &GenericDevice{}
+	device.GenericDevice.Load(ds)
+
+	bd := ds.BlockDrive
+	if bd == nil {
+		return
+	}
+	device.BlockDrive = &config.BlockDrive{
+		File:     bd.File,
+		Format:   bd.Format,
+		ID:       bd.ID,
+		Index:    bd.Index,
+		MmioAddr: bd.MmioAddr,
+		PCIAddr:  bd.PCIAddr,
+		SCSIAddr: bd.SCSIAddr,
+		NvdimmID: bd.NvdimmID,
+		VirtPath: bd.VirtPath,
+	}
 }
 
 // It should implement GetAttachCount() and DeviceID() as api.Device implementation

--- a/virtcontainers/device/drivers/generic.go
+++ b/virtcontainers/device/drivers/generic.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2018 Intel Corporation
-// Copyright (c) 2018 Huawei Corporation
+// Copyright (c) 2018-2019 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -117,8 +117,8 @@ func (device *GenericDevice) bumpAttachCount(attach bool) (skip bool, err error)
 	}
 }
 
-// Dump convert and return data in persist format
-func (device *GenericDevice) Dump() persistapi.DeviceState {
+// Save converts Device to DeviceState
+func (device *GenericDevice) Save() persistapi.DeviceState {
 	dss := persistapi.DeviceState{
 		ID:          device.ID,
 		Type:        string(device.DeviceType()),
@@ -134,4 +134,18 @@ func (device *GenericDevice) Dump() persistapi.DeviceState {
 		dss.DriverOptions = info.DriverOptions
 	}
 	return dss
+}
+
+// Load loads DeviceState and converts it to specific device
+func (device *GenericDevice) Load(ds persistapi.DeviceState) {
+	device.ID = ds.ID
+	device.RefCount = ds.RefCount
+	device.AttachCount = ds.AttachCount
+
+	device.DeviceInfo = &config.DeviceInfo{
+		DevType:       ds.DevType,
+		Major:         ds.Major,
+		Minor:         ds.Minor,
+		DriverOptions: ds.DriverOptions,
+	}
 }

--- a/virtcontainers/device/drivers/vhost_user_blk.go
+++ b/virtcontainers/device/drivers/vhost_user_blk.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2018 Intel Corporation
-// Copyright (c) 2018 Huawei Corporation
+// Copyright (c) 2018-2019 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -72,9 +72,9 @@ func (device *VhostUserBlkDevice) GetDeviceInfo() interface{} {
 	return &device.VhostUserDeviceAttrs
 }
 
-// Dump convert and return data in persist format
-func (device *VhostUserBlkDevice) Dump() persistapi.DeviceState {
-	ds := device.GenericDevice.Dump()
+// Save converts Device to DeviceState
+func (device *VhostUserBlkDevice) Save() persistapi.DeviceState {
+	ds := device.GenericDevice.Save()
 	ds.Type = string(device.DeviceType())
 	ds.VhostUserDev = &persistapi.VhostUserDeviceAttrs{
 		DevID:      device.DevID,
@@ -83,6 +83,24 @@ func (device *VhostUserBlkDevice) Dump() persistapi.DeviceState {
 		MacAddress: device.MacAddress,
 	}
 	return ds
+}
+
+// Load loads DeviceState and converts it to specific device
+func (device *VhostUserBlkDevice) Load(ds persistapi.DeviceState) {
+	device.GenericDevice = &GenericDevice{}
+	device.GenericDevice.Load(ds)
+
+	dev := ds.VhostUserDev
+	if dev == nil {
+		return
+	}
+
+	device.VhostUserDeviceAttrs = config.VhostUserDeviceAttrs{
+		DevID:      dev.DevID,
+		SocketPath: dev.SocketPath,
+		Type:       config.DeviceType(dev.Type),
+		MacAddress: dev.MacAddress,
+	}
 }
 
 // It should implement GetAttachCount() and DeviceID() as api.Device implementation

--- a/virtcontainers/device/drivers/vhost_user_net.go
+++ b/virtcontainers/device/drivers/vhost_user_net.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2018 Intel Corporation
-// Copyright (c) 2018 Huawei Corporation
+// Copyright (c) 2018-2019 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -73,9 +73,9 @@ func (device *VhostUserNetDevice) GetDeviceInfo() interface{} {
 	return &device.VhostUserDeviceAttrs
 }
 
-// Dump convert and return data in persist format
-func (device *VhostUserNetDevice) Dump() persistapi.DeviceState {
-	ds := device.GenericDevice.Dump()
+// Save converts Device to DeviceState
+func (device *VhostUserNetDevice) Save() persistapi.DeviceState {
+	ds := device.GenericDevice.Save()
 	ds.Type = string(device.DeviceType())
 	ds.VhostUserDev = &persistapi.VhostUserDeviceAttrs{
 		DevID:      device.DevID,
@@ -84,6 +84,24 @@ func (device *VhostUserNetDevice) Dump() persistapi.DeviceState {
 		MacAddress: device.MacAddress,
 	}
 	return ds
+}
+
+// Load loads DeviceState and converts it to specific device
+func (device *VhostUserNetDevice) Load(ds persistapi.DeviceState) {
+	device.GenericDevice = &GenericDevice{}
+	device.GenericDevice.Load(ds)
+
+	dev := ds.VhostUserDev
+	if dev == nil {
+		return
+	}
+
+	device.VhostUserDeviceAttrs = config.VhostUserDeviceAttrs{
+		DevID:      dev.DevID,
+		SocketPath: dev.SocketPath,
+		Type:       config.DeviceType(dev.Type),
+		MacAddress: dev.MacAddress,
+	}
 }
 
 // It should implement GetAttachCount() and DeviceID() as api.Device implementation

--- a/virtcontainers/device/drivers/vhost_user_scsi.go
+++ b/virtcontainers/device/drivers/vhost_user_scsi.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2018 Intel Corporation
-// Copyright (c) 2018 Huawei Corporation
+// Copyright (c) 2018-2019 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -73,9 +73,9 @@ func (device *VhostUserSCSIDevice) GetDeviceInfo() interface{} {
 	return &device.VhostUserDeviceAttrs
 }
 
-// Dump convert and return data in persist format
-func (device *VhostUserSCSIDevice) Dump() persistapi.DeviceState {
-	ds := device.GenericDevice.Dump()
+// Save converts Device to DeviceState
+func (device *VhostUserSCSIDevice) Save() persistapi.DeviceState {
+	ds := device.GenericDevice.Save()
 	ds.Type = string(device.DeviceType())
 	ds.VhostUserDev = &persistapi.VhostUserDeviceAttrs{
 		DevID:      device.DevID,
@@ -84,6 +84,24 @@ func (device *VhostUserSCSIDevice) Dump() persistapi.DeviceState {
 		MacAddress: device.MacAddress,
 	}
 	return ds
+}
+
+// Load loads DeviceState and converts it to specific device
+func (device *VhostUserSCSIDevice) Load(ds persistapi.DeviceState) {
+	device.GenericDevice = &GenericDevice{}
+	device.GenericDevice.Load(ds)
+
+	dev := ds.VhostUserDev
+	if dev == nil {
+		return
+	}
+
+	device.VhostUserDeviceAttrs = config.VhostUserDeviceAttrs{
+		DevID:      dev.DevID,
+		SocketPath: dev.SocketPath,
+		Type:       config.DeviceType(dev.Type),
+		MacAddress: dev.MacAddress,
+	}
 }
 
 // It should implement GetAttachCount() and DeviceID() as api.Device implementation

--- a/virtcontainers/device/manager/manager.go
+++ b/virtcontainers/device/manager/manager.go
@@ -237,34 +237,28 @@ func (dm *deviceManager) LoadDevices(devStates []persistapi.DeviceState) {
 	defer dm.Unlock()
 
 	for _, ds := range devStates {
+		var dev api.Device
+
 		switch config.DeviceType(ds.Type) {
 		case config.DeviceGeneric:
-			dev := &drivers.GenericDevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.GenericDevice{}
 		case config.DeviceBlock:
-			dev := &drivers.BlockDevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.BlockDevice{}
 		case config.DeviceVFIO:
-			dev := &drivers.VFIODevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.VFIODevice{}
 		case config.VhostUserSCSI:
-			dev := &drivers.VhostUserSCSIDevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.VhostUserSCSIDevice{}
 		case config.VhostUserBlk:
-			dev := &drivers.VhostUserBlkDevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.VhostUserBlkDevice{}
 		case config.VhostUserNet:
-			dev := &drivers.VhostUserNetDevice{}
-			dev.Load(ds)
-			dm.devices[dev.DeviceID()] = dev
+			dev = &drivers.VhostUserNetDevice{}
 		default:
 			deviceLogger().WithField("device-type", ds.Type).Warning("unrecognized device type is detected")
+			// continue the for loop
+			continue
 		}
 
+		dev.Load(ds)
+		dm.devices[dev.DeviceID()] = dev
 	}
 }

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -19,7 +19,16 @@ var (
 	errContainerPersistNotExist = errors.New("container doesn't exist in persist data")
 )
 
-func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) error {
+func (s *Sandbox) dumpVersion(ss *persistapi.SandboxState) {
+	// New created sandbox has a uninitialized `PersistVersion` which should be set to current version when do the first saving;
+	// Old restored sandbox should keep its original version and shouldn't be modified any more after it's initialized.
+	ss.PersistVersion = s.state.PersistVersion
+	if ss.PersistVersion == 0 {
+		ss.PersistVersion = persistapi.CurPersistVersion
+	}
+}
+
+func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) {
 	ss.SandboxContainer = s.id
 	ss.GuestMemoryBlockSizeMB = s.state.GuestMemoryBlockSizeMB
 	ss.State = string(s.state.State)
@@ -45,13 +54,10 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 			delete(cs, id)
 		}
 	}
-
-	return nil
 }
 
-func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) error {
+func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) {
 	ss.HypervisorState.BlockIndex = s.state.BlockIndex
-	return nil
 }
 
 func deviceToDeviceState(devices []api.Device) (dss []persistapi.DeviceState) {
@@ -61,7 +67,7 @@ func deviceToDeviceState(devices []api.Device) (dss []persistapi.DeviceState) {
 	return
 }
 
-func (s *Sandbox) dumpDevices(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) error {
+func (s *Sandbox) dumpDevices(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) {
 	ss.Devices = deviceToDeviceState(s.devManager.GetAllDevices())
 
 	for id, cont := range s.containers {
@@ -90,48 +96,34 @@ func (s *Sandbox) dumpDevices(ss *persistapi.SandboxState, cs map[string]persist
 			delete(cs, id)
 		}
 	}
+}
+
+func (s *Sandbox) Save() error {
+	var (
+		ss = persistapi.SandboxState{}
+		cs = make(map[string]persistapi.ContainerState)
+	)
+
+	s.dumpVersion(&ss)
+	s.dumpState(&ss, cs)
+	s.dumpHypervisor(&ss, cs)
+	s.dumpDevices(&ss, cs)
+
+	if err := s.newStore.ToDisk(ss, cs); err != nil {
+		return err
+	}
 
 	return nil
 }
 
-// verSaveCallback set persist data version to current version in runtime
-func (s *Sandbox) verSaveCallback() {
-	s.newStore.AddSaveCallback("version", func(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) error {
-		ss.PersistVersion = persistapi.CurPersistVersion
-		return nil
-	})
-}
-
-// stateSaveCallback register hook to set sandbox and container state to persist
-func (s *Sandbox) stateSaveCallback() {
-	s.newStore.AddSaveCallback("state", s.dumpState)
-}
-
-// hvStateSaveCallback register hook to save hypervisor state to persist data
-func (s *Sandbox) hvStateSaveCallback() {
-	s.newStore.AddSaveCallback("hypervisor", s.dumpHypervisor)
-}
-
-// PersistDevices register hook to save device informations
-func (s *Sandbox) devicesSaveCallback() {
-	s.newStore.AddSaveCallback("devices", s.dumpDevices)
-}
-
-func (s *Sandbox) getSbxAndCntStates() (*persistapi.SandboxState, map[string]persistapi.ContainerState, error) {
-	if err := s.newStore.FromDisk(s.id); err != nil {
-		return nil, nil, err
-	}
-
-	return s.newStore.GetStates()
-}
-
 // Restore will restore sandbox data from persist file on disk
 func (s *Sandbox) Restore() error {
-	ss, _, err := s.getSbxAndCntStates()
+	ss, _, err := s.newStore.FromDisk(s.id)
 	if err != nil {
 		return err
 	}
 
+	s.state.PersistVersion = ss.PersistVersion
 	s.state.GuestMemoryBlockSizeMB = ss.GuestMemoryBlockSizeMB
 	s.state.BlockIndex = ss.HypervisorState.BlockIndex
 	s.state.State = types.StateString(ss.State)
@@ -141,8 +133,9 @@ func (s *Sandbox) Restore() error {
 }
 
 // Restore will restore container data from persist file on disk
+// TODO:
 func (c *Container) Restore() error {
-	_, cs, err := c.sandbox.getSbxAndCntStates()
+	_, cs, err := c.sandbox.newStore.FromDisk(c.sandbox.id)
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -31,6 +31,7 @@ func (s *Sandbox) dumpVersion(ss *persistapi.SandboxState) {
 func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) {
 	ss.SandboxContainer = s.id
 	ss.GuestMemoryBlockSizeMB = s.state.GuestMemoryBlockSizeMB
+	ss.GuestMemoryHotplugProbe = s.state.GuestMemoryHotplugProbe
 	ss.State = string(s.state.State)
 	ss.CgroupPath = s.state.CgroupPath
 
@@ -122,6 +123,7 @@ func (s *Sandbox) loadState(ss persistapi.SandboxState) {
 	s.state.BlockIndex = ss.HypervisorState.BlockIndex
 	s.state.State = types.StateString(ss.State)
 	s.state.CgroupPath = ss.CgroupPath
+	s.state.GuestMemoryHotplugProbe = ss.GuestMemoryHotplugProbe
 }
 
 func (s *Sandbox) loadDevices(devStates []persistapi.DeviceState) {

--- a/virtcontainers/persist/api/device.go
+++ b/virtcontainers/persist/api/device.go
@@ -46,7 +46,7 @@ type VFIODev struct {
 	ID string
 
 	// Type of VFIO device
-	Type string
+	Type uint32
 
 	// BDF (Bus:Device.Function) of the PCI address
 	BDF string

--- a/virtcontainers/persist/api/interface.go
+++ b/virtcontainers/persist/api/interface.go
@@ -8,16 +8,10 @@ package persistapi
 // PersistDriver is interface describing operations to save/restore persist data
 type PersistDriver interface {
 	// ToDisk flushes data to disk(or other storage media such as a remote db)
-	ToDisk() error
+	ToDisk(SandboxState, map[string]ContainerState) error
 	// FromDisk will restore all data for sandbox with `sid` from storage.
 	// We only support get data for one whole sandbox
-	FromDisk(sid string) error
-	// AddSaveCallback addes callback function named `name` to driver storage list
-	// The callback functions will be invoked when calling `ToDisk()`, notice that
-	// callback functions are not order guaranteed,
-	AddSaveCallback(name string, f SetFunc)
+	FromDisk(sid string) (SandboxState, map[string]ContainerState, error)
 	// Destroy will remove everything from storage
 	Destroy() error
-	// GetStates will return SandboxState and ContainerState(s) directly
-	GetStates() (*SandboxState, map[string]ContainerState, error)
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -481,18 +481,10 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	s.devManager = deviceManager.NewDeviceManager(sandboxConfig.HypervisorConfig.BlockDeviceDriver, devices)
 
 	if s.supportNewStore() {
-		// register persist hook for now, data will be written to disk by ToDisk()
-		s.stateSaveCallback()
-		s.hvStateSaveCallback()
-		s.devicesSaveCallback()
-
 		if err := s.Restore(); err == nil && s.state.State != "" {
 			return s, nil
 		}
 
-		// if sandbox doesn't exist, set persist version to current version
-		// otherwise do nothing
-		s.verSaveCallback()
 	} else {
 		// We first try to fetch the sandbox state from storage.
 		// If it exists, this means this is a re-creation, i.e.
@@ -619,7 +611,7 @@ func (s *Sandbox) storeSandbox() error {
 
 	if s.supportNewStore() {
 		// flush data to storage
-		if err := s.newStore.ToDisk(); err != nil {
+		if err := s.Save(); err != nil {
 			return err
 		}
 	}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -897,6 +897,7 @@ func TestSandboxAttachDevicesVFIO(t *testing.T) {
 		hypervisor: &mockHypervisor{},
 		devManager: dm,
 		ctx:        context.Background(),
+		config:     &SandboxConfig{},
 	}
 
 	store, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -43,6 +43,11 @@ type SandboxState struct {
 	// CgroupPath is the cgroup hierarchy where sandbox's processes
 	// including the hypervisor are placed.
 	CgroupPath string `json:"cgroupPath,omitempty"`
+
+	// PersistVersion indicates current storage api version.
+	// It's also known as ABI version of kata-runtime.
+	// Note: it won't be written to disk
+	PersistVersion uint `json:"-"`
 }
 
 // Valid checks that the sandbox state is valid.


### PR DESCRIPTION
Fixes #803

It contains several commits:

1. Simplify new store API to make the code easier to understand and use.
2. newstore: remove file "devices.json" 

Signed-off-by: Wei Zhang <zhangwei555@huawei.com>
