### PR TITLE
fc-toml: remove proxy section in config

### DIFF
--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -201,8 +201,6 @@ use_vsock = true
 # Default false
 #enable_template = true
 
-[proxy.@PROJECT_TYPE@]
-
 [shim.@PROJECT_TYPE@]
 path = "@SHIMPATH@"
 


### PR DESCRIPTION
proxy will never be use with the Firecracker VMM. Keeping this header
will result in runtime failures, since the configuration will be parsed
on the path searched for.

Since vsock will always be used, remove the proxy section.

Fixes: #1761

Signed-off-by: Eric Ernst <eric.ernst@intel.com>