### PR TITLE
pkg/katautils: Do not set `init` in the kernel command line

### DIFF
--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -20,10 +20,6 @@ var GetKernelParamsFunc = getKernelParams
 
 var systemdKernelParam = []vc.Param{
 	{
-		Key:   "init",
-		Value: "/usr/lib/systemd/systemd",
-	},
-	{
 		Key:   "systemd.unit",
 		Value: systemdUnitName,
 	},


### PR DESCRIPTION
Currently kata sets the init process to systemd even when it isn't installed,
the criteria to determinate whether systemd is used as init or not
is very odd, since kata only checks whether the `image` option is set in the
configuration file, unfortunately not all images have systemd installed.
Instead kata should rely on the guest kernel and `osbuilder` to use the right
init process. `osbuilder` creates a symbolic link to `systemd` or `kata-agent`
depending on the `AGENT_INIT` environment variable.

fixes #1937

Signed-off-by: Julio Montes <julio.montes@intel.com>