### PR TITLE
factory: Add new option disable_config_check

### DIFF
--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -232,6 +232,15 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 #guest_hook_path = "/usr/share/oci/hooks"
 
 [factory]
+# In default mode, the runtime will check the VM config of VM factory before
+# get VM from it.
+# Disable VM factory config check.  Once enabled, the runtime will not check
+# whether the current VM config is same with the VM config of VM factory.
+# It helps speeding up new container creation.
+#
+# Default false
+#disable_config_check = true
+
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and
 # agent memory by mapping it readonly. It helps speeding up new container

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -75,10 +75,11 @@ type tomlConfig struct {
 }
 
 type factory struct {
-	Template        bool   `toml:"enable_template"`
-	TemplatePath    string `toml:"template_path"`
-	VMCacheNumber   uint   `toml:"vm_cache_number"`
-	VMCacheEndpoint string `toml:"vm_cache_endpoint"`
+	DisableConfigCheck bool   `toml:"disable_config_check"`
+	Template           bool   `toml:"enable_template"`
+	TemplatePath       string `toml:"template_path"`
+	VMCacheNumber      uint   `toml:"vm_cache_number"`
+	VMCacheEndpoint    string `toml:"vm_cache_endpoint"`
 }
 
 type hypervisor struct {
@@ -608,10 +609,11 @@ func newFactoryConfig(f factory) (oci.FactoryConfig, error) {
 		f.VMCacheEndpoint = defaultVMCacheEndpoint
 	}
 	return oci.FactoryConfig{
-		Template:        f.Template,
-		TemplatePath:    f.TemplatePath,
-		VMCacheNumber:   f.VMCacheNumber,
-		VMCacheEndpoint: f.VMCacheEndpoint,
+		DisableConfigCheck: f.DisableConfigCheck,
+		Template:           f.Template,
+		TemplatePath:       f.TemplatePath,
+		VMCacheNumber:      f.VMCacheNumber,
+		VMCacheEndpoint:    f.VMCacheEndpoint,
 	}, nil
 }
 

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -123,10 +123,11 @@ func HandleFactory(ctx context.Context, vci vc.VC, runtimeConfig *oci.RuntimeCon
 		return
 	}
 	factoryConfig := vf.Config{
-		Template:        runtimeConfig.FactoryConfig.Template,
-		TemplatePath:    runtimeConfig.FactoryConfig.TemplatePath,
-		VMCache:         runtimeConfig.FactoryConfig.VMCacheNumber > 0,
-		VMCacheEndpoint: runtimeConfig.FactoryConfig.VMCacheEndpoint,
+		DisableConfigCheck: runtimeConfig.FactoryConfig.DisableConfigCheck,
+		Template:           runtimeConfig.FactoryConfig.Template,
+		TemplatePath:       runtimeConfig.FactoryConfig.TemplatePath,
+		VMCache:            runtimeConfig.FactoryConfig.VMCacheNumber > 0,
+		VMCacheEndpoint:    runtimeConfig.FactoryConfig.VMCacheEndpoint,
 		VMConfig: vc.VMConfig{
 			HypervisorType:   runtimeConfig.HypervisorType,
 			HypervisorConfig: runtimeConfig.HypervisorConfig,

--- a/virtcontainers/factory/factory.go
+++ b/virtcontainers/factory/factory.go
@@ -25,17 +25,19 @@ var factoryLogger = logrus.FieldLogger(logrus.New())
 
 // Config is a collection of VM factory configurations.
 type Config struct {
-	Template        bool
-	VMCache         bool
-	Cache           uint
-	TemplatePath    string
-	VMCacheEndpoint string
+	DisableConfigCheck bool
+	Template           bool
+	VMCache            bool
+	Cache              uint
+	TemplatePath       string
+	VMCacheEndpoint    string
 
 	VMConfig vc.VMConfig
 }
 
 type factory struct {
-	base base.FactoryBase
+	disableConfigCheck bool
+	base               base.FactoryBase
 }
 
 func trace(parent context.Context, name string) (opentracing.Span, context.Context) {
@@ -89,7 +91,10 @@ func NewFactory(ctx context.Context, config Config, fetchOnly bool) (vc.Factory,
 		}
 	}
 
-	return &factory{b}, nil
+	return &factory{
+		disableConfigCheck: config.DisableConfigCheck,
+		base:               b,
+	}, nil
 }
 
 // SetLogger sets the logger for the factory.
@@ -138,6 +143,10 @@ func checkVMConfig(config1, config2 vc.VMConfig) error {
 }
 
 func (f *factory) checkConfig(config vc.VMConfig) error {
+	if f.disableConfigCheck {
+		return nil
+	}
+
 	baseConfig := f.base.Config()
 
 	return checkVMConfig(config, baseConfig)

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -95,6 +95,9 @@ type CompatOCISpec struct {
 
 // FactoryConfig is a structure to set the VM factory configuration.
 type FactoryConfig struct {
+	// DisableConfigCheck disables VM factory config check.
+	DisableConfigCheck bool
+
 	// Template enables VM templating support in VM factory.
 	Template bool
 


### PR DESCRIPTION
In default mode, the runtime will check the VM config of VM factory before
get VM from it.
Disable VM factory config check.  Once enabled, the runtime will not check
whether the current VM config is same with the VM config of VM factory.
It helps speeding up new container creation.

Fixes: #1666

Signed-off-by: Hui Zhu <teawater@hyper.sh>