### PR TITLE
versions: Update golang to 1.11.10

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -264,7 +264,7 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     uscan-url: >-
       https://github.com/golang/go/tags .*/go?([\d\.]+)\.tar\.gz
-    version: "1.10.4"
+    version: "1.11.10"
     meta:
       description: |
         'newest-version' is the latest version known to work when


### PR DESCRIPTION
Set the minimum golang version to 1.11.10, the latest stable 1.11 version
at the time of writing. Go 1.11 is required to build the agent with working
vsock support.

Fixes: #1693

Signed-off-by: Marco Vedovati <mvedovati@suse.com>