### PR TITLE
versions: Upgrade to k8s 1.15

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -188,7 +188,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.14.6"
+    version: "v1.15.0"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2
@@ -198,7 +198,7 @@ externals:
       Containerd Plugin for Kubernetes Container Runtime Interface.
     url: "github.com/containerd/cri"
     tarball_url: "https://storage.googleapis.com/cri-containerd-release"
-    version: "1.2.6"
+    version: "1.2.7"
 
   docker:
     description: "Moby project container manager"
@@ -229,7 +229,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.14.1-00"
+    version: "1.15.1-00"
 
   openshift:
     description: |


### PR DESCRIPTION
Bump CI to kubernetes 1.15.

Fixes: #1860

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>