### PR TITLE
fix the issue of hypervisor process is killed by kubelet 

### DIFF
--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -6,7 +6,6 @@
 package containerdshim
 
 import (
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd/api/types/task"
@@ -31,7 +30,6 @@ type container struct {
 	stderr   string
 	bundle   string
 	cType    vc.ContainerType
-	mu       sync.Mutex
 	exit     uint32
 	status   task.Status
 	terminal bool

--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -17,21 +17,21 @@ import (
 )
 
 func deleteContainer(ctx context.Context, s *service, c *container) error {
-
-	status, err := s.sandbox.StatusContainer(c.id)
-	if err != nil {
-		return err
-	}
-	if status.State.State != types.StateStopped {
-		_, err = s.sandbox.StopContainer(c.id)
+	if !c.cType.IsSandbox() {
+		status, err := s.sandbox.StatusContainer(c.id)
 		if err != nil {
 			return err
 		}
-	}
+		if status.State.State != types.StateStopped {
+			_, err = s.sandbox.StopContainer(c.id)
+			if err != nil {
+				return err
+			}
+		}
 
-	_, err = s.sandbox.DeleteContainer(c.id)
-	if err != nil {
-		return err
+		if _, err = s.sandbox.DeleteContainer(c.id); err != nil {
+			return err
+		}
 	}
 
 	// Run post-stop OCI hooks.

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -453,7 +453,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 		}
 
 		s.send(&eventstypes.TaskDelete{
-			ContainerID: s.id,
+			ContainerID: c.id,
 			Pid:         s.pid,
 			ExitStatus:  c.exit,
 			ExitedAt:    c.exitTime,

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -431,25 +431,8 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 	}
 
 	if r.ExecID == "" {
-		err = deleteContainer(ctx, s, c)
-		if err != nil {
+		if err = deleteContainer(ctx, s, c); err != nil {
 			return nil, err
-		}
-
-		// Take care of the use case where it is a sandbox.
-		// Right after the container representing the sandbox has
-		// been deleted, let's make sure we stop and delete the
-		// sandbox.
-		if c.cType.IsSandbox() {
-			if err = s.sandbox.Stop(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to stop sandbox")
-				return nil, err
-			}
-
-			if err = s.sandbox.Delete(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
-				return nil, err
-			}
 		}
 
 		s.send(&eventstypes.TaskDelete{


### PR DESCRIPTION
 For k8s, once all of the containers in a pod terminated, the pod status would be set "Succeeded" or "Failed" according the containers exited status, in any case, kubelet would consider the pod has terminated, and would try to cleanup the pod cgroup resources, which means kubelet would kill all of the processes in the pod cgroups, thus the qemu process would be killed by accident, at a result, kata shimv2 wouldn't communicate with qemu to do some sandbox cleanup and left the shimv2 process there.

This patch will try to fix this issue by moving "stop sandbox" from deleting podsandbox container stage to the time when podsandbox container exited and before kubelet detect the podsandbox container exited, thus kubelet wouldn't kill the hypervisor process. 