### PR TITLE
vc: Use BlockIndexMap instead of BlockIndex

### DIFF
--- a/virtcontainers/acrn_test.go
+++ b/virtcontainers/acrn_test.go
@@ -226,6 +226,7 @@ func TestAcrnCreateSandbox(t *testing.T) {
 		config: &SandboxConfig{
 			HypervisorConfig: acrnConfig,
 		},
+		state: types.SandboxState{BlockIndexMap: make(map[int]struct{})},
 	}
 
 	err = globalSandboxList.addSandbox(sandbox)

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -535,6 +535,7 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 		ID: testSandboxID,
 		State: types.SandboxState{
 			State:          types.StateReady,
+			BlockIndexMap:  make(map[int]struct{}),
 			PersistVersion: 2,
 		},
 		Hypervisor:       MockHypervisor,
@@ -594,6 +595,7 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 		ID: testSandboxID,
 		State: types.SandboxState{
 			State:          types.StateRunning,
+			BlockIndexMap:  make(map[int]struct{}),
 			PersistVersion: 2,
 		},
 		Hypervisor:       MockHypervisor,

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -34,7 +34,7 @@ type DeviceReceiver interface {
 
 	// this is only for virtio-blk and virtio-scsi support
 	GetAndSetSandboxBlockIndex() (int, error)
-	DecrementSandboxBlockIndex() error
+	UnsetSandboxBlockIndex(int) error
 	GetHypervisorType() string
 
 	// this is for appending device to hypervisor boot params

--- a/virtcontainers/device/api/mockDeviceReceiver.go
+++ b/virtcontainers/device/api/mockDeviceReceiver.go
@@ -28,7 +28,7 @@ func (mockDC *MockDeviceReceiver) GetAndSetSandboxBlockIndex() (int, error) {
 }
 
 // DecrementSandboxBlockIndex decreases virtio-blk index by one
-func (mockDC *MockDeviceReceiver) DecrementSandboxBlockIndex() error {
+func (mockDC *MockDeviceReceiver) UnsetSandboxBlockIndex(int) error {
 	return nil
 }
 

--- a/virtcontainers/device/drivers/block.go
+++ b/virtcontainers/device/drivers/block.go
@@ -51,7 +51,7 @@ func (device *BlockDevice) Attach(devReceiver api.DeviceReceiver) (err error) {
 
 	defer func() {
 		if err != nil {
-			devReceiver.DecrementSandboxBlockIndex()
+			devReceiver.UnsetSandboxBlockIndex(index)
 			device.bumpAttachCount(false)
 		}
 	}()
@@ -127,6 +127,8 @@ func (device *BlockDevice) Detach(devReceiver api.DeviceReceiver) error {
 	defer func() {
 		if err != nil {
 			device.bumpAttachCount(true)
+		} else {
+			devReceiver.UnsetSandboxBlockIndex(device.BlockDrive.Index)
 		}
 	}()
 

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -63,8 +63,8 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 
 func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState) {
 	ss.HypervisorState = s.hypervisor.save()
-	// BlockIndex will be moved from sandbox state to hypervisor state later
-	ss.HypervisorState.BlockIndex = s.state.BlockIndex
+	// BlockIndexMap will be moved from sandbox state to hypervisor state later
+	ss.HypervisorState.BlockIndexMap = s.state.BlockIndexMap
 }
 
 func deviceToDeviceState(devices []api.Device) (dss []persistapi.DeviceState) {
@@ -318,7 +318,7 @@ func (s *Sandbox) Save() error {
 func (s *Sandbox) loadState(ss persistapi.SandboxState) {
 	s.state.PersistVersion = ss.PersistVersion
 	s.state.GuestMemoryBlockSizeMB = ss.GuestMemoryBlockSizeMB
-	s.state.BlockIndex = ss.HypervisorState.BlockIndex
+	s.state.BlockIndexMap = ss.HypervisorState.BlockIndexMap
 	s.state.State = types.StateString(ss.State)
 	s.state.CgroupPath = ss.CgroupPath
 	s.state.CgroupPaths = ss.CgroupPaths

--- a/virtcontainers/persist/api/hypervisor.go
+++ b/virtcontainers/persist/api/hypervisor.go
@@ -29,9 +29,9 @@ type CPUDevice struct {
 type HypervisorState struct {
 	Pid int
 	// Type of hypervisor, E.g. qemu/firecracker/acrn.
-	Type       string
-	BlockIndex int
-	UUID       string
+	Type          string
+	BlockIndexMap map[int]struct{}
+	UUID          string
 
 	// Belows are qemu specific
 	// Refs: virtcontainers/qemu.go:QemuState

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1151,6 +1151,7 @@ func TestAttachBlockDevice(t *testing.T) {
 		hypervisor: hypervisor,
 		config:     sconfig,
 		ctx:        context.Background(),
+		state:      types.SandboxState{BlockIndexMap: make(map[int]struct{})},
 	}
 
 	contID := "100"
@@ -1180,11 +1181,21 @@ func TestAttachBlockDevice(t *testing.T) {
 	assert.True(t, ok)
 
 	container.state.State = ""
+	index, err := sandbox.getAndSetSandboxBlockIndex()
+	assert.Nil(t, err)
+	assert.Equal(t, index, 0)
+
 	err = device.Attach(sandbox)
 	assert.Nil(t, err)
+	index, err = sandbox.getAndSetSandboxBlockIndex()
+	assert.Nil(t, err)
+	assert.Equal(t, index, 2)
 
 	err = device.Detach(sandbox)
 	assert.Nil(t, err)
+	index, err = sandbox.getAndSetSandboxBlockIndex()
+	assert.Nil(t, err)
+	assert.Equal(t, index, 1)
 
 	container.state.State = types.StateReady
 	err = device.Attach(sandbox)
@@ -1227,6 +1238,7 @@ func TestPreAddDevice(t *testing.T) {
 		config:     sconfig,
 		devManager: dm,
 		ctx:        context.Background(),
+		state:      types.SandboxState{BlockIndexMap: make(map[int]struct{})},
 	}
 
 	contID := "100"

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -39,8 +39,8 @@ const (
 type SandboxState struct {
 	State StateString `json:"state"`
 
-	// Index of the block device passed to hypervisor.
-	BlockIndex int `json:"blockIndex"`
+	// Index map of the block device passed to hypervisor.
+	BlockIndexMap map[int]struct{} `json:"blockIndexMap"`
 
 	// GuestMemoryBlockSizeMB is the size of memory block of guestos
 	GuestMemoryBlockSizeMB uint32 `json:"guestMemoryBlockSize"`


### PR DESCRIPTION
This allows to reuse detached block index and ensures that the index will not reach the limit of device(such as `maxSCSIDevices`) after restarting containers many times in one pod.

I'm not sure whether it is ok to reuse the index for all the block drivers and would this change break the persist feature. 

Fixes: #2007
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>