### PR TITLE
factory: make vm templating work with vsock

### DIFF
--- a/cli/factory.go
+++ b/cli/factory.go
@@ -258,6 +258,8 @@ var destroyFactoryCommand = cli.Command{
 					HypervisorConfig: runtimeConfig.HypervisorConfig,
 					AgentType:        runtimeConfig.AgentType,
 					AgentConfig:      runtimeConfig.AgentConfig,
+					ProxyType:        runtimeConfig.ProxyType,
+					ProxyConfig:      runtimeConfig.ProxyConfig,
 				},
 			}
 			kataLog.WithField("factory", factoryConfig).Info("load vm factory")
@@ -314,6 +316,8 @@ var statusFactoryCommand = cli.Command{
 					HypervisorConfig: runtimeConfig.HypervisorConfig,
 					AgentType:        runtimeConfig.AgentType,
 					AgentConfig:      runtimeConfig.AgentConfig,
+					ProxyType:        runtimeConfig.ProxyType,
+					ProxyConfig:      runtimeConfig.ProxyConfig,
 				},
 			}
 			kataLog.WithField("factory", factoryConfig).Info("load vm factory")

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -1041,10 +1041,6 @@ func checkFactoryConfig(config oci.RuntimeConfig) error {
 		if config.HypervisorConfig.InitrdPath == "" {
 			return errors.New("Factory option enable_template requires an initrd image")
 		}
-
-		if config.HypervisorConfig.UseVSock {
-			return errors.New("config vsock conflicts with factory, please disable one of them")
-		}
 	}
 
 	if config.FactoryConfig.VMCacheNumber > 0 {

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -66,11 +66,9 @@ func HandleFactory(ctx context.Context, vci vc.VC, runtimeConfig *oci.RuntimeCon
 			HypervisorConfig: runtimeConfig.HypervisorConfig,
 			AgentType:        runtimeConfig.AgentType,
 			AgentConfig:      runtimeConfig.AgentConfig,
+			ProxyType:        runtimeConfig.ProxyType,
+			ProxyConfig:      runtimeConfig.ProxyConfig,
 		},
-	}
-	if runtimeConfig.FactoryConfig.VMCacheNumber > 0 {
-		factoryConfig.VMConfig.ProxyType = runtimeConfig.ProxyType
-		factoryConfig.VMConfig.ProxyConfig = runtimeConfig.ProxyConfig
 	}
 
 	kataUtilsLogger.WithField("factory", factoryConfig).Info("load vm factory")

--- a/virtcontainers/factory/factory.go
+++ b/virtcontainers/factory/factory.go
@@ -112,7 +112,6 @@ func resetHypervisorConfig(config *vc.VMConfig) {
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = ""
 	config.HypervisorConfig.DevicesStatePath = ""
-	config.ProxyType = vc.NoopProxyType
 	config.ProxyConfig = vc.ProxyConfig{}
 }
 
@@ -140,7 +139,7 @@ func checkVMConfig(config1, config2 vc.VMConfig) error {
 func (f *factory) checkConfig(config vc.VMConfig) error {
 	baseConfig := f.base.Config()
 
-	return checkVMConfig(config, baseConfig)
+	return checkVMConfig(baseConfig, config)
 }
 
 func (f *factory) validateNewVMConfig(config vc.VMConfig) error {

--- a/virtcontainers/factory/template/template.go
+++ b/virtcontainers/factory/template/template.go
@@ -23,7 +23,6 @@ type template struct {
 	config    vc.VMConfig
 }
 
-var templateProxyType = vc.KataBuiltInProxyType
 var templateWaitForAgent = 2 * time.Second
 
 // Fetch finds and returns a pre-built template factory.
@@ -120,10 +119,6 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
 	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
-	// template vm uses builtin proxy
-	if config.ProxyType != "noopProxy" {
-		config.ProxyType = templateProxyType
-	}
 
 	vm, err := vc.NewVM(ctx, config)
 	if err != nil {

--- a/virtcontainers/factory/template/template_test.go
+++ b/virtcontainers/factory/template/template_test.go
@@ -83,7 +83,6 @@ func TestTemplateFactory(t *testing.T) {
 	err = tt.createTemplateVM(ctx)
 	assert.Nil(err)
 
-	templateProxyType = vc.NoopProxyType
 	vm, err = tt.GetBaseVM(ctx, vmConfig)
 	assert.Nil(err)
 


### PR DESCRIPTION
As virtio v1.1 spec states:
The guest_cid configuration field MUST be fetched to determine the current CID when a VIRTIO_VSOCK_EVENT_TRANSPORT_RESET event is received.
Existing connections MUST be shut down when a VIRTIO_VSOCK_EVENT_TRANSPORT_RESET event is received.
Listen connections MUST remain operational with the current CID when a VIRTIO_VSOCK_EVENT_TRANSPORT_RESET event is received.

We should be able to use vm templating together with vsock easily, as
qemu already sends VIRTIO_VSOCK_EVENT_TRANSPORT_RESET event to guest.
