### PR TITLE
versions: kernel: update to 4.19.65

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -164,7 +164,7 @@ assets:
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
     uscan-url: >-
       https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-(4\.19\..+)\.tar\.gz
-    version: "v4.19.52"
+    version: "v4.19.65"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
52 is long in the tooth.  On to x.y.65!

Fixes: #1947

Signed-off-by: Eric Ernst <eric.ernst@intel.com>