### PR TITLE
api: add a CleanupContainer api for VC

### DIFF
--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -23,7 +23,7 @@ func deleteContainer(ctx context.Context, s *service, c *container) error {
 			return err
 		}
 		if status.State.State != types.StateStopped {
-			_, err = s.sandbox.StopContainer(c.id)
+			_, err = s.sandbox.StopContainer(c.id, false)
 			if err != nil {
 				return err
 			}

--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -65,7 +65,7 @@ func wait(s *service, c *container, execID string) (int32, error) {
 				logrus.WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
 			}
 		} else {
-			if _, err = s.sandbox.StopContainer(c.id); err != nil {
+			if _, err = s.sandbox.StopContainer(c.id, false); err != nil {
 				logrus.WithError(err).WithField("container", c.id).Warn("stop container failed")
 			}
 		}

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -176,3 +176,10 @@ func (impl *VCImpl) UpdateRoutes(ctx context.Context, sandboxID string, routes [
 func (impl *VCImpl) ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error) {
 	return ListRoutes(ctx, sandboxID)
 }
+
+// CleanupContaienr is used by shimv2 to stop and delete a container exclusively, once there is no container
+// in the sandbox left, do stop the sandbox and delete it. Those serial operations will be done exclusively by
+// locking the sandbox.
+func (impl *VCImpl) CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
+	return CleanupContainer(ctx, sandboxID, containerID, force)
+}

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -54,6 +54,8 @@ type VC interface {
 	ListInterfaces(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error)
 	UpdateRoutes(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error)
 	ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error)
+
+	CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error
 }
 
 // VCSandbox is the Sandbox interface
@@ -78,7 +80,7 @@ type VCSandbox interface {
 	CreateContainer(contConfig ContainerConfig) (VCContainer, error)
 	DeleteContainer(contID string) (VCContainer, error)
 	StartContainer(containerID string) (VCContainer, error)
-	StopContainer(containerID string) (VCContainer, error)
+	StopContainer(containerID string, force bool) (VCContainer, error)
 	KillContainer(containerID string, signal syscall.Signal, all bool) error
 	StatusContainer(containerID string) (ContainerStatus, error)
 	StatsContainer(containerID string) (ContainerStats, error)

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -298,3 +298,10 @@ func (m *VCMock) ListRoutes(ctx context.Context, sandboxID string) ([]*vcTypes.R
 
 	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
+
+func (m *VCMock) CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
+	if m.CleanupContainerFunc != nil {
+		return m.CleanupContainerFunc(ctx, sandboxID, containerID, true)
+	}
+	return fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
+}

--- a/virtcontainers/pkg/vcmock/sandbox.go
+++ b/virtcontainers/pkg/vcmock/sandbox.go
@@ -109,7 +109,7 @@ func (s *Sandbox) StartContainer(contID string) (vc.VCContainer, error) {
 }
 
 // StopContainer implements the VCSandbox function of the same name.
-func (s *Sandbox) StopContainer(contID string) (vc.VCContainer, error) {
+func (s *Sandbox) StopContainer(contID string, force bool) (vc.VCContainer, error) {
 	return &Container{}, nil
 }
 

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -70,9 +70,10 @@ type VCMock struct {
 
 	AddDeviceFunc func(ctx context.Context, sandboxID string, info config.DeviceInfo) (api.Device, error)
 
-	AddInterfaceFunc    func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
-	RemoveInterfaceFunc func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
-	ListInterfacesFunc  func(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error)
-	UpdateRoutesFunc    func(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error)
-	ListRoutesFunc      func(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error)
+	AddInterfaceFunc     func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	RemoveInterfaceFunc  func(ctx context.Context, sandboxID string, inf *vcTypes.Interface) (*vcTypes.Interface, error)
+	ListInterfacesFunc   func(ctx context.Context, sandboxID string) ([]*vcTypes.Interface, error)
+	UpdateRoutesFunc     func(ctx context.Context, sandboxID string, routes []*vcTypes.Route) ([]*vcTypes.Route, error)
+	ListRoutesFunc       func(ctx context.Context, sandboxID string) ([]*vcTypes.Route, error)
+	CleanupContainerFunc func(ctx context.Context, sandboxID, containerID string, force bool) error
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1181,7 +1181,7 @@ func (s *Sandbox) StartContainer(containerID string) (VCContainer, error) {
 }
 
 // StopContainer stops a container in the sandbox
-func (s *Sandbox) StopContainer(containerID string) (VCContainer, error) {
+func (s *Sandbox) StopContainer(containerID string, force bool) (VCContainer, error) {
 	// Fetch the container.
 	c, err := s.findContainer(containerID)
 	if err != nil {
@@ -1189,7 +1189,7 @@ func (s *Sandbox) StopContainer(containerID string) (VCContainer, error) {
 	}
 
 	// Stop it.
-	if err := c.stop(false); err != nil {
+	if err := c.stop(force); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
When shimv2 was killed by accident, containerd would try to
launch a new shimv2 binarry to cleanup the container. In order
to avoid race condition, the cleanup should be done serialized
in a sandbox. Thus adding a new api to do this by locking the
sandbox.

Fixes:kata-containers#1832

Signed-off-by: lifupan <lifupan@gmail.com>