### PR TITLE
versions: Update K8s and CRI-O version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -186,7 +186,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.13.0"
+    version: "3ddde3dee35a239712ee26fa542abe5609c4f44f"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
 
@@ -230,7 +230,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.13.3-00"
+    version: "1.14.1-00"
 
   openshift:
     description: |


### PR DESCRIPTION
This will update the k8s version to latest 1.14.1 and CRI-O to
commit 3ddde3dee35a239712ee26fa542abe5609c4f44f. We are
using this commit as crio 1.14 has an issue: cri-o/cri-o#2221 
and also does not include test fixes of cri-o/cri-o@7b8c298.
Depends-on: github.com/kata-containers/tests#1528

Fixes #1617

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>