### PR TITLE
virtiofs: wait for virtiofsd process to release its resources

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -658,6 +658,8 @@ func (q *qemu) setupVirtiofsd(timeout int) (remain int, err error) {
 			}
 		}
 		q.Logger().Info("virtiofsd quits")
+		// Wait to release resources of virtiofsd process
+		cmd.Process.Wait()
 		q.stopSandbox()
 	}()
 


### PR DESCRIPTION
We start virtiofsd in foreground (-f option), so we should wait for it
to reclaim its resources to avoid zombie process when qemu or virtiofsd
got killed unexpectedly.

Fixes: #1934
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>