### PR TITLE
Bp 1.6.5

### DIFF
--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -21,7 +21,7 @@ type container struct {
 	s        *service
 	ttyio    *ttyIO
 	spec     *oci.CompatOCISpec
-	time     time.Time
+	exitTime time.Time
 	execs    map[string]*exec
 	exitIOch chan struct{}
 	exitCh   chan uint32
@@ -61,7 +61,6 @@ func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.Con
 		status:   task.StatusCreated,
 		exitIOch: make(chan struct{}),
 		exitCh:   make(chan uint32, 1),
-		time:     time.Now(),
 	}
 	return c, nil
 }

--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -6,7 +6,6 @@
 package containerdshim
 
 import (
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd/api/types/task"
@@ -31,7 +30,6 @@ type container struct {
 	stderr   string
 	bundle   string
 	cType    vc.ContainerType
-	mu       sync.Mutex
 	exit     uint32
 	status   task.Status
 	terminal bool

--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -17,21 +17,21 @@ import (
 )
 
 func deleteContainer(ctx context.Context, s *service, c *container) error {
-
-	status, err := s.sandbox.StatusContainer(c.id)
-	if err != nil {
-		return err
-	}
-	if status.State.State != types.StateStopped {
-		_, err = s.sandbox.StopContainer(c.id)
+	if !c.cType.IsSandbox() {
+		status, err := s.sandbox.StatusContainer(c.id)
 		if err != nil {
 			return err
 		}
-	}
+		if status.State.State != types.StateStopped {
+			_, err = s.sandbox.StopContainer(c.id)
+			if err != nil {
+				return err
+			}
+		}
 
-	_, err = s.sandbox.DeleteContainer(c.id)
-	if err != nil {
-		return err
+		if _, err = s.sandbox.DeleteContainer(c.id); err != nil {
+			return err
+		}
 	}
 
 	// Run post-stop OCI hooks.

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -457,12 +457,12 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 			ContainerID: s.id,
 			Pid:         s.pid,
 			ExitStatus:  c.exit,
-			ExitedAt:    c.time,
+			ExitedAt:    c.exitTime,
 		})
 
 		return &taskAPI.DeleteResponse{
 			ExitStatus: c.exit,
-			ExitedAt:   c.time,
+			ExitedAt:   c.exitTime,
 			Pid:        s.pid,
 		}, nil
 	}
@@ -873,6 +873,7 @@ func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (_ *taskAPI.
 
 	return &taskAPI.WaitResponse{
 		ExitStatus: ret,
+		ExitedAt:   c.exitTime,
 	}, nil
 }
 

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -678,6 +678,20 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *ptypes.E
 		return nil, err
 	}
 
+	// According to CRI specs, kubelet will call StopPodSandbox()
+	// at least once before calling RemovePodSandbox, and this call
+	// is idempotent, and must not return an error if all relevant
+	// resources have already been reclaimed. And in that call it will
+	// send a SIGKILL signal first to try to stop the container, thus
+	// once the container has terminated, here should ignore this signal
+	// and return directly.
+	if signum == syscall.SIGKILL || signum == syscall.SIGTERM {
+		if c.status == task.StatusStopped {
+			logrus.WithField("sandbox", s.sandbox.ID()).WithField("Container", c.id).Debug("Container has already been stopped")
+			return empty, nil
+		}
+	}
+
 	processID := c.id
 	if r.ExecID != "" {
 		execs, err := c.getExec(r.ExecID)

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -454,7 +454,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 		}
 
 		s.send(&eventstypes.TaskDelete{
-			ContainerID: s.id,
+			ContainerID: c.id,
 			Pid:         s.pid,
 			ExitStatus:  c.exit,
 			ExitedAt:    c.exitTime,

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -432,25 +432,8 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 	}
 
 	if r.ExecID == "" {
-		err = deleteContainer(ctx, s, c)
-		if err != nil {
+		if err = deleteContainer(ctx, s, c); err != nil {
 			return nil, err
-		}
-
-		// Take care of the use case where it is a sandbox.
-		// Right after the container representing the sandbox has
-		// been deleted, let's make sure we stop and delete the
-		// sandbox.
-		if c.cType.IsSandbox() {
-			if err = s.sandbox.Stop(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to stop sandbox")
-				return nil, err
-			}
-
-			if err = s.sandbox.Delete(); err != nil {
-				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
-				return nil, err
-			}
 		}
 
 		s.send(&eventstypes.TaskDelete{

--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -41,24 +41,24 @@ func wait(s *service, c *container, execID string) (int32, error) {
 		}).Error("Wait for process failed")
 	}
 
-	if execID == "" {
-		c.exitCh <- uint32(ret)
-	} else {
-		execs.exitCh <- uint32(ret)
-	}
-
 	timeStamp := time.Now()
 	c.mu.Lock()
 	if execID == "" {
 		c.status = task.StatusStopped
 		c.exit = uint32(ret)
-		c.time = timeStamp
+		c.exitTime = timeStamp
 	} else {
 		execs.status = task.StatusStopped
 		execs.exitCode = ret
 		execs.exitTime = timeStamp
 	}
 	c.mu.Unlock()
+
+	if execID == "" {
+		c.exitCh <- uint32(ret)
+	} else {
+		execs.exitCh <- uint32(ret)
+	}
 
 	go cReap(s, int(ret), c.id, execID, timeStamp)
 

--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -7,7 +7,10 @@
 
 typeset -r script_name=${0##*/}
 typeset -r runtime_name="@RUNTIME_NAME@"
-typeset -r runtime=$(command -v "$runtime_name" 2>/dev/null)
+typeset -r runtime_path=$(command -v "$runtime_name" 2>/dev/null)
+typeset -r runtime_snap_name="kata-containers.runtime"
+typeset -r runtime_snap_path=$(command -v "$runtime_snap_name" 2>/dev/null)
+typeset -r runtime=${runtime_path:-"$runtime_snap_path"}
 typeset -r issue_url="@PROJECT_BUG_URL@"
 typeset -r script_version="@VERSION@ (commit @COMMIT@)"
 

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -263,12 +263,6 @@ func CreateContainer(ctx context.Context, vci vc.VC, sandbox vc.VCSandbox, ociSp
 		if err := AddContainerIDMapping(ctx, containerID, sandboxID); err != nil {
 			return vc.Process{}, err
 		}
-
-		kataUtilsLogger = kataUtilsLogger.WithField("sandbox", sandboxID)
-
-		if err := AddContainerIDMapping(ctx, containerID, sandboxID); err != nil {
-			return vc.Process{}, err
-		}
 	}
 
 	// Run pre-start OCI hooks.

--- a/versions.yaml
+++ b/versions.yaml
@@ -264,7 +264,7 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     uscan-url: >-
       https://github.com/golang/go/tags .*/go?([\d\.]+)\.tar\.gz
-    version: "1.10.4"
+    version: "1.11.10"
     meta:
       description: |
         'newest-version' is the latest version known to work when

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -108,6 +108,8 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		}
 	}()
 
+	s.postCreatedNetwork()
+
 	if err = s.getAndStoreGuestDetails(); err != nil {
 		return nil, err
 	}

--- a/virtcontainers/factory/cache/cache.go
+++ b/virtcontainers/factory/cache/cache.go
@@ -48,6 +48,7 @@ func New(ctx context.Context, count uint, b base.FactoryBase) base.FactoryBase {
 				case cacheCh <- vm:
 				case <-closed:
 					vm.Stop()
+					vm.Disconnect()
 					c.wg.Done()
 					return
 				}

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -47,6 +47,9 @@ func (p *kataProxy) start(params proxyParams) (int, string, error) {
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
 	if err := cmd.Start(); err != nil {
 		return -1, "", err
 	}

--- a/virtcontainers/kata_proxy.go
+++ b/virtcontainers/kata_proxy.go
@@ -54,6 +54,8 @@ func (p *kataProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", err
 	}
 
+	go cmd.Wait()
+
 	return cmd.Process.Pid, proxyURL, nil
 }
 

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1437,6 +1437,32 @@ func (n *Network) Add(ctx context.Context, config *NetworkConfig, hypervisor hyp
 	return endpoints, nil
 }
 
+func (n *Network) PostAdd(ctx context.Context, ns *NetworkNamespace, hotplug bool) error {
+	if hotplug {
+		return nil
+	}
+
+	if ns.Endpoints == nil {
+		return nil
+	}
+
+	endpoints := ns.Endpoints
+
+	for _, endpoint := range endpoints {
+		netPair := endpoint.NetworkPair()
+		if netPair == nil {
+			continue
+		}
+		if netPair.VhostFds != nil {
+			for _, VhostFd := range netPair.VhostFds {
+				VhostFd.Close()
+			}
+		}
+	}
+
+	return nil
+}
+
 // Remove network endpoints in the network namespace. It also deletes the network
 // namespace in case the namespace has been created by us.
 func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor, hotunplug bool) error {

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -816,6 +817,10 @@ func TestGetShmSizeBindMounted(t *testing.T) {
 	assert.Nil(t, err)
 
 	size := 8192
+	if runtime.GOARCH == "ppc64le" {
+		// PAGE_SIZE on ppc64le is 65536
+		size = 65536
+	}
 
 	shmOptions := "mode=1777,size=" + strconv.Itoa(size)
 	err = unix.Mount("shm", shmPath, "tmpfs", unix.MS_NOEXEC|unix.MS_NOSUID|unix.MS_NODEV, shmOptions)

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -940,6 +940,7 @@ func (q *qemu) hotAddNetDevice(name, hardAddr string, VMFds, VhostFds []*os.File
 		if err := q.qmpMonitorCh.qmp.ExecuteGetFD(q.qmpMonitorCh.ctx, fdName, VhostFd); err != nil {
 			return err
 		}
+		VhostFd.Close()
 		VhostFdNames = append(VhostFdNames, fdName)
 	}
 	return q.qmpMonitorCh.qmp.ExecuteNetdevAddByFds(q.qmpMonitorCh.ctx, "tap", name, VMFdNames, VhostFdNames)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -786,6 +786,11 @@ func (s *Sandbox) createNetwork() error {
 	return s.store.Store(store.Network, s.networkNS)
 }
 
+func (s *Sandbox) postCreatedNetwork() error {
+
+	return s.network.PostAdd(s.ctx, &s.networkNS, s.factory != nil)
+}
+
 func (s *Sandbox) removeNetwork() error {
 	span, _ := s.trace("removeNetwork")
 	defer span.Finish()

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -505,6 +505,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		shmSize:         sandboxConfig.ShmSize,
 		sharePidNs:      sandboxConfig.SharePidNs,
 		stateful:        sandboxConfig.Stateful,
+		networkNS:       NetworkNamespace{NetNsPath: sandboxConfig.NetworkConfig.NetNSPath},
 		ctx:             ctx,
 	}
 


### PR DESCRIPTION
Backports for 1.6.5 release.
kata-containers/runtime#1601
kata-containers/runtime#1665
kata-containers/runtime#1670
kata-containers/runtime#1679
kata-containers/runtime#1694
kata-containers/runtime#1703
kata-containers/runtime#1721
kata-containers/runtime#1723
kata-containers/runtime#1727
kata-containers/runtime#1741

Failed below PRs
kata-containers/runtime#1513 <-- Exists
kata-containers/runtime#1676 <-- Test without which might be causing containerd CI failure.
kata-containers/runtime#1691 <-- Not needed for 1.6 branch
kata-containers/runtime#1697 <-- Major versions of dependencies not updated to stable branches.
kata-containers/runtime#1708 <-- Does not Apply (Missing Dependencies)
kata-containers/runtime#1710 <-- Dependencies in other repositories cannot come along.
kata-containers/runtime#1717 <-- Exists
kata-containers/runtime#1722 <-- Does not Apply (Missing Dependencies)
kata-containers/runtime#1724 <-- Not needed.
kata-containers/runtime#1732 <-- Vendor changes, not needed for 1.6