### PR TITLE
Use O_NONBLOCK for tty stdin.

### DIFF
--- a/containerd-shim-v2/stream.go
+++ b/containerd-shim-v2/stream.go
@@ -56,7 +56,7 @@ func newTtyIO(ctx context.Context, stdin, stdout, stderr string, console bool) (
 	var err error
 
 	if stdin != "" {
-		in, err = fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY, 0)
+		in, err = fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
our testing found that the client does not open
stdin with O_WRONLY, so the shim v2 was blocked forever
in open stdin with O_RDONLY. It's better to make it
opened with O_NONBLOCK, and do not block starting process
of container. and the containerd runc shim has done this
by bc1ff514 as well.

Signed-off-by: Yang, Wei <w90p710@gmail.com>
Signed-off-by: Yang, Wei <wei.yang1@linux.alibaba.com>