### PR TITLE
network: Ignore routes with proto as "kernel"

### DIFF
--- a/netmon/netmon.go
+++ b/netmon/netmon.go
@@ -307,6 +307,11 @@ func convertRoutes(netRoutes []netlink.Route) []vcTypes.Route {
 	// by Kata yet.
 	for _, netRoute := range netRoutes {
 		dst := ""
+
+		if netRoute.Protocol == unix.RTPROT_KERNEL {
+			continue
+		}
+
 		if netRoute.Dst != nil {
 			if netRoute.Dst.IP.To4() != nil {
 				dst = netRoute.Dst.String()

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1170,6 +1170,10 @@ func generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*vcTypes.Interfa
 		for _, route := range endpoint.Properties().Routes {
 			var r vcTypes.Route
 
+			if route.Protocol == unix.RTPROT_KERNEL {
+				continue
+			}
+
 			if route.Dst != nil {
 				r.Dest = route.Dst.String()
 


### PR DESCRIPTION
Routes with proto "kernel" are routes that are automatically added
by the kernel.
It is a route added automatically when you assign an address to an
interface which is not /32.
With this commit, these routes are ignored. The guest kernel
would add these routes on the guest side. A corresponding commit on the
agent side would no longer delete these routes while updating them.

Without this commit, netlink gives an error complaining that a route
already exists when you try to add a route with the same dest subnet.

Something like:
dest: 192.168.1.0/24 device:net1 source:192.168.1.217 scope:253
dest: 192.168.1.0/24 device:net2 source:192.168.1.218 scope:253

Fixes: #1811

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>