### PR TITLE
empty-dir: Fix bug in the way empty-dirs are handled for overlay

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1173,7 +1173,7 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 	epheStorages := k.handleEphemeralStorage(ociSpec.Mounts)
 	ctrStorages = append(ctrStorages, epheStorages...)
 
-	localStorages := k.handleLocalStorage(ociSpec.Mounts, sandbox.id)
+	localStorages := k.handleLocalStorage(ociSpec.Mounts, sandbox.id, c.rootfsSuffix)
 	ctrStorages = append(ctrStorages, localStorages...)
 
 	// We replace all OCI mount sources that match our container mount
@@ -1285,7 +1285,7 @@ func (k *kataAgent) handleEphemeralStorage(mounts []specs.Mount) []*grpc.Storage
 
 // handleLocalStorage handles local storage within the VM
 // by creating a directory in the VM from the source of the mount point.
-func (k *kataAgent) handleLocalStorage(mounts []specs.Mount, sandboxID string) []*grpc.Storage {
+func (k *kataAgent) handleLocalStorage(mounts []specs.Mount, sandboxID string, rootfsSuffix string) []*grpc.Storage {
 	var localStorages []*grpc.Storage
 	for idx, mnt := range mounts {
 		if mnt.Type == KataLocalDevType {
@@ -1294,7 +1294,7 @@ func (k *kataAgent) handleLocalStorage(mounts []specs.Mount, sandboxID string) [
 			// We rely on the fact that the first container in the VM has the same ID as the sandbox ID.
 			// In Kubernetes, this is usually the pause container and we depend on it existing for
 			// local directories to work.
-			mounts[idx].Source = filepath.Join(kataGuestSharedDir, sandboxID, KataLocalDevType, filepath.Base(mnt.Source))
+			mounts[idx].Source = filepath.Join(kataGuestSharedDir, sandboxID, rootfsSuffix, KataLocalDevType, filepath.Base(mnt.Source))
 
 			// Create a storage struct so that the kata agent is able to create the
 			// directory inside the VM.

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -382,6 +382,30 @@ func TestHandleEphemeralStorage(t *testing.T) {
 		"Ephemeral mount point didn't match: got %s, expecting %s", epheMountPoint, expected)
 }
 
+func TestHandleLocalStorage(t *testing.T) {
+	k := kataAgent{}
+	var ociMounts []specs.Mount
+	mountSource := "mountPoint"
+
+	mount := specs.Mount{
+		Type:   KataLocalDevType,
+		Source: mountSource,
+	}
+
+	sandboxID := "sandboxid"
+	rootfsSuffix := "rootfs"
+
+	ociMounts = append(ociMounts, mount)
+	localStorages := k.handleLocalStorage(ociMounts, sandboxID, rootfsSuffix)
+
+	assert.NotNil(t, localStorages)
+	assert.Equal(t, len(localStorages), 1)
+
+	localMountPoint := localStorages[0].GetMountPoint()
+	expected := filepath.Join(kataGuestSharedDir, sandboxID, rootfsSuffix, KataLocalDevType, filepath.Base(mountSource))
+	assert.Equal(t, localMountPoint, expected)
+}
+
 func TestAppendDevicesEmptyContainerDeviceList(t *testing.T) {
 	k := kataAgent{}
 


### PR DESCRIPTION
With #1485, we moved the default medium empty-dir creation to the
sandbox rootfs. This worked for devicemapper, but in case of overlay
the "local" directory was being created outside the sandbox rootfs.
As a result we were seeing the behaviour seen in #1818.

Fixes #1818

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>