### PR TITLE
config: add an option to control memory size calculation

### DIFF
--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -65,6 +65,7 @@ default_bridges = @DEFBRIDGES@
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 default_memory = @DEFMEMSZ@
+
 #
 # Default memory slots per SB/VM.
 # If unspecified then it will be set @DEFMEMSLOTS@.
@@ -77,6 +78,9 @@ default_memory = @DEFMEMSZ@
 # should set memory_offset to the size of block device.
 # Default 0
 #memory_offset = 0
+
+# Specify whether cpu/memory used by guest is counted in container resource quota.
+#overhead_in_quota = false
 
 # Disable block device from being used for a container's rootfs.
 # In case of a storage driver like devicemapper where a container's 

--- a/cli/config/configuration-nemu.toml.in
+++ b/cli/config/configuration-nemu.toml.in
@@ -76,6 +76,7 @@ default_bridges = @DEFBRIDGES@
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 default_memory = @DEFMEMSZ@
+
 #
 # Default memory slots per SB/VM.
 # If unspecified then it will be set @DEFMEMSLOTS@.
@@ -88,6 +89,9 @@ default_memory = @DEFMEMSZ@
 # should set memory_offset to the size of block device.
 # Default 0
 #memory_offset = 0
+
+# Specify whether cpu/memory used by guest is counted in container resource quota.
+#overhead_in_quota = false
 
 # Disable block device from being used for a container's rootfs.
 # In case of a storage driver like devicemapper where a container's 

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -89,6 +89,9 @@ default_memory = @DEFMEMSZ@
 # Default 0
 #memory_offset = 0
 
+# Specify whether cpu/memory used by guest is counted in container resource quota.
+#overhead_in_quota = false
+
 # Disable block device from being used for a container's rootfs.
 # In case of a storage driver like devicemapper where a container's 
 # root file system is backed by a block device, the block device is passed

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -99,6 +99,7 @@ type hypervisor struct {
 	BlockDeviceCacheSet     bool   `toml:"block_device_cache_set"`
 	BlockDeviceCacheDirect  bool   `toml:"block_device_cache_direct"`
 	BlockDeviceCacheNoflush bool   `toml:"block_device_cache_noflush"`
+	OverheadInQuota         bool   `toml:"overhead_in_quota"`
 	NumVCPUs                int32  `toml:"default_vcpus"`
 	DefaultMaxVCPUs         uint32 `toml:"default_maxvcpus"`
 	MemorySize              uint32 `toml:"default_memory"`
@@ -487,6 +488,7 @@ func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		NumVCPUs:              h.defaultVCPUs(),
 		DefaultMaxVCPUs:       h.defaultMaxVCPUs(),
 		MemorySize:            h.defaultMemSz(),
+		OverheadInQuota:       h.OverheadInQuota,
 		MemSlots:              h.defaultMemSlots(),
 		EntropySource:         h.GetEntropySource(),
 		DefaultBridges:        h.defaultBridges(),
@@ -574,6 +576,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		NumVCPUs:                h.defaultVCPUs(),
 		DefaultMaxVCPUs:         h.defaultMaxVCPUs(),
 		MemorySize:              h.defaultMemSz(),
+		OverheadInQuota:         h.OverheadInQuota,
 		MemSlots:                h.defaultMemSlots(),
 		MemOffset:               h.defaultMemOffset(),
 		EntropySource:           h.GetEntropySource(),

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -171,6 +171,9 @@ type HypervisorConfig struct {
 	// DefaultMem specifies default memory size in MiB for the VM.
 	MemorySize uint32
 
+	// OverhaedInQuota specifies whether cpu/memory used by guest is counted in container quota.
+	OverheadInQuota bool
+
 	// DefaultBridges specifies default number of bridges for the VM.
 	// Bridges can be used to hot plug devices
 	DefaultBridges uint32


### PR DESCRIPTION
The sandbox memory overhead was not take into account when
calculating sandbox memory quota size, that cause the following
issues:

- scheduler can't get an accurate memory usage information
- memory size info in container not match user specified memory limit,
  that would confuse the user

Before the pod overhead patch[1] got merged, let's add an option
to control memory size calculation to workaround these issues.

[1]: https://github.com/kubernetes/kubernetes/pull/79247

Fixes: #1822
Signed-off-by: Li Wei <wei@hyper.sh>