### PR TITLE
virtcontainers: Use shim to print the agent logs if there is no proxy

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -498,7 +498,7 @@ func (k *kataAgent) exec(sandbox *Sandbox, c Container, cmd types.Cmd) (*Process
 	}
 
 	return prepareAndStartShim(sandbox, k.shim, c.id, req.ExecId,
-		k.state.URL, cmd, []ns.NSType{}, enterNSList)
+		k.state.URL, "", cmd, []ns.NSType{}, enterNSList)
 }
 
 func (k *kataAgent) updateInterface(ifc *vcTypes.Interface) (*vcTypes.Interface, error) {
@@ -1214,8 +1214,17 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 		})
 	}
 
+	// Ask to the shim to print the agent logs, if it's the process who monitors the sandbox and use_vsock is true (no proxy)
+	var consoleURL string
+	if sandbox.config.HypervisorConfig.UseVSock && c.GetAnnotations()[vcAnnotations.ContainerTypeKey] == string(PodSandbox) {
+		consoleURL, err = sandbox.hypervisor.getSandboxConsole(sandbox.id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return prepareAndStartShim(sandbox, k.shim, c.id, req.ExecId,
-		k.state.URL, c.config.Cmd, createNSList, enterNSList)
+		k.state.URL, consoleURL, c.config.Cmd, createNSList, enterNSList)
 }
 
 // handleEphemeralStorage handles ephemeral storages by

--- a/virtcontainers/kata_shim.go
+++ b/virtcontainers/kata_shim.go
@@ -48,6 +48,9 @@ func (s *kataShim) start(sandbox *Sandbox, params ShimParams) (int, error) {
 
 	if config.Debug {
 		args = append(args, "-log", "debug")
+		if params.ConsoleURL != "" {
+			args = append(args, "-agent-logs-socket", params.ConsoleURL)
+		}
 	}
 
 	if config.Trace {

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -38,15 +38,16 @@ var consoleFileMode = os.FileMode(0660)
 // ShimParams is the structure providing specific parameters needed
 // for the execution of the shim binary.
 type ShimParams struct {
-	Container string
-	Token     string
-	URL       string
-	Console   string
-	Terminal  bool
-	Detach    bool
-	PID       int
-	CreateNS  []ns.NSType
-	EnterNS   []ns.Namespace
+	Container  string
+	Token      string
+	URL        string
+	Console    string
+	ConsoleURL string
+	Terminal   bool
+	Detach     bool
+	PID        int
+	CreateNS   []ns.NSType
+	EnterNS    []ns.Namespace
 }
 
 // ShimConfig is the structure providing specific configuration
@@ -147,7 +148,7 @@ func stopShim(pid int) error {
 	return nil
 }
 
-func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cmd types.Cmd,
+func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url, consoleURL string, cmd types.Cmd,
 	createNSList []ns.NSType, enterNSList []ns.Namespace) (*Process, error) {
 	process := &Process{
 		Token:     token,
@@ -155,14 +156,15 @@ func prepareAndStartShim(sandbox *Sandbox, shim shim, cid, token, url string, cm
 	}
 
 	shimParams := ShimParams{
-		Container: cid,
-		Token:     token,
-		URL:       url,
-		Console:   cmd.Console,
-		Terminal:  cmd.Interactive,
-		Detach:    cmd.Detach,
-		CreateNS:  createNSList,
-		EnterNS:   enterNSList,
+		Container:  cid,
+		Token:      token,
+		URL:        url,
+		Console:    cmd.Console,
+		Terminal:   cmd.Interactive,
+		Detach:     cmd.Detach,
+		CreateNS:   createNSList,
+		EnterNS:    enterNSList,
+		ConsoleURL: consoleURL,
 	}
 
 	pid, err := shim.start(sandbox, shimParams)


### PR DESCRIPTION
The proxy is in charge to print the agent logs, but when `use_vsocks` is true
the runtime doesn't start the proxy, because it's not needed, hence the agent
logs are ignored. To mitigate this limitation and to make the debugging
process easier, the fist shim started (the one who monitors the sandbox)
will read the console.sock and print the agent logs.

Depends-on: github.com/kata-containers/shim#172

fixes #1596

Signed-off-by: Julio Montes <julio.montes@intel.com>