### PR TITLE
versions: update version of qemu to 4.1.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -103,8 +103,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "4.0.0"
-      tag: "v4.0.0"
+      version: "4.1.0"
+      tag: "v4.1.0"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
Update qemu version to bring the latest fixes and improvements:
* migration: allow private destination ram with x-ignore-shared
* hw/i386: Fix linker error when ISAPC is disabled
* hw/i386: turn off vmport if CONFIG_VMPORT is disabled

Depends-on: github.com/kata-containers/packaging#680

fixes #1978

Signed-off-by: Julio Montes <julio.montes@intel.com>