### PR TITLE
kata-check: require kvm modules for amd64

### DIFF
--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -116,17 +116,21 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 			}
 			archRequiredKernelModules = map[string]kernelModule{
 				kernelModkvm: {
-					desc: msgKernelVM,
+					desc:     msgKernelVM,
+					required: true,
 				},
 				kernelModkvmintel: {
 					desc:       "Intel KVM",
 					parameters: kvmIntelParams,
+					required:   true,
 				},
 				kernelModvhost: {
-					desc: msgKernelVirtio,
+					desc:     msgKernelVirtio,
+					required: true,
 				},
 				kernelModvhostnet: {
-					desc: msgKernelVirtioNet,
+					desc:     msgKernelVirtioNet,
+					required: true,
 				},
 				kernelModvhostvsock: {
 					desc:     msgKernelVirtioVhostVsock,
@@ -143,13 +147,16 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 			}
 			archRequiredKernelModules = map[string]kernelModule{
 				kernelModvhm: {
-					desc: "Intel ACRN",
+					desc:     "Intel ACRN",
+					required: false,
 				},
 				kernelModvhost: {
-					desc: msgKernelVirtio,
+					desc:     msgKernelVirtio,
+					required: false,
 				},
 				kernelModvhostnet: {
-					desc: msgKernelVirtioNet,
+					desc:     msgKernelVirtioNet,
+					required: false,
 				},
 			}
 		default:

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -763,3 +763,54 @@ func TestCheckKernelParamHandler(t *testing.T) {
 	// single error (due to "param1"'s value being different)
 	checkKernelParamHandler(assert, testDataToCreate, testDataToExpect, nil, false, uint32(1))
 }
+
+func TestArchRequiredKernelModules(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	_, config, err := makeRuntimeConfig(tmpdir)
+	assert.NoError(err)
+
+	err = setCPUtype(config.HypervisorType)
+	assert.NoError(err)
+
+	if len(archRequiredKernelModules) == 0 {
+		// No modules to check
+		return
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	savedModProbeCmd := modProbeCmd
+	savedSysModuleDir := sysModuleDir
+
+	// XXX: override
+	sysModuleDir = filepath.Join(dir, "sys/module")
+	modProbeCmd = "false"
+
+	defer func() {
+		sysModuleDir = savedSysModuleDir
+		modProbeCmd = savedModProbeCmd
+	}()
+
+	// Running check with no modules
+	count, err := checkKernelModules(archRequiredKernelModules, nil)
+	assert.NoError(err)
+
+	// Test that count returned matches the # of modules with required set.
+	expectedCount := 0
+	for _, module := range archRequiredKernelModules {
+		if module.required {
+			expectedCount++
+		}
+	}
+
+	assert.EqualValues(count, expectedCount)
+}


### PR DESCRIPTION
KVM modules are required when using QEMU or firecracker.

Fixes: #1985

Signed-off-by: Marco Vedovati <mvedovati@suse.com>