### PR TITLE
add watchconsole for no_proxy type

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -1044,7 +1044,7 @@ func LoadConfiguration(configPath string, ignoreLogging, builtIn bool) (resolved
 	if config.HypervisorConfig.UseVSock {
 		kataUtilsLogger.Info("VSOCK supported, configure to not use proxy")
 		config.ProxyType = vc.NoProxyType
-		config.ProxyConfig = vc.ProxyConfig{}
+		config.ProxyConfig = vc.ProxyConfig{Debug: config.Debug}
 	}
 
 	config.DisableNewNetNs = tomlConf.Runtime.DisableNewNetNs

--- a/virtcontainers/kata_builtin_proxy.go
+++ b/virtcontainers/kata_builtin_proxy.go
@@ -5,36 +5,17 @@
 
 package virtcontainers
 
-import (
-	"bufio"
-	"fmt"
-	"io"
-	"net"
-
-	"github.com/sirupsen/logrus"
-)
-
-var buildinProxyConsoleProto = consoleProtoUnix
+import "fmt"
 
 // This is a kata builtin proxy implementation of the proxy interface. Kata proxy
 // functionality is implemented inside the virtcontainers library.
 type kataBuiltInProxy struct {
-	sandboxID string
-	conn      net.Conn
-}
-
-// check if the proxy has watched the vm console.
-func (p *kataBuiltInProxy) consoleWatched() bool {
-	return p.conn != nil
+	proxyBuiltin
 }
 
 func (p *kataBuiltInProxy) validateParams(params proxyParams) error {
 	if len(params.id) == 0 || len(params.agentURL) == 0 || len(params.consoleURL) == 0 {
 		return fmt.Errorf("Invalid proxy parameters %+v", params)
-	}
-
-	if params.logger == nil {
-		return fmt.Errorf("Invalid proxy parameter: proxy logger is not set")
 	}
 
 	return nil
@@ -48,76 +29,5 @@ func (p *kataBuiltInProxy) start(params proxyParams) (int, string, error) {
 		return -1, "", err
 	}
 
-	if p.consoleWatched() {
-		return -1, "", fmt.Errorf("kata builtin proxy running for sandbox %s", params.id)
-	}
-
-	params.logger.Debug("Starting builtin kata proxy")
-
-	p.sandboxID = params.id
-
-	if params.debug {
-		err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
-		if err != nil {
-			p.sandboxID = ""
-			return -1, "", err
-		}
-	}
-
-	return params.hid, params.agentURL, nil
-}
-
-// stop is the proxy stop implementation for kata builtin proxy.
-func (p *kataBuiltInProxy) stop(pid int) error {
-	if p.conn != nil {
-		p.conn.Close()
-		p.conn = nil
-		p.sandboxID = ""
-	}
-	return nil
-}
-
-func (p *kataBuiltInProxy) watchConsole(proto, console string, logger *logrus.Entry) (err error) {
-	var (
-		scanner *bufio.Scanner
-		conn    net.Conn
-	)
-
-	switch proto {
-	case consoleProtoUnix:
-		conn, err = net.Dial("unix", console)
-		if err != nil {
-			return err
-		}
-	// TODO: add pty console support for kvmtools
-	case consoleProtoPty:
-		fallthrough
-	default:
-		return fmt.Errorf("unknown console proto %s", proto)
-	}
-
-	p.conn = conn
-
-	go func() {
-		scanner = bufio.NewScanner(conn)
-		for scanner.Scan() {
-			logger.WithFields(logrus.Fields{
-				"sandbox":   p.sandboxID,
-				"vmconsole": scanner.Text(),
-			}).Debug("reading guest console")
-		}
-
-		if err := scanner.Err(); err != nil {
-			if err == io.EOF {
-				logger.Info("console watcher quits")
-			} else {
-				logger.WithError(err).WithFields(logrus.Fields{
-					"console-protocol": proto,
-					"console-socket":   console,
-				}).Error("Failed to read agent logs")
-			}
-		}
-	}()
-
-	return nil
+	return p.proxyBuiltin.start(params)
 }

--- a/virtcontainers/kata_builtin_proxy_test.go
+++ b/virtcontainers/kata_builtin_proxy_test.go
@@ -32,12 +32,9 @@ func TestKataBuiltinProxy(t *testing.T) {
 
 	params.consoleURL = "foobarconsole"
 	err = p.validateParams(params)
-	assert.NotNil(err)
-
-	params.logger = logrus.WithField("proxy", params.id)
-	err = p.validateParams(params)
 	assert.Nil(err)
 
+	params.logger = logrus.WithField("proxy", params.id)
 	buildinProxyConsoleProto = "foobarproto"
 	_, _, err = p.start(params)
 	assert.NotNil(err)

--- a/virtcontainers/no_proxy.go
+++ b/virtcontainers/no_proxy.go
@@ -5,10 +5,6 @@
 
 package virtcontainers
 
-import (
-	"fmt"
-)
-
 // This is the no proxy implementation of the proxy interface. This
 // is a generic implementation for any case (basically any agent),
 // where no actual proxy is needed. This happens when the combination
@@ -20,29 +16,5 @@ import (
 // is to provide both shim and runtime the correct URL to connect
 // directly to the VM.
 type noProxy struct {
-}
-
-// start is noProxy start implementation for proxy interface.
-func (p *noProxy) start(params proxyParams) (int, string, error) {
-	if params.logger == nil {
-		return -1, "", fmt.Errorf("proxy logger is not set")
-	}
-
-	params.logger.Debug("No proxy started because of no-proxy implementation")
-
-	if params.agentURL == "" {
-		return -1, "", fmt.Errorf("AgentURL cannot be empty")
-	}
-
-	return params.hid, params.agentURL, nil
-}
-
-// stop is noProxy stop implementation for proxy interface.
-func (p *noProxy) stop(pid int) error {
-	return nil
-}
-
-// The noproxy doesn't need to watch the vm console, thus return false always.
-func (p *noProxy) consoleWatched() bool {
-	return false
+	proxyBuiltin
 }


### PR DESCRIPTION
For no proxy type, we also need the feature
of watch hypervisor's console to help debug.

Fixes:#1932

Signed-off-by: lifupan <lifupan@gmail.com>