### PR TITLE
shimv2: fix the issue ttrpc server canceled context

### DIFF
--- a/containerd-shim-v2/create.go
+++ b/containerd-shim-v2/create.go
@@ -80,7 +80,12 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest, netns
 		rootFs.Mounted = s.mount
 
 		katautils.HandleFactory(ctx, vci, s.config)
-		sandbox, _, err := katautils.CreateSandbox(ctx, vci, *ociSpec, *s.config, rootFs, r.ID, bundlePath, "", disableOutput, false, true)
+
+		// Pass service's context instead of local ctx to CreateSandbox(), since local
+		// ctx will be canceled after this rpc service call, but the sandbox will live
+		// across multiple rpc service calls.
+		//
+		sandbox, _, err := katautils.CreateSandbox(s.ctx, vci, *ociSpec, *s.config, rootFs, r.ID, bundlePath, "", disableOutput, false, true)
 		if err != nil {
 			return nil, err
 		}

--- a/containerd-shim-v2/create_test.go
+++ b/containerd-shim-v2/create_test.go
@@ -84,6 +84,7 @@ func TestCreateSandboxSuccess(t *testing.T) {
 		id:         testSandboxID,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{
@@ -129,6 +130,7 @@ func TestCreateSandboxFail(t *testing.T) {
 		id:         testSandboxID,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{
@@ -184,6 +186,7 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 		id:         testSandboxID,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{
@@ -245,6 +248,7 @@ func TestCreateContainerSuccess(t *testing.T) {
 		sandbox:    sandbox,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{
@@ -291,6 +295,7 @@ func TestCreateContainerFail(t *testing.T) {
 		id:         testContainerID,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{
@@ -351,6 +356,7 @@ func TestCreateContainerConfigFail(t *testing.T) {
 		sandbox:    sandbox,
 		containers: make(map[string]*container),
 		config:     &runtimeConfig,
+		ctx:        context.Background(),
 	}
 
 	req := &taskAPI.CreateTaskRequest{


### PR DESCRIPTION
This latest ttrpc vendor supports the feature of request timeout propgation.
this feature will do context cancel after a service call return, and this cancel
will propagated into kata sandbox's agent/hypervisor and resulted in the following
calls canceled. To fix this issue, pass the service's context instead of the service's
call's context to CreateSandbox(), and this context will live until the shim exited.

Fixes:#1627

Signed-off-by: lifupan <lifupan@gmail.com>