### PR TITLE
virtcontainers: support vm factory in QEMU 4

### DIFF
--- a/virtcontainers/qemu_amd64_test.go
+++ b/virtcontainers/qemu_amd64_test.go
@@ -78,6 +78,14 @@ func TestQemuAmd64CPUModel(t *testing.T) {
 	expectedOut = defaultCPUModel + ",pmu=off"
 	model = amd64.cpuModel()
 	assert.Equal(expectedOut, model)
+
+	amd64.disableNestingChecks()
+	base, ok := amd64.(*qemuAmd64)
+	assert.True(ok)
+	base.vmFactory = true
+	expectedOut = defaultCPUModel + ",vmx=off"
+	model = amd64.cpuModel()
+	assert.Equal(expectedOut, model)
 }
 
 func TestQemuAmd64MemoryTopology(t *testing.T) {


### PR DESCRIPTION
Turn off VMX if vm-factory is enabled since it's not migratable yet.
see https://bugzilla.redhat.com/show_bug.cgi?id=1689216

fixes #1747

Signed-off-by: Julio Montes <julio.montes@intel.com>