### PR TITLE
kernelRootParams: define agnostic commonkernelRootParams

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -54,11 +54,8 @@ const (
 	fcDiskPoolSize = 8
 )
 
-var fcKernelParams = []Param{
+var fcKernelParams = append(commonVirtioblkKernelRootParams, []Param{
 	// The boot source is the first partition of the first block device added
-	{"root", "/dev/vda1"},
-	{"rootflags", "data=ordered,errors=remount-ro ro"},
-	{"rootfstype", "ext4"},
 	{"pci", "off"},
 	{"reboot", "k"},
 	{"panic", "1"},
@@ -70,7 +67,7 @@ var fcKernelParams = []Param{
 	// Firecracker doesn't support ACPI
 	// Fix kernel error "ACPI BIOS Error (bug)"
 	{"acpi", "off"},
-}
+}...)
 
 func (s vmmState) String() string {
 	switch s {

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -53,6 +53,20 @@ const (
 // In some architectures the maximum number of vCPUs depends on the number of physical cores.
 var defaultMaxQemuVCPUs = MaxQemuVCPUs()
 
+// agnostic list of kernel root parameters for NVDIMM
+var commonNvdimmKernelRootParams = []Param{ //nolint: unused, deadcode, varcheck
+	{"root", "/dev/pmem0p1"},
+	{"rootflags", "dax,data=ordered,errors=remount-ro ro"},
+	{"rootfstype", "ext4"},
+}
+
+// agnostic list of kernel root parameters for virtio-blk
+var commonVirtioblkKernelRootParams = []Param{ //nolint: unused, deadcode, varcheck
+	{"root", "/dev/vda1"},
+	{"rootflags", "data=ordered,errors=remount-ro ro"},
+	{"rootfstype", "ext4"},
+}
+
 // deviceType describes a virtualized device type.
 type deviceType int
 

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -35,11 +35,7 @@ var qemuPaths = map[string]string{
 	QemuQ35:    defaultQemuPath,
 }
 
-var kernelRootParams = []Param{
-	{"root", "/dev/pmem0p1"},
-	{"rootflags", "dax,data=ordered,errors=remount-ro ro"},
-	{"rootfstype", "ext4"},
-}
+var kernelRootParams = commonNvdimmKernelRootParams
 
 var kernelParams = []Param{
 	{"tsc", "reliable"},

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -43,9 +43,12 @@ var kernelParams = []Param{
 	{"iommu.passthrough", "0"},
 }
 
+// For now, AArch64 doesn't support DAX, so we couldn't use
+// commonNvdimmKernelRootParams, the agnostic list of kernel
+// root parameters for NVDIMM
 var kernelRootParams = []Param{
 	{"root", "/dev/pmem0p1"},
-	{"rootflags", "data=ordered,errors=remount-ro rw"},
+	{"rootflags", "data=ordered,errors=remount-ro ro"},
 	{"rootfstype", "ext4"},
 }
 

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -39,9 +39,7 @@ var kernelParams = []Param{
 	{"console", "ttysclp0"},
 }
 
-var kernelRootParams = []Param{
-	{"root", "/dev/vda1"},
-}
+var kernelRootParams = commonVirtioblkKernelRootParams
 
 var supportedQemuMachines = []govmmQemu.Machine{
 	{


### PR DESCRIPTION
Let's make this option consistent cross all archs, since from a security point of view, there is no need
for us to write to the rootfs.

Fixes: #1642

Signed-off-by: Penny Zheng <penny.zheng@arm.com>