### PR TITLE
versions: add crictl version which is compatible with OpenShift

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -191,6 +191,7 @@ externals:
     version: "v1.14.6"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
+      crictl: 1.0.0-beta.2
 
   cri-containerd:
     description: |


### PR DESCRIPTION
This PR relates to https://github.com/kata-containers/tests/pull/1778

Fixes #1872