### PR TITLE
Fix fork exec test errors

### DIFF
--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -280,22 +280,33 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 }
 
 func TestQemuAddDeviceKataVSOCK(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	vsockFilename := filepath.Join(dir, "vsock")
+
 	contextID := uint64(3)
 	port := uint32(1024)
-	vHostFD := os.NewFile(1, "vsock")
+
+	vsockFile, err := os.Create(vsockFilename)
+	assert.NoError(err)
+	defer vsockFile.Close()
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.VSOCKDevice{
 			ID:        fmt.Sprintf("vsock-%d", contextID),
 			ContextID: contextID,
-			VHostFD:   vHostFD,
+			VHostFD:   vsockFile,
 		},
 	}
 
 	vsock := kataVSOCK{
 		contextID: contextID,
 		port:      port,
-		vhostFd:   vHostFD,
+		vhostFd:   vsockFile,
 	}
 
 	testQemuAddDevice(t, vsock, vSockPCIDev, expectedOut)

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1530,6 +1530,10 @@ func TestSandboxCreationFromConfigRollbackFromCreateSandbox(t *testing.T) {
 		Volumes:          nil,
 		Containers:       nil,
 	}
+
+	// Ensure hypervisor doesn't exist
+	assert.NoError(os.Remove(hConf.HypervisorPath))
+
 	_, err := createSandboxFromConfig(ctx, sConf, nil)
 	// Fail at createSandbox: QEMU path does not exist, it is expected. Then rollback is called
 	assert.Error(err)


### PR DESCRIPTION
Fixed `TestSandboxCreationFromConfigRollbackFromCreateSandbox` which requires that the hypervisor does not exist. Unfortunately, it does exist (as a fake test binary), but isn't executable meaning although the test failed (since an error is expected), rather than the expected `ENOENT` error, the test was logging a message similar to the following since the fake hypervisor exists with non-executable permissions:

```
Unable to launch /tmp/vc-tmp-526112270/hypervisor: fork/exec /tmp/vc-tmp-526112270/hypervisor: permission denied
```

Update the `TestQemuAddDeviceKataVSOCK` test so that it:

- Doesn't hard-code the file descriptor number.
- Cleans up after itself.

The latter issue was causing an odd error similar to the following in the test output:

```
Unable to launch /tmp/vc-tmp-526112270/hypervisor: fork/exec /tmp/vc-tmp-526112270/hypervisor: permission denied
```

Fixes: #1835.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
