### PR TITLE
s390x: fix compile error for 1.6.3

### DIFF
--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -10,7 +10,6 @@ import (
 	govmmQemu "github.com/intel/govmm/qemu"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/types"
-	"time"
 )
 
 type qemuS390x struct {


### PR DESCRIPTION
Remove time package because not used

Fixes: #1680

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>