### PR TITLE
virtcontainers: fix inconsistant VCPUs number

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1070,9 +1070,9 @@ func (q *qemu) hotplugNetDevice(endpoint Endpoint, op operation) error {
 			return err
 		}
 		if machine.Type == QemuCCWVirtio {
-			return q.qmpMonitorCh.qmp.ExecuteNetCCWDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, int(q.config.NumVCPUs))
+			return q.qmpMonitorCh.qmp.ExecuteNetCCWDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, int(q.qemuConfig.SMP.CPUs))
 		}
-		return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, romFile, int(q.config.NumVCPUs), q.arch.runNested())
+		return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, romFile, int(q.qemuConfig.SMP.CPUs), q.arch.runNested())
 	}
 
 	if err := q.removeDeviceFromBridge(tap.ID); err != nil {
@@ -1669,7 +1669,7 @@ func calcHotplugMemMiBSize(mem uint32, memorySectionSizeMB uint32) (uint32, erro
 
 func (q *qemu) resizeVCPUs(reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
 
-	currentVCPUs = q.config.NumVCPUs + uint32(len(q.state.HotpluggedVCPUs))
+	currentVCPUs = q.qemuConfig.SMP.CPUs + uint32(len(q.state.HotpluggedVCPUs))
 	newVCPUs = currentVCPUs
 	switch {
 	case currentVCPUs < reqVCPUs:


### PR DESCRIPTION
There are two VCPU numbers in q.config.NumVCPUs(from toml file) and
q.qemuConfig.SMP.CPUs (passed to govmm qemu).

Considered that config(the toml file) could change at any moment but
to the metadata we stored, it may be better to use q.qemuConfig.SMP.CPUs

Fixes: #1489
Signed-off-by: Jia He <justin.he@arm.com>