### PR TITLE
sandbox: remove network before stopping vm

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1473,16 +1473,16 @@ func (s *Sandbox) Stop(force bool) error {
 		}
 	}
 
+	// Remove the network.
+	if err := s.removeNetwork(); err != nil && !force {
+		return err
+	}
+
 	if err := s.stopVM(); err != nil && !force {
 		return err
 	}
 
 	if err := s.setSandboxState(types.StateStopped); err != nil {
-		return err
-	}
-
-	// Remove the network.
-	if err := s.removeNetwork(); err != nil && !force {
 		return err
 	}
 


### PR DESCRIPTION
We might need to call hypervisor hotunplug to really remove
a network device. We cannot do it after stopping the VM.

Fixes: #1956
Signed-off-by: Peng Tao <bergwolf@hyper.sh>