### PR TITLE
docs: Explain Kata Containers are Linux-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For details of the other Kata Containers repositories, see the
 (CLI) part of the Kata Containers runtime component. It leverages the
 [virtcontainers](virtcontainers)
 package to provide a high-performance standards-compliant runtime that creates
-hardware-virtualized containers.
+hardware-virtualized [Linux](https://www.kernel.org/) containers running on Linux hosts.
 
 The runtime is
 [OCI](https://github.com/opencontainers/runtime-spec)-compatible,


### PR DESCRIPTION
Update the README explaining that Kata Containers are Linux-based and run on Linux hosts.

Fixes: #1759.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>