### PR TITLE
Disable default hugepages enabling for virtio-fs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ ifneq (,$(NEMUCMD))
 
     # nemu-specific options (all should be suffixed by "_NEMU")
     # currently, huge pages are required for virtiofsd support
-    DEFENABLEHUGEPAGES_NEMU := true
+    DEFENABLEHUGEPAGES_NEMU := false
     # nemu uses virt machine type
     DEFMACHINETYPE_NEMU := virt
     DEFBLOCKSTORAGEDRIVER_NEMU := virtio-scsi


### PR DESCRIPTION
hugepages were enbled by default on NEMU to allow use of virtio-fs. kata
now has a change where virtio-fs will default to use /dev/shm as the
shared memory file backing location. With that, we should be able to
disable default hugepages for NEMU

Fixes: #1775
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>