### PR TITLE
Virtio-fs v0.3 support

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -59,7 +59,7 @@ var (
 	errorMissingOCISpec         = errors.New("Missing OCI specification")
 	defaultKataHostSharedDir    = "/run/kata-containers/shared/sandboxes/"
 	defaultKataGuestSharedDir   = "/run/kata-containers/shared/containers/"
-	mountGuest9pTag             = "kataShared"
+	mountGuestTag               = "kataShared"
 	defaultKataGuestSandboxDir  = "/run/kata-containers/sandbox/"
 	type9pFs                    = "9p"
 	typeVirtioFS                = "virtio_fs"
@@ -72,7 +72,7 @@ var (
 	kataNvdimmDevType           = "nvdimm"
 	kataVirtioFSDevType         = "virtio-fs"
 	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
-	sharedDirVirtioFSOptions    = []string{"default_permissions,allow_other,rootmode=040000,user_id=0,group_id=0,dax,tag=" + mountGuest9pTag, "nodev"}
+	sharedDirVirtioFSOptions    = []string{"default_permissions,allow_other,rootmode=040000,user_id=0,group_id=0", "nodev"}
 	sharedDirVirtioFSDaxOptions = "dax"
 	shmDir                      = "shm"
 	kataEphemeralDevType        = "ephemeral"
@@ -401,7 +401,7 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 	// Create shared directory and add the shared volume if filesystem sharing is supported.
 	// This volume contains all bind mounted container bundles.
 	sharedVolume := types.Volume{
-		MountTag: mountGuest9pTag,
+		MountTag: mountGuestTag,
 		HostPath: sharePath,
 	}
 
@@ -872,7 +872,7 @@ func setupStorages(sandbox *Sandbox) []*grpc.Storage {
 			}
 			sharedVolume := &grpc.Storage{
 				Driver:     kataVirtioFSDevType,
-				Source:     "none",
+				Source:     mountGuestTag,
 				MountPoint: kataGuestSharedDir(),
 				Fstype:     typeVirtioFS,
 				Options:    sharedDirVirtioFSOptions,
@@ -884,7 +884,7 @@ func setupStorages(sandbox *Sandbox) []*grpc.Storage {
 
 			sharedVolume := &grpc.Storage{
 				Driver:     kata9pDevType,
-				Source:     mountGuest9pTag,
+				Source:     mountGuestTag,
 				MountPoint: kataGuestSharedDir(),
 				Fstype:     type9pFs,
 				Options:    sharedDir9pOptions,

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -611,7 +611,8 @@ func (q *qemu) virtiofsdArgs(fd uintptr) []string {
 	args := []string{
 		fmt.Sprintf("--fd=%v", fd),
 		"-o", "source=" + sourcePath,
-		"-o", "cache=" + q.config.VirtioFSCache}
+		"-o", "cache=" + q.config.VirtioFSCache,
+		"--syslog"}
 	if q.config.Debug {
 		args = append(args, "-d")
 	} else {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -612,7 +612,7 @@ func (q *qemu) virtiofsdArgs(fd uintptr) []string {
 		fmt.Sprintf("--fd=%v", fd),
 		"-o", "source=" + sourcePath,
 		"-o", "cache=" + q.config.VirtioFSCache,
-		"--syslog"}
+		"--syslog", "-o", "no_posix_lock"}
 	if q.config.Debug {
 		args = append(args, "-d")
 	} else {

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	govmmQemu "github.com/intel/govmm/qemu"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
@@ -503,34 +502,14 @@ func TestQemuVirtiofsdArgs(t *testing.T) {
 		kataHostSharedDir = savedKataHostSharedDir
 	}()
 
-	result := "-o vhost_user_socket=bar1 -o source=test-share-dir/foo -o cache=none -d"
-	args := q.virtiofsdArgs("bar1")
+	result := "--fd=123 -o source=test-share-dir/foo -o cache=none -d"
+	args := q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 
 	q.config.Debug = false
-	result = "-o vhost_user_socket=bar2 -o source=test-share-dir/foo -o cache=none -f"
-	args = q.virtiofsdArgs("bar2")
+	result = "--fd=123 -o source=test-share-dir/foo -o cache=none -f"
+	args = q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
-}
-
-func TestQemuWaitVirtiofsd(t *testing.T) {
-	assert := assert.New(t)
-
-	q := &qemu{}
-
-	ready := make(chan error, 1)
-	timeout := 5
-
-	ready <- nil
-	remain, err := q.waitVirtiofsd(time.Now(), timeout, ready, "")
-	assert.Nil(err)
-	assert.True(remain <= timeout)
-	assert.True(remain >= 0)
-
-	timeout = 0
-	remain, err = q.waitVirtiofsd(time.Now(), timeout, ready, "")
-	assert.NotNil(err)
-	assert.True(remain == 0)
 }
 
 func TestQemuGetpids(t *testing.T) {

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -502,12 +502,12 @@ func TestQemuVirtiofsdArgs(t *testing.T) {
 		kataHostSharedDir = savedKataHostSharedDir
 	}()
 
-	result := "--fd=123 -o source=test-share-dir/foo -o cache=none -d"
+	result := "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -d"
 	args := q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 
 	q.config.Debug = false
-	result = "--fd=123 -o source=test-share-dir/foo -o cache=none -f"
+	result = "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -f"
 	args = q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 }

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -502,12 +502,12 @@ func TestQemuVirtiofsdArgs(t *testing.T) {
 		kataHostSharedDir = savedKataHostSharedDir
 	}()
 
-	result := "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -d"
+	result := "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -o no_posix_lock -d"
 	args := q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 
 	q.config.Debug = false
-	result = "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -f"
+	result = "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -o no_posix_lock -f"
 	args = q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 }


### PR DESCRIPTION
These patches are needed if Kata decides to update to a virtio-fs v0.3 kernel.  They are not compatible with virtio-fs v0.2, so only apply them if the guest kernel is updated.

Fixes: #1993