### PR TITLE
cli: update paths to be configurable for rootless execution

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 
 	"github.com/kata-containers/runtime/pkg/katautils"
+	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/pkg/signals"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vf "github.com/kata-containers/runtime/virtcontainers/factory"
@@ -302,6 +303,12 @@ func beforeSubcommands(c *cli.Context) error {
 	if c.NArg() == 1 && c.Args()[0] == envCmd {
 		// simply report the logging setup
 		ignoreLogging = true
+	}
+
+	// Check if running rootlessly, and setup for rootless execution
+	err = rootless.SetRootless()
+	if err != nil {
+		fatal(err)
 	}
 
 	configFile, runtimeConfig, err = katautils.LoadConfiguration(c.GlobalString(configFilePathOption), ignoreLogging, false)

--- a/pkg/katautils/oci.go
+++ b/pkg/katautils/oci.go
@@ -11,6 +11,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/kata-containers/runtime/pkg/rootless"
 )
 
 const ctrsMappingDirMode = os.FileMode(0750)
@@ -29,6 +31,10 @@ func SetCtrsMapTreePath(path string) {
 func FetchContainerIDMapping(containerID string) (string, error) {
 	if containerID == "" {
 		return "", fmt.Errorf("Missing container ID")
+	}
+
+	if rootless.IsRootless() {
+		SetCtrsMapTreePath(filepath.Join(rootless.GetRootlessDir(), ctrsMapTreePath))
 	}
 
 	dirPath := filepath.Join(ctrsMapTreePath, containerID)
@@ -62,6 +68,9 @@ func AddContainerIDMapping(ctx context.Context, containerID, sandboxID string) e
 		return fmt.Errorf("Missing sandbox ID")
 	}
 
+	if rootless.IsRootless() {
+		SetCtrsMapTreePath(filepath.Join(rootless.GetRootlessDir(), ctrsMapTreePath))
+	}
 	parentPath := filepath.Join(ctrsMapTreePath, containerID)
 
 	if err := os.RemoveAll(parentPath); err != nil {
@@ -86,6 +95,9 @@ func DelContainerIDMapping(ctx context.Context, containerID string) error {
 		return fmt.Errorf("Missing container ID")
 	}
 
+	if rootless.IsRootless() {
+		SetCtrsMapTreePath(filepath.Join(rootless.GetRootlessDir(), ctrsMapTreePath))
+	}
 	path := filepath.Join(ctrsMapTreePath, containerID)
 
 	return os.RemoveAll(path)

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -1,0 +1,112 @@
+package rootless
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var (
+	isRootless  bool
+	hostUID     int
+	rootlessDir string
+)
+
+// userMapping reads the map_uid file from proc and returns true if the
+// root container ID is mapped to a non root user ID.
+func userMapping() (bool, int, error) {
+	file, err := os.Open("/proc/self/uid_map")
+	if err != nil {
+		return false, 0, err
+	}
+	defer file.Close()
+
+	buf := bufio.NewReader(file)
+	for {
+		line, _, err := buf.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				return false, 0, nil
+			}
+			return false, 0, err
+		}
+		if line == nil {
+			return false, 0, nil
+		}
+
+		// if the container id (id[0]) is 0 (root inside the container)
+		// has a mapping to the host id (id[1]) that is not root, then
+		// it can be determined that the host user is running rootless
+		ids := strings.Fields(string(line))
+		if ids[0] == "0" && ids[1] != "0" {
+			uid, _ := strconv.Atoi(ids[1])
+			return true, uid, nil
+		}
+	}
+}
+
+func setupDir(path string) error {
+	var err error
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		return os.MkdirAll(path, 0700)
+	}
+	return err
+}
+
+// setRootlessDir prepares the directory for rootless storage
+// use homedirPath as the default location for rootless execution, however
+// if unable to access or create directory fallback to the userpath.
+func setRootlessDir() error {
+	// TODO homedirpath doesn't work.
+	//homedirPath := "~/.local/kata-rootless"
+	//if err := setupDir(homedirPath); err == nil {
+	//	rootlessDir = homedirPath
+	//	return nil
+	//}
+
+	userPath := fmt.Sprintf("/run/user/%d", hostUID)
+	if err := setupDir(userPath); err != nil {
+		return fmt.Errorf("unable to set rootless dir: %v", err)
+	}
+
+	rootlessDir = userPath
+	return nil
+}
+
+// SetRootless sets the isRootless variable depending on uid_mappings
+// This should only be called once at the beginning of kata call
+func SetRootless() error {
+	mappings, uid, err := userMapping()
+	if err != nil {
+		return err
+	}
+
+	// don't update isRootless or hostUID  until after mapping error handling
+	isRootless = mappings
+	hostUID = uid
+
+	if !isRootless {
+		return nil
+	}
+
+	return setRootlessDir()
+}
+
+// IsRootless states whether kata is being ran with root or not
+func IsRootless() bool {
+	return isRootless
+}
+
+// GetRootlessDir returns the path to the location for rootless
+// container and sandbox storage
+func GetRootlessDir() string {
+	return rootlessDir
+}
+
+// GetRootlessUID returns the UID of the user in the parent userNS
+func GetRootlessUID() int {
+	return hostUID
+}

--- a/pkg/rootless/rootless_test.go
+++ b/pkg/rootless/rootless_test.go
@@ -1,0 +1,3 @@
+package rootless
+
+// TODO

--- a/virtcontainers/store/vc.go
+++ b/virtcontainers/store/vc.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
@@ -233,13 +234,22 @@ func (s *VCStore) Unlock(token string) error {
 // SandboxConfigurationRoot returns a virtcontainers sandbox configuration root URL.
 // This will hold across host reboot persistent data about a sandbox configuration.
 // It should look like file:///var/lib/vc/sbs/<sandboxID>/
+// Or for rootless: file://<rootlessDir>/var/lib/vc/sbs/<sandboxID>/
 func SandboxConfigurationRoot(id string) string {
-	return filesystemScheme + "://" + filepath.Join(ConfigStoragePath, id)
+	path := filepath.Join(ConfigStoragePath, id)
+	if rootless.IsRootless() {
+		return filesystemScheme + "://" + filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return filesystemScheme + "://" + path
 }
 
 // SandboxConfigurationRootPath returns a virtcontainers sandbox configuration root path.
 func SandboxConfigurationRootPath(id string) string {
-	return filepath.Join(ConfigStoragePath, id)
+	path := filepath.Join(ConfigStoragePath, id)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
 }
 
 // SandboxConfigurationItemPath returns a virtcontainers sandbox configuration item path.
@@ -253,6 +263,9 @@ func SandboxConfigurationItemPath(id string, item Item) (string, error) {
 		return "", err
 	}
 
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), ConfigStoragePath, id, itemFile), nil
+	}
 	return filepath.Join(ConfigStoragePath, id, itemFile), nil
 }
 
@@ -260,13 +273,23 @@ func SandboxConfigurationItemPath(id string, item Item) (string, error) {
 // This will hold data related to a sandbox run-time state that will not
 // be persistent across host reboots.
 // It should look like file:///run/vc/sbs/<sandboxID>/
+// or if rootless: file://<rootlessDir>/run/vc/sbs/<sandboxID>/
 func SandboxRuntimeRoot(id string) string {
-	return filesystemScheme + "://" + filepath.Join(RunStoragePath, id)
+	path := filepath.Join(RunStoragePath, id)
+	if rootless.IsRootless() {
+		return filesystemScheme + "://" + filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return filesystemScheme + "://" + path
 }
 
 // SandboxRuntimeRootPath returns a virtcontainers sandbox runtime root path.
 func SandboxRuntimeRootPath(id string) string {
-	return filepath.Join(RunStoragePath, id)
+	path := filepath.Join(RunStoragePath, id)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
+
 }
 
 // SandboxRuntimeItemPath returns a virtcontainers sandbox runtime item path.
@@ -286,26 +309,44 @@ func SandboxRuntimeItemPath(id string, item Item) (string, error) {
 // ContainerConfigurationRoot returns a virtcontainers container configuration root URL.
 // This will hold across host reboot persistent data about a container configuration.
 // It should look like file:///var/lib/vc/sbs/<sandboxID>/<containerID>
+// Or if rootless file://<rootlessDir>/var/lib/vc/sbs/<sandboxID>/<containerID>
 func ContainerConfigurationRoot(sandboxID, containerID string) string {
-	return filesystemScheme + "://" + filepath.Join(ConfigStoragePath, sandboxID, containerID)
+	path := filepath.Join(ConfigStoragePath, sandboxID, containerID)
+	if rootless.IsRootless() {
+		return filesystemScheme + "://" + filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return filesystemScheme + "://" + path
 }
 
 // ContainerConfigurationRootPath returns a virtcontainers container configuration root path.
 func ContainerConfigurationRootPath(sandboxID, containerID string) string {
-	return filepath.Join(ConfigStoragePath, sandboxID, containerID)
+	path := filepath.Join(ConfigStoragePath, sandboxID, containerID)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
 }
 
 // ContainerRuntimeRoot returns a virtcontainers container runtime root URL.
 // This will hold data related to a container run-time state that will not
 // be persistent across host reboots.
 // It should look like file:///run/vc/sbs/<sandboxID>/<containerID>/
+// Or for rootless file://<rootlessDir>/run/vc/sbs/<sandboxID>/<containerID>/
 func ContainerRuntimeRoot(sandboxID, containerID string) string {
-	return filesystemScheme + "://" + filepath.Join(RunStoragePath, sandboxID, containerID)
+	path := filepath.Join(RunStoragePath, sandboxID, containerID)
+	if rootless.IsRootless() {
+		return filesystemScheme + "://" + filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return filesystemScheme + "://" + path
 }
 
 // ContainerRuntimeRootPath returns a virtcontainers container runtime root path.
 func ContainerRuntimeRootPath(sandboxID, containerID string) string {
-	return filepath.Join(RunStoragePath, sandboxID, containerID)
+	path := filepath.Join(RunStoragePath, sandboxID, containerID)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
 }
 
 // VCSandboxStoreExists returns true if a sandbox store already exists.


### PR DESCRIPTION
Before using the default ctrsMapTrePath, check whether the runtime
is being ran rootlessly, and if so set the ctrsMapTreePath to the
rootlessRuntimeDir configured by the libpod rootless library.

Fixes: #1358

Signed-off-by: Gabi Beyer <gabrielle.n.beyer@intel.com>