### PR TITLE
shimv2: update container status when process exited

### DIFF
--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -23,7 +23,9 @@ func deleteContainer(ctx context.Context, s *service, c *container) error {
 		return err
 	}
 	if status.State.State != types.StateStopped {
+		c.mu.Lock()
 		_, err = s.sandbox.StopContainer(c.id)
+		c.mu.Unlock()
 		if err != nil {
 			return err
 		}

--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -41,6 +41,15 @@ func wait(s *service, c *container, execID string) (int32, error) {
 		}).Error("Wait for process failed")
 	}
 
+	if execID == "" {
+		c.mu.Lock()
+		_, err = s.sandbox.StopContainer(c.id)
+		c.mu.Lock()
+		if err != nil {
+			logrus.WithError(err).WithField("container", c.id).Warn("stop container failed")
+		}
+	}
+
 	timeStamp := time.Now()
 	c.mu.Lock()
 	if execID == "" {


### PR DESCRIPTION
When a container process terminated, shimv2 should update
container's status internally, otherwise, ctr command would
get a wrong container status even the process had exited.

Fixes:#1602

Signed-off-by: lifupan <lifupan@gmail.com>