### PR TITLE
virtcontainers: Fix the issue of watching console for firecracker

### DIFF
--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -239,7 +239,9 @@ func (p *proxyBuiltin) start(params proxyParams) (int, string, error) {
 
 	p.sandboxID = params.id
 
-	if params.debug {
+	// For firecracker, it hasn't support the console watching and it's consoleURL
+	// will be set empty.
+	if params.debug && params.consoleURL != "" {
 		err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
 		if err != nil {
 			p.sandboxID = ""


### PR DESCRIPTION
Since firecracker hasn't support console watching by now, so skip
watching console if the consoleURL is empty.

Fixes: #1970

Signed-off-by: lifupan <lifupan@gmail.com>