### PR TITLE
mounts: fix isSystemMount check for mountSharedDirMounts

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -515,10 +515,11 @@ func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (
 	var sharedDirMounts []Mount
 	var ignoredMounts []Mount
 	for idx, m := range c.mounts {
-		if isSystemMount(m.Destination) {
-			if !(IsDockerVolume(m.Source) || Isk8sHostEmptyDir(m.Source)) {
-				continue
-			}
+		// Skip mounting certain system paths from the source on the host side
+		// into the container as it does not make sense to do so.
+		// Example sources could be /sys/fs/cgroup etc.
+		if isSystemMount(m.Source) {
+			continue
 		}
 
 		if m.Type != "bind" {


### PR DESCRIPTION
This change updates the isSystemMount check for mountSharedDirMounts
when setting up shared directory mounts for the container and uses
the source of the mount instead of the destination for the check.

We want to exclude system mounts from the host side as they
shouldn't be mounted into the container.

We do however want to allow system mounts within the
container as denying them can prevent some containers from
running properly.

Fixes #1591

Signed-off-by: Alex Price <aprice@atlassian.com>