### PR TITLE
Fix UT failures with non-root

### DIFF
--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -344,6 +344,9 @@ func TestIsEphemeralStorage(t *testing.T) {
 // or directory attempting to be unmounted doesn't exist, then it
 // is not considered an error
 func TestBindUnmountContainerRootfsENOENTNotError(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test disabled as requires root user")
+	}
 	testMnt := "/tmp/test_mount"
 	sID := "sandIDTest"
 	cID := "contIDTest"

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1458,6 +1458,9 @@ func TestGetNetNs(t *testing.T) {
 }
 
 func TestStartNetworkMonitor(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test disabled as requires root user")
+	}
 	trueBinPath, err := exec.LookPath("true")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, trueBinPath)


### PR DESCRIPTION
1. 
```
=== RUN   TestStartNetworkMonitor
--- FAIL: TestStartNetworkMonitor (0.00s)
        Error Trace:    sandbox_test.go:1481
        Error:          Expected nil, but got: &errors.errorString{s:"Error switching to ns /proc/6648/task/6651/ns/net: operation not permitted"}
```
2.
```
=== RUN   TestBindUnmountContainerRootfsENOENTNotError
--- FAIL: TestBindUnmountContainerRootfsENOENTNotError (0.00s)
        Error Trace:    mount_test.go:360
        Error:          Expected nil, but got: 0x1
```

They should both be skipped with non-root.
