### PR TITLE
firecracker: Upgrade firecracker to 0.16.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -76,7 +76,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.15.2"
+      version: "v0.16.0"
 
     nemu:
       description: "Modern Hypervisor for the Cloud"


### PR DESCRIPTION
Upgrade firecracker to 0.16.0

Fixes: 0.16.0

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>