### PR TITLE
vc/readme: fix cri url

### DIFF
--- a/virtcontainers/README.md
+++ b/virtcontainers/README.md
@@ -43,7 +43,7 @@ or the [Kubernetes CRI][cri]) to the `virtcontainers` API.
 `virtcontainers` was used as a foundational package for the [Clear Containers][cc] [runtime][cc-runtime] implementation.
 
 [oci]: https://github.com/opencontainers/runtime-spec
-[cri]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md
+[cri]: https://git.k8s.io/community/contributors/devel/sig-node/container-runtime-interface.md
 [cc]: https://github.com/clearcontainers/
 [cc-runtime]: https://github.com/clearcontainers/runtime/
 


### PR DESCRIPTION
The old one was invalidated since 2019-07-01.

Fixes: #1847