### PR TITLE
versions: Bump NEMU version to latest release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -84,7 +84,7 @@ assets:
       uscan-url: >-
         https://github.com/intel/nemu/tags
         .*/release-?(\d\S+)\.tar\.gz
-      version: "release-2019-03-11"
+      version: "release-2019-04-25"
 
     nemu-ovmf:
       description: "OVMF firmware used by nemu hypervisor"


### PR DESCRIPTION
This release is based off of QEMU 4.0 and also includes support for
virtio-fs.

Fixes: #1580

Signed-off-by: Rob Bradford <robert.bradford@intel.com>