### PR TITLE
acrn: Add toml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swp
 .git-commit
 .git-commit.tmp
+/cli/config/configuration-acrn.toml
 /cli/config/configuration-fc.toml
 /cli/config/configuration-nemu.toml
 /cli/config/configuration-qemu.toml


### PR DESCRIPTION
Add acrn's generated configuration toml file to the gitignore list.

Fixes: #1927
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>