### PR TITLE
build: Fix virtcontainers static check make target

### DIFF
--- a/virtcontainers/Makefile
+++ b/virtcontainers/Makefile
@@ -46,7 +46,7 @@ binaries: hook kata-shim
 check: check-go-static check-go-test
 
 check-go-static:
-	bash $(MK_DIR)/../.ci/go-lint.sh
+	bash $(MK_DIR)/../.ci/static-checks.sh
 
 check-go-test:
 	bash $(MK_DIR)/../.ci/go-test.sh \


### PR DESCRIPTION
The virtcontainers `Makefile` was referencing an old script to handle static checks. Although these are still run if `make` is invoked at the top-level, correct the error.

Fixes #1609.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>