### PR TITLE
test: Skip namespace test on Centos

### DIFF
--- a/pkg/katautils/network_test.go
+++ b/pkg/katautils/network_test.go
@@ -69,6 +69,10 @@ func TestHostNetworkingRequested(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedRoot)
 	}
 
+	if tc.NotValid(ktu.NeedKernelVersionGE("3.19.0")) {
+		t.Skip("skipping this test as it requires a greater kernel version")
+	}
+
 	// Network namespace same as the host
 	selfNsPath := "/proc/self/ns/net"
 	isHostNs, err := hostNetworkingRequested(selfNsPath)


### PR DESCRIPTION
Skip TestHostNetworkingRequested test as nsfs is not supported on
older kernel versions. Currently, CentOS has issues with this test as is using
a kernel version of 3.10 and to run this test we need a kernel version
greater than 3.19.

Fixes #1629

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>