### PR TITLE
kata_proxy: Open a special goroutine do cmd.Wait

### DIFF
--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -51,6 +51,8 @@ func (p *kataProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", err
 	}
 
+	go cmd.Wait()
+
 	return cmd.Process.Pid, proxyURL, nil
 }
 


### PR DESCRIPTION
Got a defunct kata-proxy after kata quit when VMCache is enabled.
The reason is vmcache server opens kata-proxy but doesn't wait it.

If VMCache is disabled, kata-runtime will quit before kata-proxy.
So it will not meet the issue.

Open a special goroutine do cmd.Wait in kataProxy.start to handle
the isssue.

Fixes: #1678

Signed-off-by: Hui Zhu <teawater@hyper.sh>