### PR TITLE
virtcontainers: support SMP die

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -391,11 +391,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:6b643bd5e349019c33430301a3e5c38324c3014c423fe5e7cf857a8dd341efe2"
+  digest = "1:bba46c73858fda3e8066d66553615bd271f1ee811a0bf19f239ea2fb1e313f22"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "52b2309a558fe89b3e81b85440144b535288ce4f"
+  revision = "e0505242c0670f1a522f5b2d827e4a7e4062a14d"
 
 [[projects]]
   digest = "1:36dfd4701e98a9d8371dd3053e32d4f29e82b07bcc9e655db82138f9273bcb0f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "52b2309a558fe89b3e81b85440144b535288ce4f"
+  revision = "e0505242c0670f1a522f5b2d827e4a7e4062a14d"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1307,6 +1307,7 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		driver := hc.Type
 		cpuID := fmt.Sprintf("cpu-%d", len(q.state.HotpluggedVCPUs))
 		socketID := fmt.Sprintf("%d", hc.Properties.Socket)
+		dieID := fmt.Sprintf("%d", hc.Properties.Die)
 		coreID := fmt.Sprintf("%d", hc.Properties.Core)
 		threadID := fmt.Sprintf("%d", hc.Properties.Thread)
 
@@ -1314,9 +1315,10 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		if machine.Type == "pseries" || machine.Type == "s390-ccw-virtio" {
 			socketID = ""
 			threadID = ""
+			dieID = ""
 		}
 
-		if err := q.qmpMonitorCh.qmp.ExecuteCPUDeviceAdd(q.qmpMonitorCh.ctx, driver, cpuID, socketID, coreID, threadID, romFile); err != nil {
+		if err := q.qmpMonitorCh.qmp.ExecuteCPUDeviceAdd(q.qmpMonitorCh.ctx, driver, cpuID, socketID, dieID, coreID, threadID, romFile); err != nil {
 			// don't fail, let's try with other CPU
 			continue
 		}


### PR DESCRIPTION
CPU topology has changed in QEMU 4.1: socket > die > core > thread.
die option must be specified in order to hotplug CPUs on x86_64

Depends-on: github.com/kata-containers/packaging#657

fixes #1913

Signed-off-by: Julio Montes <julio.montes@intel.com>