### PR TITLE
Firecracker: Fix kernel command line parameters

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -57,6 +57,13 @@ const (
 var fcKernelParams = []Param{
 	// The boot source is the first partition of the first block device added
 	{"root", "/dev/vda1"},
+	{"pci", "off"},
+	{"reboot", "k"},
+	{"panic", "1"},
+	{"iommu", "off"},
+	{"8250.nr_uarts", "0"},
+	{"net.ifnames", "0"},
+	{"random.trust_cpu", "on"},
 
 	// Firecracker doesn't support ACPI
 	// Fix kernel error "ACPI BIOS Error (bug)"


### PR DESCRIPTION
Firecracker does not support pci. It also uses kbd to implement reboot/reset.
Fix the kernel boot params to address this.

It also does not have good entropy at startup. Use the hardware random
number generator to support entropy.

Fixes: #1620

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>