### PR TITLE
pkg/katautils: improve boot time disabling systemd units

### DIFF
--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -52,6 +52,10 @@ var noTraceKernelParam = []vc.Param{
 		Key:   "systemd.mask",
 		Value: "systemd-journal-flush.service",
 	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-journald-dev-log.socket",
+	},
 	// No udev events: agent implements udev events
 	{
 		Key:   "systemd.mask",
@@ -64,6 +68,14 @@ var noTraceKernelParam = []vc.Param{
 	{
 		Key:   "systemd.mask",
 		Value: "systemd-udev-trigger.service",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-udevd-kernel.socket",
+	},
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-udevd-control.socket",
 	},
 	// No timesync: kata is able to setup the time and this service consume network
 	{
@@ -97,6 +109,11 @@ var noTraceKernelParam = []vc.Param{
 	{
 		Key:   "systemd.mask",
 		Value: "systemd-random-seed.service",
+	},
+	// No coredump
+	{
+		Key:   "systemd.mask",
+		Value: "systemd-coredump@.service",
 	},
 }
 


### PR DESCRIPTION
There are still some systemd units that fail to start for different
reasons. Disable these systemd units to improve boot time.

fixes #1686

![1](https://user-images.githubusercontent.com/13009432/57795274-27f19480-770b-11e9-9211-97c5e91650fd.png)

cc @grahamwhaley 

Signed-off-by: Julio Montes <julio.montes@intel.com>