### PR TITLE
shimv2: remove use containerd ns as netns

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -334,15 +334,8 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	defer s.mu.Unlock()
 
 	var c *container
-	var netns string
 
-	//the network namespace created by cni plugin
-	netns, err = namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "create namespace")
-	}
-
-	c, err = create(ctx, s, r, netns)
+	c, err = create(ctx, s, r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
//the network namespace created by cni plugin
netns, err = namespaces.NamespaceRequired(ctx)
if err != nil {
        return nil, errors.Wrap(err, "create namespace")
}
```

the netns is a containerd namespace concept, it not netns, event a cni
set netns for this, this is a tricky way, so remove the logic.

Fixes: #1692

Signed-off-by: Ace-Tang <aceapril@126.com>