### PR TITLE
shimv2: create the rootfs dir if it doesn't exist

### DIFF
--- a/containerd-shim-v2/create.go
+++ b/containerd-shim-v2/create.go
@@ -210,6 +210,16 @@ func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) error {
 }
 
 func doMount(mounts []*containerd_types.Mount, rootfs string) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+
+	if _, err := os.Stat(rootfs); os.IsNotExist(err) {
+		if err := os.Mkdir(rootfs, 0711); err != nil {
+			return err
+		}
+	}
+
 	for _, rm := range mounts {
 		m := &mount.Mount{
 			Type:    rm.Type,


### PR DESCRIPTION
Latest containerd commit<c0f0b21314b93a1> had moved the
step of creating rootfs dir from creating bundle to container
creation; in order to support both of the old and latest
containerd, check the "rootfs" existed before creating it.

Signed-off-by: lifupan <lifupan@gmail.com>