### PR TITLE
virtcontainers: fix invalid CPU topology

### DIFF
--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -257,7 +257,7 @@ func (q *qemuArchBase) bridges(number uint32) []types.PCIBridge {
 func (q *qemuArchBase) cpuTopology(vcpus, maxvcpus uint32) govmmQemu.SMP {
 	smp := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Sockets: vcpus,
+		Sockets: maxvcpus,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
 		MaxCPUs: maxvcpus,

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -165,7 +165,7 @@ func TestQemuArchBaseCPUTopology(t *testing.T) {
 
 	expectedSMP := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Sockets: vcpus,
+		Sockets: defaultMaxQemuVCPUs,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
 		MaxCPUs: defaultMaxQemuVCPUs,


### PR DESCRIPTION
sockets * cores * threads should be equal to maxcpus otherwise a
warning is thrown: 'warning: Invalid CPU topology deprecated:
    sockets * cores * threads != maxcpus'

This warning in the future will be an error and won't be possible to run
kata containers.

fixes #1605

Signed-off-by: Julio Montes <julio.montes@intel.com>