### PR TITLE
backports: Bp 1.6.4 rel

### DIFF
--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	cpuFlagsTag        = genericCPUFlagsTag
-	archCPUVendorField = genericCPUVendorField
-	archCPUModelField  = genericCPUModelField
-	archGenuineIntel   = "GenuineIntel"
-	archAuthenticAMD   = "AuthenticAMD"
-	msgKernelVM        = "Kernel-based Virtual Machine"
-	msgKernelVirtio    = "Host kernel accelerator for virtio"
-	msgKernelVirtioNet = "Host kernel accelerator for virtio network"
+	cpuFlagsTag               = genericCPUFlagsTag
+	archCPUVendorField        = genericCPUVendorField
+	archCPUModelField         = genericCPUModelField
+	archGenuineIntel          = "GenuineIntel"
+	archAuthenticAMD          = "AuthenticAMD"
+	msgKernelVM               = "Kernel-based Virtual Machine"
+	msgKernelVirtio           = "Host kernel accelerator for virtio"
+	msgKernelVirtioNet        = "Host kernel accelerator for virtio network"
+	msgKernelVirtioVhostVsock = "Host Support for Linux VM Sockets"
 )
 
 // CPU types
@@ -75,17 +76,25 @@ func setCPUtype() error {
 		}
 		archRequiredKernelModules = map[string]kernelModule{
 			"kvm": {
-				desc: msgKernelVM,
+				desc:     msgKernelVM,
+				required: true,
 			},
 			"kvm_intel": {
 				desc:       "Intel KVM",
 				parameters: kvmIntelParams,
+				required:   true,
 			},
 			"vhost": {
-				desc: msgKernelVirtio,
+				desc:     msgKernelVirtio,
+				required: true,
 			},
 			"vhost_net": {
-				desc: msgKernelVirtioNet,
+				desc:     msgKernelVirtioNet,
+				required: true,
+			},
+			"vhost_vsock": {
+				desc:     msgKernelVirtioVhostVsock,
+				required: false,
 			},
 		}
 	} else if cpuType == cpuTypeAMD {
@@ -99,16 +108,24 @@ func setCPUtype() error {
 		}
 		archRequiredKernelModules = map[string]kernelModule{
 			"kvm": {
-				desc: msgKernelVM,
+				desc:     msgKernelVM,
+				required: true,
 			},
 			"kvm_amd": {
-				desc: "AMD KVM",
+				desc:     "AMD KVM",
+				required: true,
 			},
 			"vhost": {
-				desc: msgKernelVirtio,
+				desc:     msgKernelVirtio,
+				required: true,
 			},
 			"vhost_net": {
-				desc: msgKernelVirtioNet,
+				desc:     msgKernelVirtioNet,
+				required: true,
+			},
+			"vhost_vsock": {
+				desc:     msgKernelVirtioVhostVsock,
+				required: false,
 			},
 		}
 	}

--- a/cli/kata-check_amd64_test.go
+++ b/cli/kata-check_amd64_test.go
@@ -171,6 +171,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 				"nested":             "Y",
 				"unrestricted_guest": "Y",
 			},
+			required: true,
 		},
 	}
 
@@ -255,6 +256,7 @@ func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 				"nested":             "Y",
 				"unrestricted_guest": "Y",
 			},
+			required: true,
 		},
 	}
 

--- a/cli/kata-check_arm64.go
+++ b/cli/kata-check_arm64.go
@@ -30,13 +30,20 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
 	},
 	"vhost": {
-		desc: "Host kernel accelerator for virtio",
+		desc:     "Host kernel accelerator for virtio",
+		required: true,
 	},
 	"vhost_net": {
-		desc: "Host kernel accelerator for virtio network",
+		desc:     "Host kernel accelerator for virtio network",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_ppc64le.go
+++ b/cli/kata-check_ppc64le.go
@@ -42,10 +42,16 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
 	},
 	"kvm_hv": {
-		desc: "Kernel-based Virtual Machine hardware virtualization",
+		desc:     "Kernel-based Virtual Machine hardware virtualization",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_s390x.go
+++ b/cli/kata-check_s390x.go
@@ -33,7 +33,12 @@ var archRequiredCPUAttribs = map[string]string{}
 // required module parameters.
 var archRequiredKernelModules = map[string]kernelModule{
 	"kvm": {
-		desc: "Kernel-based Virtual Machine",
+		desc:     "Kernel-based Virtual Machine",
+		required: true,
+	},
+	"vhost_vsock": {
+		desc:     "Host Support for Linux VM Sockets",
+		required: false,
 	},
 }
 

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -501,6 +501,7 @@ func TestCheckCheckKernelModules(t *testing.T) {
 		"foo": {
 			desc:       "desc",
 			parameters: map[string]string{},
+			required:   true,
 		},
 		"bar": {
 			desc: "desc",
@@ -510,6 +511,7 @@ func TestCheckCheckKernelModules(t *testing.T) {
 				"param3": "a",
 				"param4": ".",
 			},
+			required: true,
 		},
 	}
 
@@ -569,6 +571,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "wibble",
 			},
+			required: true,
 		},
 	}
 
@@ -616,6 +619,7 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "wibble",
 			},
+			required: true,
 		},
 	}
 
@@ -712,6 +716,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 		"foo": {
 			desc:       "desc",
 			parameters: map[string]string{},
+			required:   true,
 		},
 		"bar": {
 			desc: "desc",
@@ -719,6 +724,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 				"param1": "hello",
 				"param2": "world",
 			},
+			required: true,
 		},
 	}
 
@@ -730,6 +736,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "moo",
 			},
+			required: true,
 		},
 	}
 
@@ -739,6 +746,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 			parameters: map[string]string{
 				"param1": "bar",
 			},
+			required: true,
 		},
 	}
 

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -719,13 +719,10 @@ func TestMinimalRuntimeConfigWithVsock(t *testing.T) {
 	[agent.kata]
 `
 	orgVHostVSockDevicePath := utils.VHostVSockDevicePath
-	orgVSockDevicePath := utils.VSockDevicePath
 	defer func() {
 		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
-		utils.VSockDevicePath = orgVSockDevicePath
 	}()
 	utils.VHostVSockDevicePath = "/dev/null"
-	utils.VSockDevicePath = "/dev/null"
 
 	configPath := path.Join(dir, "runtime.toml")
 	err = createConfig(configPath, runtimeMinimalConfig)
@@ -765,13 +762,10 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 	disableBlock := true
 	enableIOThreads := true
 	hotplugVFIOOnRootBus := true
-	orgVSockDevicePath := utils.VSockDevicePath
 	orgVHostVSockDevicePath := utils.VHostVSockDevicePath
 	defer func() {
-		utils.VSockDevicePath = orgVSockDevicePath
 		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
 	}()
-	utils.VSockDevicePath = "/dev/abc/xyz"
 	utils.VHostVSockDevicePath = "/dev/abc/xyz"
 
 	hypervisor := hypervisor{
@@ -808,7 +802,6 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	utils.VSockDevicePath = "/dev/null"
 	utils.VHostVSockDevicePath = "/dev/null"
 
 	// all paths exist now

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -164,7 +164,7 @@ func SetEphemeralStorageType(ociSpec oci.CompatOCISpec) oci.CompatOCISpec {
 
 // CreateSandbox create a sandbox container
 func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, runtimeConfig oci.RuntimeConfig,
-	containerID, bundlePath, console string, disableOutput, systemdCgroup, builtIn bool) (vc.VCSandbox, vc.Process, error) {
+	containerID, bundlePath, console string, disableOutput, systemdCgroup, builtIn bool) (_ vc.VCSandbox, _ vc.Process, err error) {
 	span, ctx := Trace(ctx, "createSandbox")
 	defer span.Finish()
 
@@ -183,6 +183,16 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec oci.CompatOCISpec, ru
 	if err := SetupNetworkNamespace(&sandboxConfig.NetworkConfig); err != nil {
 		return nil, vc.Process{}, err
 	}
+
+	defer func() {
+		// cleanup netns if kata creates it
+		ns := sandboxConfig.NetworkConfig
+		if err != nil && ns.NetNsCreated {
+			if ex := cleanupNetNS(ns.NetNSPath); ex != nil {
+				kataUtilsLogger.WithField("path", ns.NetNSPath).WithError(ex).Warn("failed to cleanup netns")
+			}
+		}
+	}()
 
 	// Run pre-start OCI hooks.
 	err = EnterNetNS(sandboxConfig.NetworkConfig.NetNSPath, func() error {

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -253,7 +253,7 @@ func (q *qemuArchBase) bridges(number uint32) []types.PCIBridge {
 func (q *qemuArchBase) cpuTopology(vcpus, maxvcpus uint32) govmmQemu.SMP {
 	smp := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Sockets: vcpus,
+		Sockets: maxvcpus,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
 		MaxCPUs: maxvcpus,

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -165,7 +165,7 @@ func TestQemuArchBaseCPUTopology(t *testing.T) {
 
 	expectedSMP := govmmQemu.SMP{
 		CPUs:    vcpus,
-		Sockets: vcpus,
+		Sockets: defaultMaxQemuVCPUs,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
 		MaxCPUs: defaultMaxQemuVCPUs,

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -29,9 +29,6 @@ const MibToBytesShift = 20
 // See unix(7).
 const MaxSocketPathLen = 107
 
-// VSockDevicePath path to vsock device
-var VSockDevicePath = "/dev/vsock"
-
 // VHostVSockDevicePath path to vhost-vsock device
 var VHostVSockDevicePath = "/dev/vhost-vsock"
 
@@ -234,10 +231,6 @@ func BuildSocketPath(elements ...string) (string, error) {
 
 // SupportsVsocks returns true if vsocks are supported, otherwise false
 func SupportsVsocks() bool {
-	if _, err := os.Stat(VSockDevicePath); err != nil {
-		return false
-	}
-
 	if _, err := os.Stat(VHostVSockDevicePath); err != nil {
 		return false
 	}

--- a/virtcontainers/utils/utils_test.go
+++ b/virtcontainers/utils/utils_test.go
@@ -298,23 +298,12 @@ func TestBuildSocketPath(t *testing.T) {
 func TestSupportsVsocks(t *testing.T) {
 	assert := assert.New(t)
 
-	orgVSockDevicePath := VSockDevicePath
 	orgVHostVSockDevicePath := VHostVSockDevicePath
 	defer func() {
-		VSockDevicePath = orgVSockDevicePath
 		VHostVSockDevicePath = orgVHostVSockDevicePath
 	}()
 
-	VSockDevicePath = "/abc/xyz/123"
 	VHostVSockDevicePath = "/abc/xyz/123"
-	assert.False(SupportsVsocks())
-
-	vSockDeviceFile, err := ioutil.TempFile("", "vsock")
-	assert.NoError(err)
-	defer os.Remove(vSockDeviceFile.Name())
-	defer vSockDeviceFile.Close()
-	VSockDevicePath = vSockDeviceFile.Name()
-
 	assert.False(SupportsVsocks())
 
 	vHostVSockFile, err := ioutil.TempFile("", "vhost-vsock")


### PR DESCRIPTION
This stable backport includes the below changes.
https://github.com/kata-containers/runtime/pull/1513
https://github.com/kata-containers/runtime/pull/1606
https://github.com/kata-containers/runtime/pull/1641

The below changes marked as `stable-candidate` were not included cause of missing base changes.
https://github.com/kata-containers/runtime/pull/1623 
https://github.com/kata-containers/runtime/pull/1628
https://github.com/kata-containers/runtime/pull/1630
https://github.com/kata-containers/runtime/pull/1651 