### PR TITLE
backport: ci: Build kata-runtime before running static checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -9,4 +9,8 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+# Build kata-runtime before running static checks
+make -C "${cidir}/../"
+
+# Run static checks
 run_static_checks


### PR DESCRIPTION
We need to build kata-runtime to have the correct files
in place to be able to run the static checks script.

Fixes #1716.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>