### PR TITLE
vc: Fix TestQemuPPC64leMemoryTopology after qemu version bump

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -121,7 +121,7 @@ func (q *qemuPPC64le) cpuModel() string {
 
 func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {
 
-	if qemuMajorVersion >= 2 && qemuMinorVersion >= 10 {
+	if (qemuMajorVersion > 2) || (qemuMajorVersion == 2 && qemuMinorVersion >= 10) {
 		q.Logger().Debug("Aligning maxmem to multiples of 256MB. Assumption: Kernel Version >= 4.11")
 		hostMemoryMb -= (hostMemoryMb % 256)
 	} else {


### PR DESCRIPTION
TestQemuPPC64leMemoryTopology fails on ppc64le
as the corect qemu version is not detected.

Fixes: #1790

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com