### PR TITLE
Waiting event of vsock running before use it when use_vsock enabled

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -391,11 +391,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:bba46c73858fda3e8066d66553615bd271f1ee811a0bf19f239ea2fb1e313f22"
+  digest = "1:87c2fabdc0b5e8bf3555f20fc7dcb9650ad97233738f08330981117723cab23c"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "e0505242c0670f1a522f5b2d827e4a7e4062a14d"
+  revision = "aa341b005e9371b26d6ab95bcccb67eb5f48ee33"
 
 [[projects]]
   digest = "1:36dfd4701e98a9d8371dd3053e32d4f29e82b07bcc9e655db82138f9273bcb0f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "e0505242c0670f1a522f5b2d827e4a7e4062a14d"
+  revision = "aa341b005e9371b26d6ab95bcccb67eb5f48ee33"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -84,6 +84,9 @@ type QMPConfig struct {
 	// logger is used by the qmpStart function and all the go routines
 	// it spawns to log information.
 	Logger QMPLog
+
+	// specify the capacity of buffer used by receive QMP response.
+	MaxCapacity int
 }
 
 type qmpEventFilter struct {
@@ -242,8 +245,19 @@ type MigrationStatus struct {
 	XbzrleCache  MigrationXbzrleCache     `json:"xbzrle-cache,omitempty"`
 }
 
+// SchemaInfo represents all QMP wire ABI
+type SchemaInfo struct {
+	MetaType string `json:"meta-type"`
+	Name     string `json:"name"`
+}
+
 func (q *QMP) readLoop(fromVMCh chan<- []byte) {
 	scanner := bufio.NewScanner(q.conn)
+	if q.cfg.MaxCapacity > 0 {
+		buffer := make([]byte, q.cfg.MaxCapacity)
+		scanner.Buffer(buffer, q.cfg.MaxCapacity)
+	}
+
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if q.cfg.Logger.V(1) {
@@ -260,6 +274,7 @@ func (q *QMP) readLoop(fromVMCh chan<- []byte) {
 
 		fromVMCh <- sendLine
 	}
+	q.cfg.Logger.Infof("sanner return error: %v", scanner.Err())
 	close(fromVMCh)
 }
 
@@ -1508,4 +1523,25 @@ func (q *QMP) ExecuteMigrationIncoming(ctx context.Context, uri string) error {
 		"uri": uri,
 	}
 	return q.executeCommand(ctx, "migrate-incoming", args, nil)
+}
+
+// ExecQueryQmpSchema query all QMP wire ABI and returns a slice
+func (q *QMP) ExecQueryQmpSchema(ctx context.Context) ([]SchemaInfo, error) {
+	response, err := q.executeCommandWithResponse(ctx, "query-qmp-schema", nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert response to json
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract memory devices information: %v", err)
+	}
+
+	var schemaInfo []SchemaInfo
+	if err = json.Unmarshal(data, &schemaInfo); err != nil {
+		return nil, fmt.Errorf("unable to convert json to schemaInfo: %v", err)
+	}
+
+	return schemaInfo, nil
 }


### PR DESCRIPTION
Fixes: #1917 

`kata-runtime` needs wait qemu report event of vsock is running.
see https://github.com/BetaXOi/qemu/commit/9b536b67436f6d9ec61c46b11be1bd2eca6f7fc5

Signed-off-by: Ning Bo <n.b@live.com>