### PR TITLE
virtcontainers: kill hypervisor if startSandbox fails

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -967,11 +967,8 @@ func (s *Sandbox) startVM() (err error) {
 			if err != nil {
 				return err
 			}
-			err = vm.assignSandbox(s)
-			if err != nil {
-				return err
-			}
-			return nil
+
+			return vm.assignSandbox(s)
 		}
 
 		return s.hypervisor.startSandbox(vmStartTimeout)


### PR DESCRIPTION
Make sure the hypervisor is stopped if startSandbox does not succeed, by calling stopSandbox.
    
Fixes: #1636    
