### PR TITLE
runtime: Enable file based backend

### DIFF
--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -165,6 +165,12 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # result in memory pre allocation
 #enable_hugepages = true
 
+# Enable file based guest memory support. The default is an empty string which
+# will disable this feature. In the case of virtio-fs, this is enabled
+# automatically and '/dev/shm' is used as the backing folder.
+# This option will be ignored if VM templating is enabled.
+#file_mem_backend = ""
+
 # Enable swap of vm memory. Default false.
 # The behaviour is undefined if mem_prealloc is also set to true
 #enable_swap = true

--- a/pkg/katautils/config-settings.go
+++ b/pkg/katautils/config-settings.go
@@ -35,6 +35,7 @@ const defaultBlockDeviceCacheNoflush bool = false
 const defaultEnableIOThreads bool = false
 const defaultEnableMemPrealloc bool = false
 const defaultEnableHugePages bool = false
+const defaultFileBackedMemRootDir string = ""
 const defaultEnableSwap bool = false
 const defaultEnableDebug bool = false
 const defaultDisableNestingChecks bool = false

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -109,6 +109,7 @@ type hypervisor struct {
 	DisableBlockDeviceUse   bool   `toml:"disable_block_device_use"`
 	MemPrealloc             bool   `toml:"enable_mem_prealloc"`
 	HugePages               bool   `toml:"enable_hugepages"`
+	FileBackedMemRootDir    string `toml:"file_mem_backend"`
 	Swap                    bool   `toml:"enable_swap"`
 	Debug                   bool   `toml:"enable_debug"`
 	DisableNestingChecks    bool   `toml:"disable_nesting_checks"`
@@ -584,6 +585,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		VirtioFSCache:           h.VirtioFSCache,
 		MemPrealloc:             h.MemPrealloc,
 		HugePages:               h.HugePages,
+		FileBackedMemRootDir:    h.FileBackedMemRootDir,
 		Mlock:                   !h.Swap,
 		Debug:                   h.Debug,
 		DisableNestingChecks:    h.DisableNestingChecks,
@@ -850,6 +852,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		DefaultBridges:          defaultBridgesCount,
 		MemPrealloc:             defaultEnableMemPrealloc,
 		HugePages:               defaultEnableHugePages,
+		FileBackedMemRootDir:    defaultFileBackedMemRootDir,
 		Mlock:                   !defaultEnableSwap,
 		Debug:                   defaultEnableDebug,
 		DisableNestingChecks:    defaultDisableNestingChecks,

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -263,6 +263,9 @@ type HypervisorConfig struct {
 	// HugePages specifies if the memory should be pre-allocated from huge pages
 	HugePages bool
 
+	// File based memory backend root directory
+	FileBackedMemRootDir string
+
 	// Realtime Used to enable/disable realtime
 	Realtime bool
 

--- a/virtcontainers/persist/api/config.go
+++ b/virtcontainers/persist/api/config.go
@@ -121,6 +121,9 @@ type HypervisorConfig struct {
 	// HugePages specifies if the memory should be pre-allocated from huge pages
 	HugePages bool
 
+	// File based memory backend root directory
+	FileBackedMemRootDir string
+
 	// Realtime Used to enable/disable realtime
 	Realtime bool
 


### PR DESCRIPTION
A file based memory backend mapped to the host, fot eg: '/dev/shm' will
be used by virtio-fs for performance reasons. This change is a generic
implementation of that for kata. This will be enabled default for
virtio-fs negating the need to enable hugepages in that scenario. This
option can be used without virtio-fs by setting 'file_mem_backend' to
the location in the configuration file. Default value is an empty
string.

Fixes: #1656
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>
(cherry picked from commit a41894da18310b9c14dd59da1e924f4938271d4f)