### PR TITLE
network: fix failed to remove network

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -65,11 +65,9 @@ func CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	return s, err
 }
 
-func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (_ *Sandbox, err error) {
 	span, ctx := trace(ctx, "createSandboxFromConfig")
 	defer span.Finish()
-
-	var err error
 
 	// Create the sandbox.
 	s, err := createSandbox(ctx, sandboxConfig, factory)
@@ -91,7 +89,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 
 	// network rollback
 	defer func() {
-		if err != nil && s.networkNS.NetNsCreated {
+		if err != nil {
 			s.removeNetwork()
 		}
 	}()


### PR DESCRIPTION
in create sandbox, if process error, should remove network without judge
NetNsCreated is true, since network is created by kata and should be
removed by kata, and network.Remove has judged if need to delete netns
depend on NetNsCreated

Fixes: #1920

Signed-off-by: Ace-Tang <aceapril@126.com>