### PR TITLE
add virtiofsd to sandbox cgroup

### DIFF
--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -617,8 +617,8 @@ func (a *acrn) cleanup() error {
 	return nil
 }
 
-func (a *acrn) pid() int {
-	return a.info.PID
+func (a *acrn) getPids() []int {
+	return []int{a.info.PID}
 }
 
 func (a *acrn) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {
@@ -639,7 +639,7 @@ func (a *acrn) storeInfo() error {
 }
 
 func (a *acrn) save() (s persistapi.HypervisorState) {
-	s.Pid = a.pid()
+	s.Pid = a.info.PID
 	s.Type = string(AcrnHypervisor)
 	s.UUID = a.state.UUID
 	return
@@ -651,7 +651,7 @@ func (a *acrn) load(s persistapi.HypervisorState) {
 }
 
 func (a *acrn) check() error {
-	if err := syscall.Kill(a.pid(), syscall.Signal(0)); err != nil {
+	if err := syscall.Kill(a.info.PID, syscall.Signal(0)); err != nil {
 		return errors.Wrapf(err, "failed to ping acrn process")
 	}
 

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -985,8 +985,8 @@ func (fc *firecracker) cleanup() error {
 	return nil
 }
 
-func (fc *firecracker) pid() int {
-	return fc.info.PID
+func (fc *firecracker) getPids() []int {
+	return []int{fc.info.PID}
 }
 
 func (fc *firecracker) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {
@@ -998,7 +998,7 @@ func (fc *firecracker) toGrpc() ([]byte, error) {
 }
 
 func (fc *firecracker) save() (s persistapi.HypervisorState) {
-	s.Pid = fc.pid()
+	s.Pid = fc.info.PID
 	s.Type = string(FirecrackerHypervisor)
 	return
 }
@@ -1008,7 +1008,7 @@ func (fc *firecracker) load(s persistapi.HypervisorState) {
 }
 
 func (fc *firecracker) check() error {
-	if err := syscall.Kill(fc.pid(), syscall.Signal(0)); err != nil {
+	if err := syscall.Kill(fc.info.PID, syscall.Signal(0)); err != nil {
 		return errors.Wrapf(err, "failed to ping fc process")
 	}
 

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -648,6 +648,14 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 	return false, fmt.Errorf("Couldn't find %q from %q output", flagsField, cpuInfoPath)
 }
 
+func getHypervisorPid(h hypervisor) int {
+	pids := h.getPids()
+	if len(pids) == 0 {
+		return 0
+	}
+	return pids[0]
+}
+
 // hypervisor is the virtcontainers hypervisor interface.
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
@@ -668,7 +676,9 @@ type hypervisor interface {
 	hypervisorConfig() HypervisorConfig
 	getThreadIDs() (vcpuThreadIDs, error)
 	cleanup() error
-	pid() int
+	// getPids returns a slice of hypervisor related process ids.
+	// The hypervisor pid must be put at index 0.
+	getPids() []int
 	fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error
 	toGrpc() ([]byte, error)
 	check() error

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -657,7 +657,7 @@ func (k *kataAgent) startProxy(sandbox *Sandbox) error {
 
 	proxyParams := proxyParams{
 		id:         sandbox.id,
-		hid:        sandbox.hypervisor.pid(),
+		hid:        getHypervisorPid(sandbox.hypervisor),
 		path:       sandbox.config.ProxyConfig.Path,
 		agentURL:   agentURL,
 		consoleURL: consoleURL,

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -104,8 +104,8 @@ func (m *mockHypervisor) cleanup() error {
 	return nil
 }
 
-func (m *mockHypervisor) pid() int {
-	return m.mockPid
+func (m *mockHypervisor) getPids() []int {
+	return []int{m.mockPid}
 }
 
 func (m *mockHypervisor) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {

--- a/virtcontainers/persist/api/hypervisor.go
+++ b/virtcontainers/persist/api/hypervisor.go
@@ -39,5 +39,6 @@ type HypervisorState struct {
 	// HotpluggedCPUs is the list of CPUs that were hot-added
 	HotpluggedVCPUs      []CPUDevice
 	HotpluggedMemory     int
+	VirtiofsdPid         int
 	HotplugVFIOOnRootBus bool
 }

--- a/virtcontainers/persist/api/version.go
+++ b/virtcontainers/persist/api/version.go
@@ -15,5 +15,5 @@ const (
 	// If you can't be sure if the change in persistapi package
 	// requires a bump of CurPersistVersion or not, do it for peace!
 	// --@WeiZhang555
-	CurPersistVersion uint = 1
+	CurPersistVersion uint = 2
 )

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -568,3 +568,40 @@ func TestQemuWaitVirtiofsd(t *testing.T) {
 	assert.NotNil(err)
 	assert.True(remain == 0)
 }
+
+func TestQemuGetpids(t *testing.T) {
+	assert := assert.New(t)
+
+	qemuConfig := newQemuConfig()
+	q := &qemu{}
+	pids := q.getPids()
+	assert.NotNil(pids)
+	assert.True(len(pids) == 1)
+	assert.True(pids[0] == 0)
+
+	q = &qemu{
+		config: qemuConfig,
+	}
+	f, err := ioutil.TempFile("", "qemu-test-")
+	assert.Nil(err)
+	tmpfile := f.Name()
+	f.Close()
+	defer os.Remove(tmpfile)
+
+	q.qemuConfig.PidFile = tmpfile
+	pids = q.getPids()
+	assert.True(len(pids) == 1)
+	assert.True(pids[0] == 0)
+
+	err = ioutil.WriteFile(tmpfile, []byte("100"), 0)
+	assert.Nil(err)
+	pids = q.getPids()
+	assert.True(len(pids) == 1)
+	assert.True(pids[0] == 100)
+
+	q.state.VirtiofsdPid = 200
+	pids = q.getPids()
+	assert.True(len(pids) == 2)
+	assert.True(pids[0] == 100)
+	assert.True(pids[1] == 200)
+}

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -475,7 +475,7 @@ func (v *VM) ToGrpc(config VMConfig) (*pb.GrpcVM, error) {
 
 func (v *VM) GetVMStatus() *pb.GrpcVMStatus {
 	return &pb.GrpcVMStatus{
-		Pid:    int64(v.hypervisor.pid()),
+		Pid:    int64(getHypervisorPid(v.hypervisor)),
 		Cpu:    v.cpu,
 		Memory: v.memory,
 	}


### PR DESCRIPTION
Right now virtiofsd daemon is not in sandbox cgroup. We should add it to the same cgroup as the qemu main process.

Before fix:
```
$sudo cat /proc/101318/cgroup
12:pids:/system.slice/containerd.service
11:rdma:/
10:net_cls,net_prio:/
9:memory:/system.slice/containerd.service
8:freezer:/
7:blkio:/system.slice/containerd.service
6:cpu,cpuacct:/system.slice/containerd.service
5:perf_event:/
4:devices:/system.slice/containerd.service
3:cpuset:/
2:hugetlb:/
1:name=systemd:/system.slice/containerd.service
0::/system.slice/containerd.service
```
After fix:
```
$sudo cat /proc/99841/cgroup
12:pids:/system.slice/containerd.service
11:rdma:/
10:net_cls,net_prio:/
9:memory:/kata/docker/kata_84b5062407c3b2a8dde2bf51391f553362fb5f81a8ac1d7d891dcdd61c832fb2
8:freezer:/
7:blkio:/system.slice/containerd.service
6:cpu,cpuacct:/system.slice/containerd.service
5:perf_event:/
4:devices:/system.slice/containerd.service
3:cpuset:/
2:hugetlb:/
1:name=systemd:/system.slice/containerd.service
0::/system.slice/containerd.service
```