### PR TITLE
data/kata-collect-data: support kata containers snap

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -7,7 +7,10 @@
 
 typeset -r script_name=${0##*/}
 typeset -r runtime_name="@RUNTIME_NAME@"
-typeset -r runtime=$(command -v "$runtime_name" 2>/dev/null)
+typeset -r runtime_path=$(command -v "$runtime_name" 2>/dev/null)
+typeset -r runtime_snap_name="kata-containers.runtime"
+typeset -r runtime_snap_path=$(command -v "$runtime_snap_name" 2>/dev/null)
+typeset -r runtime=${runtime_path:-"$runtime_snap_path"}
 typeset -r issue_url="@PROJECT_BUG_URL@"
 typeset -r script_version="@VERSION@ (commit @COMMIT@)"
 


### PR DESCRIPTION
Use `kata-containers.runtime` that is the runtime binary, to
collect the data if the kata-runtime binary is not installed

fixes #1720

Signed-off-by: Julio Montes <julio.montes@intel.com>