### PR TITLE
[RFC][WIP]: Sandbox Annotations: Add new annotations for sandbox setup

### DIFF
--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -8,6 +8,15 @@ package annotations
 const (
 	vcAnnotationsPrefix = "com.github.containers.virtcontainers."
 
+	// SandboxMemory is a sandbox annotation for passing a per sandbox memory limit
+	// This detemines the memory size of the virtual machine
+	// Typically an admission controller would set this. This allows hypervisors that do not support
+	// memory hotplug to have a VM that is sized to match the sum of the container resources
+	SandboxMemory = vcAnnotationsPrefix + "SandboxMemory"
+
+	// SandboxCpus is a sandbox annotation for passing a per sandbox CPU limit
+	SandboxCpus = vcAnnotationsPrefix + "SandboxCpus"
+
 	// KernelPath is a sandbox annotation for passing a per container path pointing at the kernel needed to boot the container VM.
 	KernelPath = vcAnnotationsPrefix + "KernelPath"
 


### PR DESCRIPTION
Kata-runtime supports multiple hypervisors. Not all hypervisor
support hotplug of resources. Hence all resources required by
the containers in the sandbox need to be setup at VM creation
time.

Introduce support for sandbox annotations which allow the
orchestrator to inject resource requirements at the pod level.
These annotations will typically be added to the pod spec
by an admission controller or an operator.

Initially add support for configuring memory and cpu.
Longer term this can be enhanced to include devices and other
resources.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>