### PR TITLE
Fix the issue of update resources wrong

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1138,10 +1138,6 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 		return nil, err
 	}
 
-	if err := s.store.Store(store.Configuration, *(s.config)); err != nil {
-		return nil, err
-	}
-
 	if err := s.updateCgroups(); err != nil {
 		return nil, err
 	}
@@ -1240,11 +1236,6 @@ func (s *Sandbox) DeleteContainer(containerID string) (VCContainer, error) {
 			s.config.Containers = append(s.config.Containers[:idx], s.config.Containers[idx+1:]...)
 			break
 		}
-	}
-
-	// Store sandbox config
-	if err := s.store.Store(store.Configuration, *(s.config)); err != nil {
-		return nil, err
 	}
 
 	if err = s.storeSandbox(); err != nil {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1116,6 +1116,13 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	// Update sandbox config.
 	s.config.Containers = append(s.config.Containers, contConfig)
 
+	defer func() {
+		if err != nil && len(s.config.Containers) > 0 {
+			// delete container config
+			s.config.Containers = s.config.Containers[:len(s.config.Containers)-1]
+		}
+	}()
+
 	// Sandbox is reponsable to update VM resources needed by Containers
 	err = s.updateResources()
 	if err != nil {
@@ -1128,7 +1135,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	}
 
 	// Add the container to the containers list in the sandbox.
-	if err := s.addContainer(c); err != nil {
+	if err = s.addContainer(c); err != nil {
 		return nil, err
 	}
 
@@ -1138,7 +1145,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 		return nil, err
 	}
 
-	if err := s.updateCgroups(); err != nil {
+	if err = s.updateCgroups(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -909,6 +909,12 @@ func TestCreateContainer(t *testing.T) {
 	contConfig := newTestContainerConfigNoop(contID)
 	_, err = s.CreateContainer(contConfig)
 	assert.Nil(t, err, "Failed to create container %+v in sandbox %+v: %v", contConfig, s, err)
+
+	assert.Equal(t, len(s.config.Containers), 1, "Container config list length from sandbox structure should be 1")
+
+	_, err = s.CreateContainer(contConfig)
+	assert.NotNil(t, err, "Should failed to create a duplicated container")
+	assert.Equal(t, len(s.config.Containers), 1, "Container config list length from sandbox structure should be 1")
 }
 
 func TestDeleteContainer(t *testing.T) {


### PR DESCRIPTION
When create container failed, it should delete the container
config from sandbox, otherwise, the following new creating container
 would get a wrong resources caculating which would contain the previous
 failed container resources such as memory and cpu.

Fixes: #1997