### PR TITLE
vsock: set VHOST_VSOCK_SET_GUEST_CID for ppc64le

### DIFF
--- a/virtcontainers/utils/utils_linux.go
+++ b/virtcontainers/utils/utils_linux.go
@@ -16,10 +16,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// from <linux/vhost.h>
-// VHOST_VSOCK_SET_GUEST_CID = _IOW(VHOST_VIRTIO, 0x60, __u64)
-const ioctlVhostVsockSetGuestCid = 0x4008AF60
-
 var ioctlFunc = Ioctl
 
 // maxUInt represents the maximum valid value for the context ID.
@@ -78,6 +74,7 @@ func FindContextID() (*os.File, uint64, error) {
 		}
 	}
 
+	ioctlVhostVsockSetGuestCid := getIoctlVhostVsockGuestCid()
 	// Last chance to get a free context ID.
 	for cid := contextID - 1; cid >= firstContextID; cid-- {
 		if err = ioctlFunc(vsockFd.Fd(), ioctlVhostVsockSetGuestCid, uintptr(unsafe.Pointer(&cid))); err == nil {

--- a/virtcontainers/utils/utils_linux_generic.go
+++ b/virtcontainers/utils/utils_linux_generic.go
@@ -1,0 +1,16 @@
+// +build amd64 arm64 s390x !ppc64le
+
+// Copyright (c) 2019 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+// from <linux/vhost.h>
+// VHOST_VSOCK_SET_GUEST_CID = _IOW(VHOST_VIRTIO, 0x60, __u64)
+const ioctlVhostVsockSetGuestCid = 0x4008AF60
+
+func getIoctlVhostVsockGuestCid() uintptr {
+	return ioctlVhostVsockSetGuestCid
+}

--- a/virtcontainers/utils/utils_linux_ppc64le.go
+++ b/virtcontainers/utils/utils_linux_ppc64le.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+// from <linux/vhost.h>
+// VHOST_VSOCK_SET_GUEST_CID = _IOW(VHOST_VIRTIO, 0x60, __u64)
+
+// _IOC_WRITE is 1 for arch generic and 4 for powerpc
+// Code reference: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/powerpc/include/uapi/asm/ioctl.h
+// Explanation: https://github.com/kata-containers/runtime/pull/1989#issuecomment-525993135
+const ioctlVhostVsockSetGuestCid = 0x8008AF60
+
+func getIoctlVhostVsockGuestCid() uintptr {
+	return ioctlVhostVsockSetGuestCid
+}


### PR DESCRIPTION
Set the right VHOST_VSOCK_SET_GUEST_CID when
running on ppc64le arch

Fixes: #1988

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>