### PR TITLE
Networking: Ensure that network namespace is propagated

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -543,6 +543,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		shmSize:         sandboxConfig.ShmSize,
 		sharePidNs:      sandboxConfig.SharePidNs,
 		stateful:        sandboxConfig.Stateful,
+		networkNS:       NetworkNamespace{NetNsPath: sandboxConfig.NetworkConfig.NetNSPath},
 		ctx:             ctx,
 	}
 


### PR DESCRIPTION
Network namespace needs to be propagated if available at
createSandbox()

Fixes: #1664

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>