### PR TITLE
v2: Prevent killing all container processes when exec is failed

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -675,6 +675,14 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *ptypes.E
 			return nil, err
 		}
 		processID = execs.id
+		if processID == "" {
+			logrus.WithFields(logrus.Fields{
+				"sandbox":   s.sandbox.ID(),
+				"Container": c.id,
+				"ExecID":    r.ExecID,
+			}).Debug("Id of exec process to be signalled is empty")
+			return empty, errors.New("The exec process does not exist")
+		}
 	}
 
 	return empty, s.sandbox.SignalProcess(c.id, processID, signum, r.All)


### PR DESCRIPTION
If an exec is failed(such as executable file not found in $PATH), the `execs.id` will be empty. This leads to all the container processes being killed when calling `Kill` on such exec id.

Fixes: #2001
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>