### PR TITLE
ci: Verify and block merge if other projects are not updated

### DIFF
--- a/.ci/versions_checker.sh
+++ b/.ci/versions_checker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The purpose of this script is to
+# run the tag_repos.sh script that is in the
+# packaging repository which checks the VERSION
+# file from the components in order to verify
+# that the VERSION matches between them.
+# This ensures that the rest
+# of the components are merged before the runtime
+
+set -e
+
+GOPATH=${GOPATH:-${HOME}/go}
+
+PACKAGING_REPO="github.com/kata-containers/packaging"
+RUNTIME_REPO="github.com/kata-containers/runtime"
+
+go get -d "${PACKAGING_REPO}" || true
+
+check_changes=$(git diff "${GOPATH}/src/${RUNTIME_REPO}/VERSION")
+version_to_check=$(cat "${GOPATH}/src/${RUNTIME_REPO}/VERSION")
+
+if [ ! -z "$check_changes" ]; then
+	pushd "${GOPATH}/src/${PACKAGING_REPO}"
+	./release/tag_repos.sh pre-release "${version_to_check}" 
+	popd
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 
 before_script:
   - ".ci/static-checks.sh"
+  - ".ci/versions_checker.sh"
 
 install:
   - cd ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
This will take the VERSION of all the components in order to
verify that they match among them before merging the runtime.

Fixes #1581

Depends-on: github.com/kata-containers/packaging#614

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>