### PR TITLE
cli: do not fail on list when some containers bust

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -331,7 +331,8 @@ func getContainers(ctx context.Context, context *cli.Context) ([]fullContainerSt
 
 			uid, err := getDirOwner(container.RootFs)
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "WARNING: failed to get container %s rootfs: %s\n", ociState.ID, err)
+				continue
 			}
 
 			owner := fmt.Sprintf("#%v", uid)


### PR DESCRIPTION
kata-runtime list command should list all valid container, not fail
when some containers information uncorrent, like rootfs not found.

Fixes: #1592

Signed-off-by: Ace-Tang <aceapril@126.com>