### PR TITLE
versions: Update docker to 19.03

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -210,9 +210,14 @@ externals:
     description: "Moby project container manager"
     notes: "Docker Swarm requires an older version of Docker."
     url: "https://github.com/moby/moby"
-    version: "v18.06-ce"
+    version: "v19.03-ce"
     meta:
       swarm-version: "1.12.1"
+      # Latest docker on the ppc64 repos is this one:
+      ppc64le-version: "v18.06-ce"
+      # FC needs to work with block storage devices, which
+      # are not availabe on recent docker versions.
+      firecracker-version: "v18.06-ce"
 
   gometalinter:
     description: "utility to run various golang linters"


### PR DESCRIPTION
Move our supported docker version to 18.09.
This is the latest stable and the only supported for Fedora 29,
which we are going to use soon for our CI as Fedora 28 is EOL
at the end of the month. In addition docker 18.09 is the
one that our documentation says that we support.

Fixes: #1110.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>