### PR TITLE
do not hotplug network device when stopping sandbox

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1480,22 +1480,16 @@ func (n *Network) PostAdd(ctx context.Context, ns *NetworkNamespace, hotplug boo
 
 // Remove network endpoints in the network namespace. It also deletes the network
 // namespace in case the namespace has been created by us.
-func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor, hotunplug bool) error {
+func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor) error {
 	span, _ := n.trace(ctx, "remove")
 	defer span.Finish()
 
 	for _, endpoint := range ns.Endpoints {
 		// Detach for an endpoint should enter the network namespace
 		// if required.
-		networkLogger().WithField("endpoint-type", endpoint.Type()).WithField("hotunplug", hotunplug).Info("Detaching endpoint")
-		if hotunplug {
-			if err := endpoint.HotDetach(hypervisor, ns.NetNsCreated, ns.NetNsPath); err != nil {
-				return err
-			}
-		} else {
-			if err := endpoint.Detach(ns.NetNsCreated, ns.NetNsPath); err != nil {
-				return err
-			}
+		networkLogger().WithField("endpoint-type", endpoint.Type()).Info("Detaching endpoint")
+		if err := endpoint.Detach(ns.NetNsCreated, ns.NetNsPath); err != nil {
+			return err
 		}
 	}
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -862,7 +862,7 @@ func (s *Sandbox) removeNetwork() error {
 		}
 	}
 
-	return s.network.Remove(s.ctx, &s.networkNS, s.hypervisor, s.factory != nil)
+	return s.network.Remove(s.ctx, &s.networkNS, s.hypervisor)
 }
 
 func (s *Sandbox) generateNetInfo(inf *vcTypes.Interface) (NetworkInfo, error) {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1473,16 +1473,16 @@ func (s *Sandbox) Stop(force bool) error {
 		}
 	}
 
-	// Remove the network.
-	if err := s.removeNetwork(); err != nil && !force {
-		return err
-	}
-
 	if err := s.stopVM(); err != nil && !force {
 		return err
 	}
 
 	if err := s.setSandboxState(types.StateStopped); err != nil {
+		return err
+	}
+
+	// Remove the network.
+	if err := s.removeNetwork(); err != nil && !force {
 		return err
 	}
 


### PR DESCRIPTION
#1957 is problematic that it causes vfio nic passthrough to fail, because we need to bind the device back to host and that is not possible when qemu is still running. So we should revert it.

And to fix the original issue #1956, we can just skip hotunplug all together as it is not really necessary when stopping a vm.