### PR TITLE
shimv2: Make shimv2 in case any source files change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ GENERATED_FILES += $(CLI_DIR)/config-generated.go
 $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 	$(QUIET_BUILD)(cd $(CLI_DIR) && go build $(BUILDFLAGS) -o $@ .)
 
-$(SHIMV2_OUTPUT):
+$(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build -i -o $@ .)
 
 .PHONY: \


### PR DESCRIPTION
shimv2 binary was not being built in case of any source changes.
Add dependency of source files to the shimv2 make target to fix this.

Fixes #1805

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>