### PR TITLE
shim-v2: fix shim leak when hypervisor exit unexpectly

### DIFF
--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -117,7 +117,6 @@ func watchSandbox(s *service) {
 			}
 		}
 	}
-	s.containers = make(map[string]*container)
 
 	// Existing container/exec will be cleaned up by its waiters.
 	// No need to send async events here.


### PR DESCRIPTION
Fixes: #1929

in containerd-kata-v2, container can only be deleted in Delete
interface, or other shim operates(like kill/delete) all fails
since can not get container info.