### PR TITLE
trace: Add missing log message

### DIFF
--- a/pkg/katautils/tracing.go
+++ b/pkg/katautils/tracing.go
@@ -88,5 +88,12 @@ func Trace(parent context.Context, name string) (opentracing.Span, context.Conte
 	span.SetTag("source", "runtime")
 	span.SetTag("component", "cli")
 
+	// This is slightly confusing: when tracing is disabled, trace spans
+	// are still created - but the tracer used is a NOP. Therefore, only
+	// display the message when tracing is really enabled.
+	if tracing {
+		kataUtilsLogger.Debugf("created span %v", span)
+	}
+
 	return span, ctx
 }


### PR DESCRIPTION
Add a log message for every trace span created, required by the tracing tests to validate tracing is working.

Fixes: #1814.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>