### PR TITLE
runtime : delete redundant code in CreateContainer

### DIFF
--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -228,12 +228,6 @@ func CreateContainer(ctx context.Context, vci vc.VC, sandbox vc.VCSandbox, ociSp
 		if err := AddContainerIDMapping(ctx, containerID, sandboxID); err != nil {
 			return vc.Process{}, err
 		}
-
-		kataUtilsLogger = kataUtilsLogger.WithField("sandbox", sandboxID)
-
-		if err := AddContainerIDMapping(ctx, containerID, sandboxID); err != nil {
-			return vc.Process{}, err
-		}
 	}
 
 	// Run pre-start OCI hooks.


### PR DESCRIPTION
Here we have done with logger and container ID map
Just delete these code.
fixes #1740

Signed-off-by: Haomin Tsai <caihaomin@huawei.com>