### PR TITLE
[cherry-pick 1.6]: katautils: fix shim v2 fail to work with libnetwork

### DIFF
--- a/pkg/katautils/hook.go
+++ b/pkg/katautils/hook.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -39,7 +38,7 @@ func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error
 		log.String("hook-args", strings.Join(hook.Args, " ")))
 
 	state := specs.State{
-		Pid:    os.Getpid(),
+		Pid:    syscall.Gettid(),
 		Bundle: bundlePath,
 		ID:     cid,
 	}


### PR DESCRIPTION
detail how kata work with libnetwork
1. kata create a new netns
2. with EnterNS, kata change netns to the created one.
3. in pre-start hook, kata will re-exec libnetwork process
libnetwork-setkey, and send self pid to it. libnetwork use
/proc/pid/ns/net to find the netns kata use, and set veth into the netns.

v1/v2 shim use the same way to create network, v1 can successful
because EnterNS changed both current thread and main thread's netns.
But use v2 shim, only changed current thread netns, main thread still
use host netns, so it fails. Looks like v1 just lucky to be successful.
In kata, `state.Pid` should be tid.

Fixes: #1788

Signed-off-by: Ace-Tang <aceapril@126.com>