### PR TITLE
dnm: test fc ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -734,4 +734,4 @@ ifneq (,$(findstring $(HYPERVISOR_ACRN),$(KNOWN_HYPERVISORS)))
 endif
 	@printf "\tassets path (PKGDATADIR) : %s\n" $(abspath $(PKGDATADIR))
 	@printf "\tproxy+shim path (PKGLIBEXECDIR) : %s\n" $(abspath $(PKGLIBEXECDIR))
-	@printf "\n"
+	@printf " \n"


### PR DESCRIPTION
Because the tests repo doesn't test fc, I have to use the runtime
repo ci to validate a tests PR for fc CI, for now.

Fixes: #999999
Depends-on: github.com/kata-containers/tests#1847