### PR TITLE
qemu: fix error message miss

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -748,7 +748,7 @@ func (q *qemu) startSandbox(timeout int) error {
 	var strErr string
 	strErr, err = govmmQemu.LaunchQemu(q.qemuConfig, newQMPLogger())
 	if err != nil {
-		return fmt.Errorf("%s", strErr)
+		return fmt.Errorf("fail to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}
 
 	err = q.waitSandbox(timeout) // the virtiofsd deferred checks err's value


### PR DESCRIPTION
strErr is qemu log message, should add err in error message, or if fail
before launch qemu, can not get corrent message.

Fixes: #1991

Signed-off-by: Ace-Tang <aceapril@126.com>