### PR TITLE
vc: Add some defaultQemuMachineOptions for qemu 4.0

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -26,7 +26,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken"
 
 const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
 


### PR DESCRIPTION
We need to add a few extra defaultQemuMachineOptions
for ppc64le for kata to work with  qemu 4.0 version.

Fixes: #1771

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com