### PR TITLE
shim v2: fix set status when container exit

### DIFF
--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -21,7 +21,7 @@ type container struct {
 	s        *service
 	ttyio    *ttyIO
 	spec     *oci.CompatOCISpec
-	time     time.Time
+	exitTime time.Time
 	execs    map[string]*exec
 	exitIOch chan struct{}
 	exitCh   chan uint32
@@ -61,7 +61,6 @@ func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.Con
 		status:   task.StatusCreated,
 		exitIOch: make(chan struct{}),
 		exitCh:   make(chan uint32, 1),
-		time:     time.Now(),
 	}
 	return c, nil
 }

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -444,12 +444,12 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 			ContainerID: s.id,
 			Pid:         s.pid,
 			ExitStatus:  c.exit,
-			ExitedAt:    c.time,
+			ExitedAt:    c.exitTime,
 		})
 
 		return &taskAPI.DeleteResponse{
 			ExitStatus: c.exit,
-			ExitedAt:   c.time,
+			ExitedAt:   c.exitTime,
 			Pid:        s.pid,
 		}, nil
 	}
@@ -860,6 +860,7 @@ func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (_ *taskAPI.
 
 	return &taskAPI.WaitResponse{
 		ExitStatus: ret,
+		ExitedAt:   c.exitTime,
 	}, nil
 }
 

--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -41,24 +41,24 @@ func wait(s *service, c *container, execID string) (int32, error) {
 		}).Error("Wait for process failed")
 	}
 
-	if execID == "" {
-		c.exitCh <- uint32(ret)
-	} else {
-		execs.exitCh <- uint32(ret)
-	}
-
 	timeStamp := time.Now()
 	c.mu.Lock()
 	if execID == "" {
 		c.status = task.StatusStopped
 		c.exit = uint32(ret)
-		c.time = timeStamp
+		c.exitTime = timeStamp
 	} else {
 		execs.status = task.StatusStopped
 		execs.exitCode = ret
 		execs.exitTime = timeStamp
 	}
 	c.mu.Unlock()
+
+	if execID == "" {
+		c.exitCh <- uint32(ret)
+	} else {
+		execs.exitCh <- uint32(ret)
+	}
 
 	go cReap(s, int(ret), c.id, execID, timeStamp)
 


### PR DESCRIPTION
in wait function, should send msg to exit channel after task status has
updated, since shim.Wait() is running in another goroutine, when it
receive msg from exit channel, it will stop waiting and return, then
someone who hold this Wait() get return, it can delete task, if exit msg
is send first, the container status may still be running.

Fixes: #1600 

Signed-off-by: Ace-Tang <aceapril@126.com>