### PR TITLE
sandbox: make sure qemu process not exit after stop

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -584,7 +584,7 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 				container.state.State == types.StatePaused) &&
 				container.process.Pid > 0 {
 
-				running, err := isShimRunning(container.process.Pid)
+				running, err := isProcRunning(container.process.Pid)
 				if err != nil {
 					return ContainerStatus{}, err
 				}

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -981,7 +981,7 @@ func (c *Container) stop(force bool) error {
 
 		// If shim is still running something went wrong
 		// Make sure we stop the shim process
-		if running, _ := isShimRunning(c.process.Pid); running {
+		if running, _ := isProcRunning(c.process.Pid); running {
 			l := c.Logger()
 			l.Error("Failed to stop container so stopping dangling shim")
 			if err := stopShim(c.process.Pid); err != nil {

--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -227,7 +227,7 @@ func startShim(args []string, params ShimParams) (int, error) {
 	return cmd.Process.Pid, nil
 }
 
-func isShimRunning(pid int) (bool, error) {
+func isProcRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
@@ -253,7 +253,7 @@ func waitForShim(pid int) error {
 
 	tInit := time.Now()
 	for {
-		running, err := isShimRunning(pid)
+		running, err := isProcRunning(pid)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/shim_test.go
+++ b/virtcontainers/shim_test.go
@@ -190,7 +190,7 @@ func TestStopShimSuccessfulProcessRunning(t *testing.T) {
 
 func testIsShimRunning(t *testing.T, pid int, expected bool) {
 	assert := assert.New(t)
-	running, err := isShimRunning(pid)
+	running, err := isProcRunning(pid)
 	assert.NoError(err)
 	assert.Equal(running, expected)
 }


### PR DESCRIPTION
We found qemu still living for a while after stopVM successful, this
will cause a problem when we use passthrough network. In stop
container/pod, network plugin try bind vf to host kernel driver, if qemu
still running, kernel got panic

bind vf to virtio-pci driver
```
0xffffffffa02f6d50 : __vfio_group_unset_container+0x0/0xc0 [vfio]
0xffffffffa02f6e39 : vfio_group_try_dissolve_container+0x29/0x30 [vfio]
0xffffffffa02f7192 : vfio_group_put_external_user+0x12/0x70 [vfio]
0xffffffffa056aff3 : kvm_vfio_group_put_external_user+0x23/0x40 [kvm]
0xffffffffa056b10b : kvm_vfio_destroy+0x3b/0x90 [kvm]
0xffffffffa0563421 : kvm_put_kvm+0x161/0x1e0 [kvm]
0xffffffffa0563511 : kvm_vm_release+0x21/0x30 [kvm]
```

kvm release container fd

```
0xffffffffa0045900 : virtnet_probe+0x0/0x0 [virtio_net]
0xffffffffa007d6e4 : virtio_dev_probe+0x144/0x1e0 [virtio]
0xffffffff814e2e37 : driver_probe_device+0x1c7/0x410 [kernel]
0xffffffff814e31fc : __device_attach_driver+0x8c/0x100 [kernel]
0xffffffff814e0957 : bus_for_each_drv+0x67/0xb0 [kernel]
0xffffffff814e2aed : __device_attach+0xdd/0x160 [kernel]
0xffffffff814e32b3 : device_initial_probe+0x13/0x20 [kernel]
0xffffffff814e1d22 : bus_probe_device+0x92/0xa0 [kernel]
0xffffffff814df889 : device_add+0x3c9/0x620 [kernel]
```

Fixes: #1945

Signed-off-by: Ace-Tang <aceapril@126.com>