### PR TITLE
nemu: update nemu version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -84,7 +84,7 @@ assets:
       uscan-url: >-
         https://github.com/intel/nemu/tags
         .*/release-?(\d\S+)\.tar\.gz
-      version: "release-2019-05-07"
+      version: "release-2019-05-21"
 
     nemu-ovmf:
       description: "OVMF firmware used by nemu VMM"


### PR DESCRIPTION
virtio-fs is now available in 1.7 release and needs hugepages enabled.
NEMU's machine_type `virt` has issues getting network access when
hugepages is enabled. Temporarily changing type to `pc` to fix this
issue. Accompanying changes to runtime and tests are underway.

Fixes: #1709
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>