### PR TITLE
virtcontainers: convert virtcontainers tests to testify/assert

### DIFF
--- a/virtcontainers/agent_test.go
+++ b/virtcontainers/agent_test.go
@@ -6,21 +6,18 @@
 package virtcontainers
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testSetAgentType(t *testing.T, value string, expected AgentType) {
 	var agentType AgentType
+	assert := assert.New(t)
 
 	err := (&agentType).Set(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if agentType != expected {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
+	assert.Equal(agentType, expected)
 }
 
 func TestSetNoopAgentType(t *testing.T) {
@@ -33,22 +30,16 @@ func TestSetKataAgentType(t *testing.T) {
 
 func TestSetUnknownAgentType(t *testing.T) {
 	var agentType AgentType
+	assert := assert.New(t)
 
 	err := (&agentType).Set("unknown")
-	if err == nil {
-		t.Fatal()
-	}
-
-	if agentType == NoopAgentType {
-		t.Fatal()
-	}
+	assert.Error(err)
+	assert.NotEqual(agentType, NoopAgentType)
 }
 
 func testStringFromAgentType(t *testing.T, agentType AgentType, expected string) {
 	agentTypeStr := (&agentType).String()
-	if agentTypeStr != expected {
-		t.Fatal()
-	}
+	assert.Equal(t, agentTypeStr, expected)
 }
 
 func TestStringFromNoopAgentType(t *testing.T) {
@@ -66,10 +57,7 @@ func TestStringFromUnknownAgentType(t *testing.T) {
 
 func testNewAgentFromAgentType(t *testing.T, agentType AgentType, expected agent) {
 	ag := newAgent(agentType)
-
-	if reflect.DeepEqual(ag, expected) == false {
-		t.Fatal()
-	}
+	assert.Exactly(t, ag, expected)
 }
 
 func TestNewAgentFromNoopAgentType(t *testing.T) {
@@ -87,14 +75,8 @@ func TestNewAgentFromUnknownAgentType(t *testing.T) {
 
 func testNewAgentConfig(t *testing.T, config SandboxConfig, expected interface{}) {
 	agentConfig, err := newAgentConfig(config.AgentType, config.AgentConfig)
-	if err != nil {
-		t.Fatal(err)
-
-	}
-
-	if reflect.DeepEqual(agentConfig, expected) == false {
-		t.Fatal()
-	}
+	assert.NoError(t, err)
+	assert.Exactly(t, agentConfig, expected)
 }
 
 func TestNewAgentConfigFromNoopAgentType(t *testing.T) {

--- a/virtcontainers/bridgedmacvlan_endpoint_test.go
+++ b/virtcontainers/bridgedmacvlan_endpoint_test.go
@@ -7,8 +7,9 @@ package virtcontainers
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateBridgedMacvlanEndpoint(t *testing.T) {
@@ -33,9 +34,7 @@ func TestCreateBridgedMacvlanEndpoint(t *testing.T) {
 	}
 
 	result, err := createBridgedMacvlanNetworkEndpoint(4, "", DefaultNetInterworkingModel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-4"
@@ -43,7 +42,5 @@ func TestCreateBridgedMacvlanEndpoint(t *testing.T) {
 	// the resulting mac address will be random - so lets overwrite it
 	result.NetPair.VirtIface.HardAddr = macAddr.String()
 
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
-	}
+	assert.Exactly(t, result, expected)
 }

--- a/virtcontainers/endpoint_test.go
+++ b/virtcontainers/endpoint_test.go
@@ -5,19 +5,18 @@
 
 package virtcontainers
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func testEndpointTypeSet(t *testing.T, value string, expected EndpointType) {
 	var endpointType EndpointType
 
 	err := endpointType.Set(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if endpointType != expected {
-		t.Fatal()
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, endpointType, expected)
 }
 
 func TestPhysicalEndpointTypeSet(t *testing.T) {
@@ -43,18 +42,12 @@ func TestMacvtapEndpointTypeSet(t *testing.T) {
 func TestEndpointTypeSetFailure(t *testing.T) {
 	var endpointType EndpointType
 
-	err := endpointType.Set("wrong-value")
-	if err == nil {
-		t.Fatal(err)
-	}
+	assert.Error(t, endpointType.Set("wrong-value"))
 }
 
 func testEndpointTypeString(t *testing.T, endpointType *EndpointType, expected string) {
 	result := endpointType.String()
-
-	if result != expected {
-		t.Fatal()
-	}
+	assert.Equal(t, result, expected)
 }
 
 func TestPhysicalEndpointTypeString(t *testing.T) {

--- a/virtcontainers/hypervisor_amd64_test.go
+++ b/virtcontainers/hypervisor_amd64_test.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var dataFlagsFieldWithoutHypervisor = []byte(`
@@ -69,16 +71,12 @@ func TestRunningOnVMM(t *testing.T) {
 
 func TestRunningOnVMMNotExistingCPUInfoPathFailure(t *testing.T) {
 	f, err := ioutil.TempFile("", "cpuinfo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	filePath := f.Name()
 
 	f.Close()
 	os.Remove(filePath)
-
-	if _, err := RunningOnVMM(filePath); err == nil {
-		t.Fatalf("Should fail because %q file path does not exist", filePath)
-	}
+	_, err = RunningOnVMM(filePath)
+	assert.Error(t, err)
 }

--- a/virtcontainers/hypervisor_arm64_test.go
+++ b/virtcontainers/hypervisor_arm64_test.go
@@ -18,9 +18,7 @@ func TestRunningOnVMM(t *testing.T) {
 	expectedOutput := false
 
 	f, err := ioutil.TempFile("", "cpuinfo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.Remove(f.Name())
 	defer f.Close()
 

--- a/virtcontainers/hypervisor_test.go
+++ b/virtcontainers/hypervisor_test.go
@@ -10,21 +10,18 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testSetHypervisorType(t *testing.T, value string, expected HypervisorType) {
 	var hypervisorType HypervisorType
+	assert := assert.New(t)
 
 	err := (&hypervisorType).Set(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if hypervisorType != expected {
-		t.Fatal()
-	}
+	assert.NoError(err)
+	assert.Equal(hypervisorType, expected)
 }
 
 func TestSetQemuHypervisorType(t *testing.T) {
@@ -37,23 +34,18 @@ func TestSetMockHypervisorType(t *testing.T) {
 
 func TestSetUnknownHypervisorType(t *testing.T) {
 	var hypervisorType HypervisorType
+	assert := assert.New(t)
 
 	err := (&hypervisorType).Set("unknown")
-	if err == nil {
-		t.Fatal()
-	}
-
-	if hypervisorType == QemuHypervisor ||
-		hypervisorType == MockHypervisor {
-		t.Fatal()
-	}
+	assert.Error(err)
+	assert.NotEqual(hypervisorType, QemuHypervisor)
+	assert.NotEqual(hypervisorType, MockHypervisor)
 }
 
 func testStringFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected string) {
 	hypervisorTypeStr := (&hypervisorType).String()
-	if hypervisorTypeStr != expected {
-		t.Fatal()
-	}
+	assert := assert.New(t)
+	assert.Equal(hypervisorTypeStr, expected)
 }
 
 func TestStringFromQemuHypervisorType(t *testing.T) {
@@ -72,14 +64,10 @@ func TestStringFromUnknownHypervisorType(t *testing.T) {
 }
 
 func testNewHypervisorFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected hypervisor) {
+	assert := assert.New(t)
 	hy, err := newHypervisor(hypervisorType)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if reflect.DeepEqual(hy, expected) == false {
-		t.Fatal()
-	}
+	assert.NoError(err)
+	assert.Exactly(hy, expected)
 }
 
 func TestNewHypervisorFromQemuHypervisorType(t *testing.T) {
@@ -96,25 +84,18 @@ func TestNewHypervisorFromMockHypervisorType(t *testing.T) {
 
 func TestNewHypervisorFromUnknownHypervisorType(t *testing.T) {
 	var hypervisorType HypervisorType
+	assert := assert.New(t)
 
 	hy, err := newHypervisor(hypervisorType)
-	if err == nil {
-		t.Fatal()
-	}
-
-	if hy != nil {
-		t.Fatal()
-	}
+	assert.Error(err)
+	assert.Nil(hy)
 }
 
 func testHypervisorConfigValid(t *testing.T, hypervisorConfig *HypervisorConfig, success bool) {
 	err := hypervisorConfig.valid()
-	if success && err != nil {
-		t.Fatal()
-	}
-	if !success && err == nil {
-		t.Fatal()
-	}
+	assert := assert.New(t)
+	assert.False(success && err != nil)
+	assert.False(!success && err == nil)
 }
 
 func TestHypervisorConfigNoKernelPath(t *testing.T) {
@@ -182,6 +163,7 @@ func TestHypervisorConfigValidTemplateConfig(t *testing.T) {
 }
 
 func TestHypervisorConfigDefaults(t *testing.T) {
+	assert := assert.New(t)
 	hypervisorConfig := &HypervisorConfig{
 		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
 		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
@@ -201,12 +183,11 @@ func TestHypervisorConfigDefaults(t *testing.T) {
 		Msize9p:           defaultMsize9p,
 	}
 
-	if reflect.DeepEqual(hypervisorConfig, hypervisorConfigDefaultsExpected) == false {
-		t.Fatal()
-	}
+	assert.Exactly(hypervisorConfig, hypervisorConfigDefaultsExpected)
 }
 
 func TestAppendParams(t *testing.T) {
+	assert := assert.New(t)
 	paramList := []Param{
 		{
 			Key:   "param1",
@@ -226,16 +207,13 @@ func TestAppendParams(t *testing.T) {
 	}
 
 	paramList = appendParam(paramList, "param2", "value2")
-	if reflect.DeepEqual(paramList, expectedParams) == false {
-		t.Fatal()
-	}
+	assert.Exactly(paramList, expectedParams)
 }
 
 func testSerializeParams(t *testing.T, params []Param, delim string, expected []string) {
+	assert := assert.New(t)
 	result := SerializeParams(params, delim)
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatal()
-	}
+	assert.Exactly(result, expected)
 }
 
 func TestSerializeParamsNoParamNoValue(t *testing.T) {
@@ -301,10 +279,9 @@ func TestSerializeParams(t *testing.T) {
 }
 
 func testDeserializeParams(t *testing.T, parameters []string, expected []Param) {
+	assert := assert.New(t)
 	result := DeserializeParams(parameters)
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatal()
-	}
+	assert.Exactly(result, expected)
 }
 
 func TestDeserializeParamsNil(t *testing.T) {
@@ -354,32 +331,31 @@ func TestDeserializeParams(t *testing.T) {
 
 func TestAddKernelParamValid(t *testing.T) {
 	var config HypervisorConfig
+	assert := assert.New(t)
 
 	expected := []Param{
 		{"foo", "bar"},
 	}
 
 	err := config.AddKernelParam(expected[0])
-	if err != nil || reflect.DeepEqual(config.KernelParams, expected) == false {
-		t.Fatal()
-	}
+	assert.NoError(err)
+	assert.Exactly(config.KernelParams, expected)
 }
 
 func TestAddKernelParamInvalid(t *testing.T) {
 	var config HypervisorConfig
+	assert := assert.New(t)
 
 	invalid := []Param{
 		{"", "bar"},
 	}
 
 	err := config.AddKernelParam(invalid[0])
-	if err == nil {
-		t.Fatal()
-	}
+	assert.Error(err)
 }
 
 func TestGetHostMemorySizeKb(t *testing.T) {
-
+	assert := assert.New(t)
 	type testData struct {
 		contents       string
 		expectedResult int
@@ -409,31 +385,23 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 	}
 
 	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "meminfo")
-	if _, err := getHostMemorySizeKb(file); err == nil {
-		t.Fatalf("expected failure as file %q does not exist", file)
-	}
+	_, err = getHostMemorySizeKb(file)
+	assert.Error(err)
 
 	for _, d := range data {
-		if err := ioutil.WriteFile(file, []byte(d.contents), os.FileMode(0640)); err != nil {
-			t.Fatal(err)
-		}
+		err = ioutil.WriteFile(file, []byte(d.contents), os.FileMode(0640))
+		assert.NoError(err)
 		defer os.Remove(file)
 
 		hostMemKb, err := getHostMemorySizeKb(file)
 
-		if (d.expectError && err == nil) || (!d.expectError && err != nil) {
-			t.Fatalf("got %d, input %v", hostMemKb, d)
-		}
-
-		if reflect.DeepEqual(hostMemKb, d.expectedResult) {
-			t.Fatalf("got %d, input %v", hostMemKb, d)
-		}
+		assert.False((d.expectError && err == nil))
+		assert.False((!d.expectError && err != nil))
+		assert.NotEqual(hostMemKb, d.expectedResult)
 	}
 }
 
@@ -446,21 +414,16 @@ type testNestedVMMData struct {
 
 // nolint: unused, deadcode
 func genericTestRunningOnVMM(t *testing.T, data []testNestedVMMData) {
+	assert := assert.New(t)
 	for _, d := range data {
 		f, err := ioutil.TempFile("", "cpuinfo")
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(err)
 		defer os.Remove(f.Name())
 		defer f.Close()
 
 		n, err := f.Write(d.content)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if n != len(d.content) {
-			t.Fatalf("Only %d bytes written out of %d expected", n, len(d.content))
-		}
+		assert.NoError(err)
+		assert.Equal(n, len(d.content))
 
 		running, err := RunningOnVMM(f.Name())
 		if !d.expectedErr && err != nil {
@@ -469,8 +432,6 @@ func genericTestRunningOnVMM(t *testing.T, data []testNestedVMMData) {
 			t.Fatalf("This test should fail")
 		}
 
-		if running != d.expected {
-			t.Fatalf("Expecting running on VMM = %t, Got %t", d.expected, running)
-		}
+		assert.Equal(running, d.expected)
 	}
 }

--- a/virtcontainers/iostream_test.go
+++ b/virtcontainers/iostream_test.go
@@ -14,9 +14,7 @@ import (
 func TestIOStream(t *testing.T) {
 	hConfig := newHypervisorConfig(nil, nil)
 	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NetworkConfig{}, []ContainerConfig{}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer cleanUp()
 
 	contID := "foo"

--- a/virtcontainers/ipvlan_endpoint_test.go
+++ b/virtcontainers/ipvlan_endpoint_test.go
@@ -7,11 +7,13 @@ package virtcontainers
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateIPVlanEndpoint(t *testing.T) {
+	assert := assert.New(t)
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
 	expected := &IPVlanEndpoint{
@@ -34,9 +36,7 @@ func TestCreateIPVlanEndpoint(t *testing.T) {
 	}
 
 	result, err := createIPVlanNetworkEndpoint(5, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-5"
@@ -44,7 +44,5 @@ func TestCreateIPVlanEndpoint(t *testing.T) {
 	// the resulting mac address will be random - so lets overwrite it
 	result.NetPair.VirtIface.HardAddr = macAddr.String()
 
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
-	}
+	assert.Exactly(result, expected)
 }

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -58,20 +58,18 @@ func testGenerateKataProxySockDir() (string, error) {
 }
 
 func TestKataAgentConnect(t *testing.T) {
+	assert := assert.New(t)
 	proxy := mock.ProxyUnixMock{
 		ClientHandler: proxyHandlerDiscard,
 	}
 
 	sockDir, err := testGenerateKataProxySockDir()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.RemoveAll(sockDir)
 
 	testKataProxyURL := fmt.Sprintf(testKataProxyURLTempl, sockDir)
-	if err := proxy.Start(testKataProxyURL); err != nil {
-		t.Fatal(err)
-	}
+	err = proxy.Start(testKataProxyURL)
+	assert.NoError(err)
 	defer proxy.Stop()
 
 	k := &kataAgent{
@@ -81,30 +79,24 @@ func TestKataAgentConnect(t *testing.T) {
 		},
 	}
 
-	if err := k.connect(); err != nil {
-		t.Fatal(err)
-	}
-
-	if k.client == nil {
-		t.Fatal("Kata agent client is not properly initialized")
-	}
+	err = k.connect()
+	assert.NoError(err)
+	assert.NotNil(k.client)
 }
 
 func TestKataAgentDisconnect(t *testing.T) {
+	assert := assert.New(t)
 	proxy := mock.ProxyUnixMock{
 		ClientHandler: proxyHandlerDiscard,
 	}
 
 	sockDir, err := testGenerateKataProxySockDir()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.RemoveAll(sockDir)
 
 	testKataProxyURL := fmt.Sprintf(testKataProxyURLTempl, sockDir)
-	if err := proxy.Start(testKataProxyURL); err != nil {
-		t.Fatal(err)
-	}
+	err = proxy.Start(testKataProxyURL)
+	assert.NoError(err)
 	defer proxy.Stop()
 
 	k := &kataAgent{
@@ -114,17 +106,9 @@ func TestKataAgentDisconnect(t *testing.T) {
 		},
 	}
 
-	if err := k.connect(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := k.disconnect(); err != nil {
-		t.Fatal(err)
-	}
-
-	if k.client != nil {
-		t.Fatal("Kata agent client pointer should be nil")
-	}
+	assert.NoError(k.connect())
+	assert.NoError(k.disconnect())
+	assert.Nil(k.client)
 }
 
 type gRPCProxy struct{}
@@ -816,15 +800,11 @@ func TestAgentNetworkOperation(t *testing.T) {
 	}
 
 	sockDir, err := testGenerateKataProxySockDir()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.RemoveAll(sockDir)
 
 	testKataProxyURL := fmt.Sprintf(testKataProxyURLTempl, sockDir)
-	if err := proxy.Start(testKataProxyURL); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(proxy.Start(testKataProxyURL))
 	defer proxy.Stop()
 
 	k := &kataAgent{
@@ -956,9 +936,8 @@ func TestKataCleanupSandbox(t *testing.T) {
 	k := &kataAgent{}
 	k.cleanup(s.id)
 
-	if _, err = os.Stat(dir); os.IsExist(err) {
-		t.Fatalf("%s still exists\n", dir)
-	}
+	_, err = os.Stat(dir)
+	assert.False(os.IsExist(err))
 }
 
 func TestKataAgentKernelParams(t *testing.T) {

--- a/virtcontainers/macvtap_endpoint_test.go
+++ b/virtcontainers/macvtap_endpoint_test.go
@@ -6,8 +6,9 @@
 package virtcontainers
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateMacvtapEndpoint(t *testing.T) {
@@ -22,11 +23,6 @@ func TestCreateMacvtapEndpoint(t *testing.T) {
 	}
 
 	result, err := createMacvtapNetworkEndpoint(netInfo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
-	}
+	assert.NoError(t, err)
+	assert.Exactly(t, result, expected)
 }

--- a/virtcontainers/mock_hypervisor_test.go
+++ b/virtcontainers/mock_hypervisor_test.go
@@ -9,10 +9,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMockHypervisorCreateSandbox(t *testing.T) {
 	var m *mockHypervisor
+	assert := assert.New(t)
 
 	sandbox := &Sandbox{
 		config: &SandboxConfig{
@@ -28,9 +31,8 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 	ctx := context.Background()
 
 	// wrong config
-	if err := m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil); err == nil {
-		t.Fatal()
-	}
+	err := m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil)
+	assert.Error(err)
 
 	sandbox.config.HypervisorConfig = HypervisorConfig{
 		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
@@ -38,56 +40,41 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
 	}
 
-	if err := m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil); err != nil {
-		t.Fatal(err)
-	}
+	err = m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil)
+	assert.NoError(err)
 }
 
 func TestMockHypervisorStartSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.startSandbox(vmStartTimeout); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, m.startSandbox(vmStartTimeout))
 }
 
 func TestMockHypervisorStopSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.stopSandbox(); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, m.stopSandbox())
 }
 
 func TestMockHypervisorAddDevice(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.addDevice(nil, imgDev); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, m.addDevice(nil, imgDev))
 }
 
 func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 	var m *mockHypervisor
 
 	expected := ""
-
 	result, err := m.getSandboxConsole("testSandboxID")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if result != expected {
-		t.Fatalf("Got %s\nExpecting %s", result, expected)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, result, expected)
 }
 
 func TestMockHypervisorSaveSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	if err := m.saveSandbox(); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, m.saveSandbox())
 }
 
 func TestMockHypervisorDisconnect(t *testing.T) {

--- a/virtcontainers/monitor_test.go
+++ b/virtcontainers/monitor_test.go
@@ -16,23 +16,22 @@ func TestMonitorSuccess(t *testing.T) {
 	contID := "505"
 	contConfig := newTestContainerConfigNoop(contID)
 	hConfig := newHypervisorConfig(nil, nil)
+	assert := assert.New(t)
 
 	// create a sandbox
 	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NetworkConfig{}, []ContainerConfig{contConfig}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
 	m := newMonitor(s)
 
 	ch, err := m.newWatcher()
-	assert.Nil(t, err, "newWatcher failed: %v", err)
+	assert.Nil(err, "newWatcher failed: %v", err)
 
 	fakeErr := errors.New("foobar error")
 	m.notify(fakeErr)
 	resultErr := <-ch
-	assert.True(t, resultErr == fakeErr, "monitor notification mismatch %v vs. %v", resultErr, fakeErr)
+	assert.True(resultErr == fakeErr, "monitor notification mismatch %v vs. %v", resultErr, fakeErr)
 
 	m.stop()
 }
@@ -41,18 +40,17 @@ func TestMonitorClosedChannel(t *testing.T) {
 	contID := "505"
 	contConfig := newTestContainerConfigNoop(contID)
 	hConfig := newHypervisorConfig(nil, nil)
+	assert := assert.New(t)
 
 	// create a sandbox
 	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NetworkConfig{}, []ContainerConfig{contConfig}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
 	m := newMonitor(s)
 
 	ch, err := m.newWatcher()
-	assert.Nil(t, err, "newWatcher failed: %v", err)
+	assert.Nil(err, "newWatcher failed: %v", err)
 
 	close(ch)
 	fakeErr := errors.New("foobar error")

--- a/virtcontainers/network_test.go
+++ b/virtcontainers/network_test.go
@@ -18,28 +18,20 @@ import (
 )
 
 func TestCreateDeleteNetNS(t *testing.T) {
+	assert := assert.New(t)
 	if tc.NotValid(ktu.NeedRoot()) {
 		t.Skip(testDisabledAsNonRoot)
 	}
 
 	netNSPath, err := createNetNS()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if netNSPath == "" {
-		t.Fatal()
-	}
+	assert.NoError(err)
+	assert.NotEmpty(netNSPath)
 
 	_, err = os.Stat(netNSPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = deleteNetNS(netNSPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestGenerateInterfacesAndRoutes(t *testing.T) {

--- a/virtcontainers/noop_agent_test.go
+++ b/virtcontainers/noop_agent_test.go
@@ -39,133 +39,111 @@ func testCreateNoopContainer() (*Sandbox, *Container, error) {
 func TestNoopAgentInit(t *testing.T) {
 	n := &noopAgent{}
 	sandbox := &Sandbox{}
+	assert := assert.New(t)
 
 	disableVMShutdown, err := n.init(context.Background(), sandbox, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if disableVMShutdown != false {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
+	assert.False(disableVMShutdown)
 }
 
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	cmd := types.Cmd{}
+	assert := assert.New(t)
+
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
-	if _, err = n.exec(sandbox, *container, cmd); err != nil {
-		t.Fatal(err)
-	}
+	_, err = n.exec(sandbox, *container, cmd)
+	assert.NoError(err)
 }
 
 func TestNoopAgentStartSandbox(t *testing.T) {
 	n := &noopAgent{}
 	sandbox := &Sandbox{}
+	assert := assert.New(t)
 
 	err := n.startSandbox(sandbox)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentStopSandbox(t *testing.T) {
 	n := &noopAgent{}
 	sandbox := &Sandbox{}
+	assert := assert.New(t)
 
 	err := n.stopSandbox(sandbox)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentCreateContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
-	if err := n.startSandbox(sandbox); err != nil {
-		t.Fatal(err)
-	}
+	err = n.startSandbox(sandbox)
+	assert.NoError(err)
 
-	if _, err := n.createContainer(sandbox, container); err != nil {
-		t.Fatal(err)
-	}
+	_, err = n.createContainer(sandbox, container)
+	assert.NoError(err)
 }
 
 func TestNoopAgentStartContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
+
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
 	err = n.startContainer(sandbox, container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentStopContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 
 	err = n.stopContainer(sandbox, *container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentStatsContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
+
 	defer cleanUp()
 	_, err = n.statsContainer(sandbox, *container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentPauseContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
+
 	defer cleanUp()
 	err = n.pauseContainer(sandbox, *container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentResumeContainer(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 	err = n.resumeContainer(sandbox, *container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentConfigure(t *testing.T) {
@@ -173,102 +151,88 @@ func TestNoopAgentConfigure(t *testing.T) {
 	h := &mockHypervisor{}
 	id := "foobar"
 	sharePath := "foobarDir"
+	assert := assert.New(t)
 	err := n.configure(h, id, sharePath, true, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentGetVMPath(t *testing.T) {
 	n := &noopAgent{}
 	path := n.getVMPath("")
-	if path != "" {
-		t.Fatal("getSharePath returns non empty path")
-	}
+	assert := assert.New(t)
+	assert.Empty(path)
 }
 
 func TestNoopAgentGetSharePath(t *testing.T) {
 	n := &noopAgent{}
 	path := n.getSharePath("")
-	if path != "" {
-		t.Fatal("getSharePath returns non empty path")
-	}
+	assert := assert.New(t)
+	assert.Empty(path)
 }
 
 func TestNoopAgentStartProxy(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	sandbox, _, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	assert.NoError(err)
 	defer cleanUp()
 	err = n.startProxy(sandbox)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentProcessListContainer(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	sandbox, container, err := testCreateNoopContainer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer cleanUp()
 	_, err = n.processListContainer(sandbox, *container, ProcessListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentReseedRNG(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	err := n.reseedRNG([]byte{})
-	if err != nil {
-		t.Fatal("reseedRNG failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentUpdateInterface(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	_, err := n.updateInterface(nil)
-	if err != nil {
-		t.Fatal("updateInterface failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentListInterfaces(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	_, err := n.listInterfaces()
-	if err != nil {
-		t.Fatal("listInterfaces failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentUpdateRoutes(t *testing.T) {
+	assert := assert.New(t)
 	n := &noopAgent{}
 	_, err := n.updateRoutes(nil)
-	if err != nil {
-		t.Fatal("updateRoutes failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentListRoutes(t *testing.T) {
 	n := &noopAgent{}
+	assert := assert.New(t)
 	_, err := n.listRoutes()
-	if err != nil {
-		t.Fatal("listRoutes failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopAgentRSetProxy(t *testing.T) {
 	n := &noopAgent{}
 	p := &noopProxy{}
 	s := &Sandbox{}
+	assert := assert.New(t)
 	err := n.setProxy(s, p, 0, "")
-	if err != nil {
-		t.Fatal("set proxy failed")
-	}
+	assert.NoError(err)
 }
 
 func TestNoopGetAgentUrl(t *testing.T) {

--- a/virtcontainers/noop_shim_test.go
+++ b/virtcontainers/noop_shim_test.go
@@ -7,20 +7,18 @@ package virtcontainers
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNoopShimStart(t *testing.T) {
+	assert := assert.New(t)
 	s := &noopShim{}
 	sandbox := &Sandbox{}
 	params := ShimParams{}
 	expected := 0
 
 	pid, err := s.start(sandbox, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if pid != expected {
-		t.Fatalf("PID should be %d", expected)
-	}
+	assert.NoError(err)
+	assert.Equal(pid, expected)
 }

--- a/virtcontainers/nsenter_test.go
+++ b/virtcontainers/nsenter_test.go
@@ -8,19 +8,16 @@ package virtcontainers
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testNsEnterFormatArgs(t *testing.T, args []string, expected string) {
 	nsenter := &nsenter{}
 
 	cmd, err := nsenter.formatArgs(args)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if strings.Join(cmd, " ") != expected {
-		t.Fatal()
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, strings.Join(cmd, " "), expected)
 }
 
 func TestNsEnterFormatArgsHello(t *testing.T) {

--- a/virtcontainers/physical_endpoint_test.go
+++ b/virtcontainers/physical_endpoint_test.go
@@ -43,6 +43,8 @@ func TestPhysicalEndpoint_HotDetach(t *testing.T) {
 }
 
 func TestIsPhysicalIface(t *testing.T) {
+	assert := assert.New(t)
+
 	if tc.NotValid(ktu.NeedRoot()) {
 		t.Skip(testDisabledAsNonRoot)
 	}
@@ -52,9 +54,7 @@ func TestIsPhysicalIface(t *testing.T) {
 	testMACAddr := "00:00:00:00:00:01"
 
 	hwAddr, err := net.ParseMAC(testMACAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	link := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
@@ -66,26 +66,19 @@ func TestIsPhysicalIface(t *testing.T) {
 	}
 
 	n, err := ns.NewNS()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer n.Close()
 
 	netnsHandle, err := netns.GetFromPath(n.Path())
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer netnsHandle.Close()
 
 	netlinkHandle, err := netlink.NewHandleAt(netnsHandle)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer netlinkHandle.Delete()
 
-	if err := netlinkHandle.LinkAdd(link); err != nil {
-		t.Fatal(err)
-	}
+	err = netlinkHandle.LinkAdd(link)
+	assert.NoError(err)
 
 	var isPhysical bool
 	err = doNetNS(n.Path(), func(_ ns.NetNS) error {
@@ -93,12 +86,6 @@ func TestIsPhysicalIface(t *testing.T) {
 		isPhysical, err = isPhysicalIface(testNetIface)
 		return err
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if isPhysical == true {
-		t.Fatalf("Got %+v\nExpecting %+v", isPhysical, false)
-	}
+	assert.NoError(err)
+	assert.False(isPhysical)
 }

--- a/virtcontainers/pkg/nsenter/nsenter_test.go
+++ b/virtcontainers/pkg/nsenter/nsenter_test.go
@@ -51,15 +51,11 @@ func TestGetFileFromNSEmptyNSPathFailure(t *testing.T) {
 
 func TestGetFileFromNSNotExistingNSPathFailure(t *testing.T) {
 	nsFile, err := ioutil.TempFile("", "not-existing-ns-path")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	nsFilePath := nsFile.Name()
 	nsFile.Close()
 
-	if err := os.Remove(nsFilePath); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, os.Remove(nsFilePath))
 
 	nsFile, err = getFileFromNS(nsFilePath)
 	assert.NotNil(t, err, "Not existing path should result as a failure")
@@ -68,9 +64,7 @@ func TestGetFileFromNSNotExistingNSPathFailure(t *testing.T) {
 
 func TestGetFileFromNSWrongNSPathFailure(t *testing.T) {
 	nsFile, err := ioutil.TempFile("", "wrong-ns-path")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	nsFilePath := nsFile.Name()
 	nsFile.Close()
 
@@ -125,9 +119,7 @@ func TestSetNSUnknownNSTypeFailure(t *testing.T) {
 
 func TestSetNSWrongFileFailure(t *testing.T) {
 	nsFile, err := ioutil.TempFile("", "wrong-ns-path")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer func() {
 		nsFilePath := nsFile.Name()
 		nsFile.Close()
@@ -182,9 +174,7 @@ func TestNsEnterSuccessful(t *testing.T) {
 	}
 
 	sleepPID, err := startSleepBinary(sleepDuration, cloneFlags)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer func() {
 		if sleepPID > 1 {
 			unix.Kill(sleepPID, syscall.SIGKILL)

--- a/virtcontainers/pkg/uuid/uuid_test.go
+++ b/virtcontainers/pkg/uuid/uuid_test.go
@@ -5,7 +5,11 @@
 
 package uuid
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 // Test UUID parsing and string conversation.
 //
@@ -13,6 +17,7 @@ import "testing"
 //
 // The original strings and the strings generated from the UUIDs match.
 func TestUUID(t *testing.T) {
+	assert := assert.New(t)
 	testUUIDs := []string{
 		"f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
 		"30dedd5c-48d9-45d3-8b44-f973e4f35e48",
@@ -25,13 +30,9 @@ func TestUUID(t *testing.T) {
 
 	for _, s := range testUUIDs {
 		uuid, err := Parse(s)
-		if err != nil {
-			t.Fatalf("Unable to parse %s: %s", s, err)
-		}
+		assert.NoError(err)
 		s2 := uuid.String()
-		if s != s2 {
-			t.Fatalf("%s and %s do not match", s, s2)
-		}
+		assert.Equal(s, s2)
 	}
 }
 
@@ -43,19 +44,14 @@ func TestUUID(t *testing.T) {
 // The UUIDs are generated correctly, their version number is correct,
 // and they can be parsed.
 func TestGenUUID(t *testing.T) {
+	assert := assert.New(t)
 	for i := 0; i < 100; i++ {
 		u := Generate()
 		s := u.String()
-		if s[14] != '4' {
-			t.Fatalf("Invalid UUID.  Version number is incorrect")
-		}
+		assert.EqualValues(s[14], '4')
 		u2, err := Parse(s)
-		if err != nil {
-			t.Fatalf("Failed to parse UUID %s : %s", s, err)
-		}
-		if u != u2 {
-			t.Fatalf("Generated and Parsed UUIDs are not equal")
-		}
+		assert.NoError(err)
+		assert.Equal(u, u2)
 	}
 }
 
@@ -77,8 +73,6 @@ func TestBadUUID(t *testing.T) {
 
 	for _, s := range badTestUUIDs {
 		_, err := Parse(s)
-		if err == nil {
-			t.Fatalf("uuid.Parse should fail to parse %s", s)
-		}
+		assert.Error(t, err)
 	}
 }

--- a/virtcontainers/syscall_test.go
+++ b/virtcontainers/syscall_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBindMountInvalidSourceSymlink(t *testing.T) {
@@ -21,9 +22,7 @@ func TestBindMountInvalidSourceSymlink(t *testing.T) {
 	os.Remove(source)
 
 	err := bindMount(context.Background(), source, "", false)
-	if err == nil {
-		t.Fatal()
-	}
+	assert.Error(t, err)
 }
 
 func TestBindMountFailingMount(t *testing.T) {
@@ -31,24 +30,20 @@ func TestBindMountFailingMount(t *testing.T) {
 	fakeSource := filepath.Join(testDir, "fooFile")
 	os.Remove(source)
 	os.Remove(fakeSource)
+	assert := assert.New(t)
 
 	_, err := os.OpenFile(fakeSource, os.O_CREATE, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = os.Symlink(fakeSource, source)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = bindMount(context.Background(), source, "", false)
-	if err == nil {
-		t.Fatal()
-	}
+	assert.Error(err)
 }
 
 func TestBindMountSuccessful(t *testing.T) {
+	assert := assert.New(t)
 	if tc.NotValid(ktu.NeedRoot()) {
 		t.Skip(testDisabledAsNonRoot)
 	}
@@ -60,24 +55,19 @@ func TestBindMountSuccessful(t *testing.T) {
 	os.Remove(dest)
 
 	err := os.MkdirAll(source, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = os.MkdirAll(dest, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = bindMount(context.Background(), source, dest, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	syscall.Unmount(dest, 0)
 }
 
 func TestBindMountReadonlySuccessful(t *testing.T) {
+	assert := assert.New(t)
 	if tc.NotValid(ktu.NeedRoot()) {
 		t.Skip(testDisabledAsNonRoot)
 	}
@@ -89,35 +79,25 @@ func TestBindMountReadonlySuccessful(t *testing.T) {
 	os.Remove(dest)
 
 	err := os.MkdirAll(source, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = os.MkdirAll(dest, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = bindMount(context.Background(), source, dest, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	defer syscall.Unmount(dest, 0)
 
 	// should not be able to create file in read-only mount
 	destFile := filepath.Join(dest, "foo")
 	_, err = os.OpenFile(destFile, os.O_CREATE, mountPerm)
-	if err == nil {
-		t.Fatal(err)
-	}
+	assert.Error(err)
 }
 
 func TestEnsureDestinationExistsNonExistingSource(t *testing.T) {
 	err := ensureDestinationExists("", "")
-	if err == nil {
-		t.Fatal()
-	}
+	assert.Error(t, err)
 }
 
 func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
@@ -125,16 +105,13 @@ func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
 	dest := filepath.Join(source, "fooDest")
 	os.Remove(source)
 	os.Remove(dest)
+	assert := assert.New(t)
 
 	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = ensureDestinationExists(source, dest)
-	if err == nil {
-		t.Fatal()
-	}
+	assert.Error(err)
 }
 
 func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
@@ -142,16 +119,13 @@ func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
 	dest := filepath.Join(testDir, "fooDirDest")
 	os.Remove(source)
 	os.Remove(dest)
+	assert := assert.New(t)
 
 	err := os.MkdirAll(source, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = ensureDestinationExists(source, dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }
 
 func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
@@ -159,14 +133,11 @@ func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
 	dest := filepath.Join(testDir, "fooDirDest")
 	os.Remove(source)
 	os.Remove(dest)
+	assert := assert.New(t)
 
 	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	err = ensureDestinationExists(source, dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 }

--- a/virtcontainers/types/capabilities_test.go
+++ b/virtcontainers/types/capabilities_test.go
@@ -5,46 +5,32 @@
 
 package types
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestBlockDeviceCapability(t *testing.T) {
 	var caps Capabilities
 
-	if caps.IsBlockDeviceSupported() {
-		t.Fatal()
-	}
-
+	assert.False(t, caps.IsBlockDeviceSupported())
 	caps.SetBlockDeviceSupport()
-
-	if !caps.IsBlockDeviceSupported() {
-		t.Fatal()
-	}
+	assert.True(t, caps.IsBlockDeviceSupported())
 }
 
 func TestBlockDeviceHotplugCapability(t *testing.T) {
 	var caps Capabilities
 
-	if caps.IsBlockDeviceHotplugSupported() {
-		t.Fatal()
-	}
-
+	assert.False(t, caps.IsBlockDeviceHotplugSupported())
 	caps.SetBlockDeviceHotplugSupport()
-
-	if !caps.IsBlockDeviceHotplugSupported() {
-		t.Fatal()
-	}
+	assert.True(t, caps.IsBlockDeviceHotplugSupported())
 }
 
 func TestFsSharingCapability(t *testing.T) {
 	var caps Capabilities
 
-	if !caps.IsFsSharingSupported() {
-		t.Fatal()
-	}
-
+	assert.True(t, caps.IsFsSharingSupported())
 	caps.SetFsSharingUnsupported()
-
-	if caps.IsFsSharingSupported() {
-		t.Fatal()
-	}
+	assert.False(t, caps.IsFsSharingSupported())
 }

--- a/virtcontainers/types_test.go
+++ b/virtcontainers/types_test.go
@@ -7,12 +7,12 @@ package virtcontainers
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testIsSandbox(t *testing.T, cType ContainerType, expected bool) {
-	if result := cType.IsSandbox(); result != expected {
-		t.Fatalf("Got %t, Expecting %t", result, expected)
-	}
+	assert.Equal(t, cType.IsSandbox(), expected)
 }
 
 func TestIsPodSandboxTrue(t *testing.T) {

--- a/virtcontainers/utils/utils_test.go
+++ b/virtcontainers/utils/utils_test.go
@@ -17,127 +17,91 @@ import (
 )
 
 func TestFileCopySuccessful(t *testing.T) {
+	assert := assert.New(t)
 	fileContent := "testContent"
 
 	srcFile, err := ioutil.TempFile("", "test_src_copy")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.Remove(srcFile.Name())
 	defer srcFile.Close()
 
 	dstFile, err := ioutil.TempFile("", "test_dst_copy")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 	defer os.Remove(dstFile.Name())
 
 	dstPath := dstFile.Name()
 
-	if err := dstFile.Close(); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(dstFile.Close())
 
-	if _, err := srcFile.WriteString(fileContent); err != nil {
-		t.Fatal(err)
-	}
+	_, err = srcFile.WriteString(fileContent)
+	assert.NoError(err)
 
-	if err := FileCopy(srcFile.Name(), dstPath); err != nil {
-		t.Fatal(err)
-	}
+	err = FileCopy(srcFile.Name(), dstPath)
+	assert.NoError(err)
 
 	dstContent, err := ioutil.ReadFile(dstPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(dstContent) != fileContent {
-		t.Fatalf("Got %q\nExpecting %q", string(dstContent), fileContent)
-	}
+	assert.NoError(err)
+	assert.Equal(string(dstContent), fileContent)
 
 	srcInfo, err := srcFile.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	dstInfo, err := os.Stat(dstPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
-	if dstInfo.Mode() != srcInfo.Mode() {
-		t.Fatalf("Got FileMode %d\nExpecting FileMode %d", dstInfo.Mode(), srcInfo.Mode())
-	}
-
-	if dstInfo.IsDir() != srcInfo.IsDir() {
-		t.Fatalf("Got IsDir() = %t\nExpecting IsDir() = %t", dstInfo.IsDir(), srcInfo.IsDir())
-	}
-
-	if dstInfo.Size() != srcInfo.Size() {
-		t.Fatalf("Got Size() = %d\nExpecting Size() = %d", dstInfo.Size(), srcInfo.Size())
-	}
+	assert.Equal(dstInfo.Mode(), srcInfo.Mode())
+	assert.Equal(dstInfo.IsDir(), srcInfo.IsDir())
+	assert.Equal(dstInfo.Size(), srcInfo.Size())
 }
 
 func TestFileCopySourceEmptyFailure(t *testing.T) {
-	if err := FileCopy("", "testDst"); err == nil {
-		t.Fatal("This test should fail because source path is empty")
-	}
+	assert := assert.New(t)
+	err := FileCopy("", "testDst")
+	assert.Error(err)
 }
 
 func TestFileCopyDestinationEmptyFailure(t *testing.T) {
-	if err := FileCopy("testSrc", ""); err == nil {
-		t.Fatal("This test should fail because destination path is empty")
-	}
+	assert := assert.New(t)
+	err := FileCopy("testSrc", "")
+	assert.Error(err)
 }
 
 func TestFileCopySourceNotExistFailure(t *testing.T) {
+	assert := assert.New(t)
 	srcFile, err := ioutil.TempFile("", "test_src_copy")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	srcPath := srcFile.Name()
+	assert.NoError(srcFile.Close())
+	assert.NoError(os.Remove(srcPath))
 
-	if err := srcFile.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Remove(srcPath); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := FileCopy(srcPath, "testDest"); err == nil {
-		t.Fatal("This test should fail because source file does not exist")
-	}
+	err = FileCopy(srcPath, "testDest")
+	assert.Error(err)
 }
 
 func TestGenerateRandomBytes(t *testing.T) {
+	assert := assert.New(t)
 	bytesNeeded := 8
 	randBytes, err := GenerateRandomBytes(bytesNeeded)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(randBytes) != bytesNeeded {
-		t.Fatalf("Failed to generate %d random bytes", bytesNeeded)
-	}
+	assert.NoError(err)
+	assert.Equal(len(randBytes), bytesNeeded)
 }
 
 func TestRevereString(t *testing.T) {
+	assert := assert.New(t)
 	str := "Teststr"
 	reversed := ReverseString(str)
-
-	if reversed != "rtstseT" {
-		t.Fatal("Incorrect String Reversal")
-	}
+	assert.Equal(reversed, "rtstseT")
 }
 
 func TestWriteToFile(t *testing.T) {
+	assert := assert.New(t)
+
 	err := WriteToFile("/file-does-not-exist", []byte("test-data"))
-	assert.NotNil(t, err)
+	assert.NotNil(err)
 
 	tmpFile, err := ioutil.TempFile("", "test_append_file")
-	assert.Nil(t, err)
+	assert.NoError(err)
 
 	filename := tmpFile.Name()
 	defer os.Remove(filename)
@@ -146,12 +110,12 @@ func TestWriteToFile(t *testing.T) {
 
 	testData := []byte("test-data")
 	err = WriteToFile(filename, testData)
-	assert.Nil(t, err)
+	assert.NoError(err)
 
 	data, err := ioutil.ReadFile(filename)
-	assert.Nil(t, err)
+	assert.NoError(err)
 
-	assert.True(t, reflect.DeepEqual(testData, data))
+	assert.True(reflect.DeepEqual(testData, data))
 }
 
 func TestConstraintsToVCPUs(t *testing.T) {
@@ -172,14 +136,13 @@ func TestConstraintsToVCPUs(t *testing.T) {
 }
 
 func TestGetVirtDriveNameInvalidIndex(t *testing.T) {
+	assert := assert.New(t)
 	_, err := GetVirtDriveName(-1)
-
-	if err == nil {
-		t.Fatal(err)
-	}
+	assert.Error(err)
 }
 
 func TestGetVirtDriveName(t *testing.T) {
+	assert := assert.New(t)
 	tests := []struct {
 		index         int
 		expectedDrive string
@@ -193,17 +156,14 @@ func TestGetVirtDriveName(t *testing.T) {
 
 	for _, test := range tests {
 		driveName, err := GetVirtDriveName(test.index)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if driveName != test.expectedDrive {
-			t.Fatalf("Incorrect drive Name: Got: %s, Expecting :%s", driveName, test.expectedDrive)
-
-		}
+		assert.NoError(err)
+		assert.Equal(driveName, test.expectedDrive)
 	}
 }
 
 func TestGetSCSIIdLun(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		index          int
 		expectedScsiID int
@@ -222,18 +182,17 @@ func TestGetSCSIIdLun(t *testing.T) {
 
 	for _, test := range tests {
 		scsiID, lun, err := GetSCSIIdLun(test.index)
-		assert.Nil(t, err)
-
-		if scsiID != test.expectedScsiID && lun != test.expectedLun {
-			t.Fatalf("Expecting scsi-id:lun %d:%d,  Got %d:%d", test.expectedScsiID, test.expectedLun, scsiID, lun)
-		}
+		assert.NoError(err)
+		assert.Equal(scsiID, test.expectedScsiID)
+		assert.Equal(lun, test.expectedLun)
 	}
 
 	_, _, err := GetSCSIIdLun(maxSCSIDevices + 1)
-	assert.NotNil(t, err)
+	assert.NotNil(err)
 }
 
 func TestGetSCSIAddress(t *testing.T) {
+	assert := assert.New(t)
 	tests := []struct {
 		index               int
 		expectedSCSIAddress string
@@ -247,9 +206,8 @@ func TestGetSCSIAddress(t *testing.T) {
 
 	for _, test := range tests {
 		scsiAddr, err := GetSCSIAddress(test.index)
-		assert.Nil(t, err)
-		assert.Equal(t, scsiAddr, test.expectedSCSIAddress)
-
+		assert.NoError(err)
+		assert.Equal(scsiAddr, test.expectedSCSIAddress)
 	}
 }
 

--- a/virtcontainers/veth_endpoint_test.go
+++ b/virtcontainers/veth_endpoint_test.go
@@ -7,11 +7,13 @@ package virtcontainers
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateVethNetworkEndpoint(t *testing.T) {
+	assert := assert.New(t)
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
 	expected := &VethEndpoint{
@@ -33,9 +35,7 @@ func TestCreateVethNetworkEndpoint(t *testing.T) {
 	}
 
 	result, err := createVethNetworkEndpoint(4, "", DefaultNetInterworkingModel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-4"
@@ -43,12 +43,11 @@ func TestCreateVethNetworkEndpoint(t *testing.T) {
 	// the resulting mac address will be random - so lets overwrite it
 	result.NetPair.VirtIface.HardAddr = macAddr.String()
 
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
-	}
+	assert.Exactly(result, expected)
 }
 
 func TestCreateVethNetworkEndpointChooseIfaceName(t *testing.T) {
+	assert := assert.New(t)
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
 	expected := &VethEndpoint{
@@ -70,9 +69,7 @@ func TestCreateVethNetworkEndpointChooseIfaceName(t *testing.T) {
 	}
 
 	result, err := createVethNetworkEndpoint(4, "eth1", DefaultNetInterworkingModel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(err)
 
 	// the resulting ID will be random - so let's overwrite to test the rest of the flow
 	result.NetPair.ID = "uniqueTestID-4"
@@ -80,9 +77,7 @@ func TestCreateVethNetworkEndpointChooseIfaceName(t *testing.T) {
 	// the resulting mac address will be random - so lets overwrite it
 	result.NetPair.VirtIface.HardAddr = macAddr.String()
 
-	if reflect.DeepEqual(result, expected) == false {
-		t.Fatalf("\nGot: %+v, \n\nExpected: %+v", result, expected)
-	}
+	assert.Exactly(result, expected)
 }
 
 func TestCreateVethNetworkEndpointInvalidArgs(t *testing.T) {
@@ -91,6 +86,8 @@ func TestCreateVethNetworkEndpointInvalidArgs(t *testing.T) {
 		ifName string
 	}
 
+	assert := assert.New(t)
+
 	// all elements are expected to result in failure
 	failingValues := []endpointValues{
 		{-1, "bar"},
@@ -98,9 +95,7 @@ func TestCreateVethNetworkEndpointInvalidArgs(t *testing.T) {
 	}
 
 	for _, d := range failingValues {
-		result, err := createVethNetworkEndpoint(d.idx, d.ifName, DefaultNetInterworkingModel)
-		if err == nil {
-			t.Fatalf("expected invalid endpoint for %v, got %v", d, result)
-		}
+		_, err := createVethNetworkEndpoint(d.idx, d.ifName, DefaultNetInterworkingModel)
+		assert.Error(err)
 	}
 }


### PR DESCRIPTION
Convert virtcontainers tests to testify/assert to make the virtcontainers
tests more readable.

fixes #156

Signed-off-by: Julio Montes <julio.montes@intel.com>