### PR TITLE
virtcontainers: skip vfio device hotplug for privileged

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -646,6 +646,14 @@ func filterDevices(c *Container, devices []ContainerDevice) (ret []ContainerDevi
 			continue
 		}
 
+		devType := c.sandbox.devManager.GetDeviceByID(dev.ID).DeviceType()
+		if devType == config.DeviceVFIO {
+			c.Logger().WithFields(logrus.Fields{
+				"device": dev.ContainerPath,
+			}).Info("Not attach device because it is a VFIO")
+			continue
+		}
+
 		ret = append(ret, dev)
 	}
 	return


### PR DESCRIPTION
Now the container will hotplug all the block device
and vfio devices in privileged. There is one case is that
one vfio device has already been hotplug to guest, so will
cause duplicate.

Fixes: #1712

Signed-off-by: Zha Bin <zhabin@linux.alibaba.com>