### PR TITLE
firecracker: Setup rootfs to be RO

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -57,6 +57,8 @@ const (
 var fcKernelParams = []Param{
 	// The boot source is the first partition of the first block device added
 	{"root", "/dev/vda1"},
+	{"rootflags", "data=ordered,errors=remount-ro ro"},
+	{"rootfstype", "ext4"},
 	{"pci", "off"},
 	{"reboot", "k"},
 	{"panic", "1"},
@@ -299,7 +301,7 @@ func (fc *firecracker) fcSetVMRootfs(path string) error {
 	driveID := "rootfs"
 	driveParams := ops.NewPutGuestDriveByIDParams()
 	driveParams.SetDriveID(driveID)
-	isReadOnly := false
+	isReadOnly := true
 	//Add it as a regular block device
 	//This allows us to use a paritioned root block device
 	isRootDevice := false


### PR DESCRIPTION
Setup rootfs to be RO both from the VMM point of view and the
VM point of view.

Fixes: #1632

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>