### PR TITLE
Stable 1.8 backports2

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -674,6 +674,14 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *ptypes.E
 			return nil, err
 		}
 		processID = execs.id
+		if processID == "" {
+			logrus.WithFields(logrus.Fields{
+				"sandbox":   s.sandbox.ID(),
+				"Container": c.id,
+				"ExecID":    r.ExecID,
+			}).Debug("Id of exec process to be signalled is empty")
+			return empty, errors.New("The exec process does not exist")
+		}
 	}
 
 	return empty, s.sandbox.SignalProcess(c.id, processID, signum, r.All)

--- a/pkg/katautils/create.go
+++ b/pkg/katautils/create.go
@@ -20,10 +20,6 @@ var GetKernelParamsFunc = getKernelParams
 
 var systemdKernelParam = []vc.Param{
 	{
-		Key:   "init",
-		Value: "/usr/lib/systemd/systemd",
-	},
-	{
 		Key:   "systemd.unit",
 		Value: systemdUnitName,
 	},

--- a/versions.yaml
+++ b/versions.yaml
@@ -164,7 +164,7 @@ assets:
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
     uscan-url: >-
       https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-(4\.19\..+)\.tar\.gz
-    version: "v4.19.52"
+    version: "v4.19.65"
 
 components:
   description: "Core system functionality"

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -65,11 +65,9 @@ func CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	return s, err
 }
 
-func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (_ *Sandbox, err error) {
 	span, ctx := trace(ctx, "createSandboxFromConfig")
 	defer span.Finish()
-
-	var err error
 
 	// Create the sandbox.
 	s, err := createSandbox(ctx, sandboxConfig, factory)
@@ -91,7 +89,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 
 	// network rollback
 	defer func() {
-		if err != nil && s.networkNS.NetNsCreated {
+		if err != nil {
 			s.removeNetwork()
 		}
 	}()

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1202,8 +1202,8 @@ func (c *Container) pause() error {
 		return err
 	}
 
-	if c.state.State != types.StateRunning && c.state.State != types.StateReady {
-		return fmt.Errorf("Container not running or ready, impossible to pause")
+	if c.state.State != types.StateRunning {
+		return fmt.Errorf("Container not running, impossible to pause")
 	}
 
 	if err := c.sandbox.agent.pauseContainer(c.sandbox, *c); err != nil {

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -54,6 +54,7 @@ const (
 
 var (
 	checkRequestTimeout   = 30 * time.Second
+	defaultRequestTimeout = 60 * time.Second
 	defaultKataSocketName = "kata.sock"
 	defaultKataChannel    = "agent.channel.0"
 	defaultKataDeviceID   = "channel0"
@@ -94,6 +95,38 @@ const (
 
 	defaultAgentTraceMode = agentTraceModeDynamic
 	defaultAgentTraceType = agentTraceTypeIsolated
+)
+
+const (
+	grpcCheckRequest             = "grpc.CheckRequest"
+	grpcExecProcessRequest       = "grpc.ExecProcessRequest"
+	grpcCreateSandboxRequest     = "grpc.CreateSandboxRequest"
+	grpcDestroySandboxRequest    = "grpc.DestroySandboxRequest"
+	grpcCreateContainerRequest   = "grpc.CreateContainerRequest"
+	grpcStartContainerRequest    = "grpc.StartContainerRequest"
+	grpcRemoveContainerRequest   = "grpc.RemoveContainerRequest"
+	grpcSignalProcessRequest     = "grpc.SignalProcessRequest"
+	grpcUpdateRoutesRequest      = "grpc.UpdateRoutesRequest"
+	grpcUpdateInterfaceRequest   = "grpc.UpdateInterfaceRequest"
+	grpcListInterfacesRequest    = "grpc.ListInterfacesRequest"
+	grpcListRoutesRequest        = "grpc.ListRoutesRequest"
+	grpcOnlineCPUMemRequest      = "grpc.OnlineCPUMemRequest"
+	grpcListProcessesRequest     = "grpc.ListProcessesRequest"
+	grpcUpdateContainerRequest   = "grpc.UpdateContainerRequest"
+	grpcWaitProcessRequest       = "grpc.WaitProcessRequest"
+	grpcTtyWinResizeRequest      = "grpc.TtyWinResizeRequest"
+	grpcWriteStreamRequest       = "grpc.WriteStreamRequest"
+	grpcCloseStdinRequest        = "grpc.CloseStdinRequest"
+	grpcStatsContainerRequest    = "grpc.StatsContainerRequest"
+	grpcPauseContainerRequest    = "grpc.PauseContainerRequest"
+	grpcResumeContainerRequest   = "grpc.ResumeContainerRequest"
+	grpcReseedRandomDevRequest   = "grpc.ReseedRandomDevRequest"
+	grpcGuestDetailsRequest      = "grpc.GuestDetailsRequest"
+	grpcMemHotplugByProbeRequest = "grpc.MemHotplugByProbeRequest"
+	grpcCopyFileRequest          = "grpc.CopyFileRequest"
+	grpcSetGuestDateTimeRequest  = "grpc.SetGuestDateTimeRequest"
+	grpcStartTracingRequest      = "grpc.StartTracingRequest"
+	grpcStopTracingRequest       = "grpc.StopTracingRequest"
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -1687,95 +1720,107 @@ type reqFunc func(context.Context, interface{}, ...golangGrpc.CallOption) (inter
 
 func (k *kataAgent) installReqFunc(c *kataclient.AgentClient) {
 	k.reqHandlers = make(map[string]reqFunc)
-	k.reqHandlers["grpc.CheckRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
-		ctx, cancel := context.WithTimeout(ctx, checkRequestTimeout)
-		defer cancel()
+	k.reqHandlers[grpcCheckRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.Check(ctx, req.(*grpc.CheckRequest), opts...)
 	}
-	k.reqHandlers["grpc.ExecProcessRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcExecProcessRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ExecProcess(ctx, req.(*grpc.ExecProcessRequest), opts...)
 	}
-	k.reqHandlers["grpc.CreateSandboxRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcCreateSandboxRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.CreateSandbox(ctx, req.(*grpc.CreateSandboxRequest), opts...)
 	}
-	k.reqHandlers["grpc.DestroySandboxRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcDestroySandboxRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.DestroySandbox(ctx, req.(*grpc.DestroySandboxRequest), opts...)
 	}
-	k.reqHandlers["grpc.CreateContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcCreateContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.CreateContainer(ctx, req.(*grpc.CreateContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.StartContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcStartContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.StartContainer(ctx, req.(*grpc.StartContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.RemoveContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcRemoveContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.RemoveContainer(ctx, req.(*grpc.RemoveContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.SignalProcessRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcSignalProcessRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.SignalProcess(ctx, req.(*grpc.SignalProcessRequest), opts...)
 	}
-	k.reqHandlers["grpc.UpdateRoutesRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcUpdateRoutesRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.UpdateRoutes(ctx, req.(*grpc.UpdateRoutesRequest), opts...)
 	}
-	k.reqHandlers["grpc.UpdateInterfaceRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcUpdateInterfaceRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.UpdateInterface(ctx, req.(*grpc.UpdateInterfaceRequest), opts...)
 	}
-	k.reqHandlers["grpc.ListInterfacesRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcListInterfacesRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ListInterfaces(ctx, req.(*grpc.ListInterfacesRequest), opts...)
 	}
-	k.reqHandlers["grpc.ListRoutesRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcListRoutesRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ListRoutes(ctx, req.(*grpc.ListRoutesRequest), opts...)
 	}
-	k.reqHandlers["grpc.OnlineCPUMemRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcOnlineCPUMemRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.OnlineCPUMem(ctx, req.(*grpc.OnlineCPUMemRequest), opts...)
 	}
-	k.reqHandlers["grpc.ListProcessesRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcListProcessesRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ListProcesses(ctx, req.(*grpc.ListProcessesRequest), opts...)
 	}
-	k.reqHandlers["grpc.UpdateContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcUpdateContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.UpdateContainer(ctx, req.(*grpc.UpdateContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.WaitProcessRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcWaitProcessRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.WaitProcess(ctx, req.(*grpc.WaitProcessRequest), opts...)
 	}
-	k.reqHandlers["grpc.TtyWinResizeRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcTtyWinResizeRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.TtyWinResize(ctx, req.(*grpc.TtyWinResizeRequest), opts...)
 	}
-	k.reqHandlers["grpc.WriteStreamRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcWriteStreamRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.WriteStdin(ctx, req.(*grpc.WriteStreamRequest), opts...)
 	}
-	k.reqHandlers["grpc.CloseStdinRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcCloseStdinRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.CloseStdin(ctx, req.(*grpc.CloseStdinRequest), opts...)
 	}
-	k.reqHandlers["grpc.StatsContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcStatsContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.StatsContainer(ctx, req.(*grpc.StatsContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.PauseContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcPauseContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.PauseContainer(ctx, req.(*grpc.PauseContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.ResumeContainerRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcResumeContainerRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ResumeContainer(ctx, req.(*grpc.ResumeContainerRequest), opts...)
 	}
-	k.reqHandlers["grpc.ReseedRandomDevRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcReseedRandomDevRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.ReseedRandomDev(ctx, req.(*grpc.ReseedRandomDevRequest), opts...)
 	}
-	k.reqHandlers["grpc.GuestDetailsRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcGuestDetailsRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.GetGuestDetails(ctx, req.(*grpc.GuestDetailsRequest), opts...)
 	}
-	k.reqHandlers["grpc.MemHotplugByProbeRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcMemHotplugByProbeRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.MemHotplugByProbe(ctx, req.(*grpc.MemHotplugByProbeRequest), opts...)
 	}
-	k.reqHandlers["grpc.CopyFileRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcCopyFileRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.CopyFile(ctx, req.(*grpc.CopyFileRequest), opts...)
 	}
-	k.reqHandlers["grpc.SetGuestDateTimeRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcSetGuestDateTimeRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.SetGuestDateTime(ctx, req.(*grpc.SetGuestDateTimeRequest), opts...)
 	}
-	k.reqHandlers["grpc.StartTracingRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcStartTracingRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.StartTracing(ctx, req.(*grpc.StartTracingRequest), opts...)
 	}
-	k.reqHandlers["grpc.StopTracingRequest"] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
+	k.reqHandlers[grpcStopTracingRequest] = func(ctx context.Context, req interface{}, opts ...golangGrpc.CallOption) (interface{}, error) {
 		return k.client.StopTracing(ctx, req.(*grpc.StopTracingRequest), opts...)
 	}
+}
+
+func (k *kataAgent) getReqContext(reqName string) (ctx context.Context, cancel context.CancelFunc) {
+	ctx = context.Background()
+	switch reqName {
+	case grpcWaitProcessRequest:
+		// Wait has no timeout
+	case grpcCheckRequest:
+		ctx, cancel = context.WithTimeout(ctx, checkRequestTimeout)
+	default:
+		ctx, cancel = context.WithTimeout(ctx, defaultRequestTimeout)
+	}
+
+	return ctx, cancel
 }
 
 func (k *kataAgent) sendReq(request interface{}) (interface{}, error) {
@@ -1803,9 +1848,13 @@ func (k *kataAgent) sendReq(request interface{}) (interface{}, error) {
 		return nil, errors.New("Invalid request type")
 	}
 	message := request.(proto.Message)
+	ctx, cancel := k.getReqContext(msgName)
+	if cancel != nil {
+		defer cancel()
+	}
 	k.Logger().WithField("name", msgName).WithField("req", message.String()).Debug("sending request")
 
-	return handler(k.ctx, request)
+	return handler(ctx, request)
 }
 
 // readStdout and readStderr are special that we cannot differentiate them with the request types...

--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -344,6 +344,9 @@ func TestIsEphemeralStorage(t *testing.T) {
 // or directory attempting to be unmounted doesn't exist, then it
 // is not considered an error
 func TestBindUnmountContainerRootfsENOENTNotError(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test disabled as requires root user")
+	}
 	testMnt := "/tmp/test_mount"
 	sID := "sandIDTest"
 	cID := "contIDTest"

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1476,22 +1476,16 @@ func (n *Network) PostAdd(ctx context.Context, ns *NetworkNamespace, hotplug boo
 
 // Remove network endpoints in the network namespace. It also deletes the network
 // namespace in case the namespace has been created by us.
-func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor, hotunplug bool) error {
+func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor) error {
 	span, _ := n.trace(ctx, "remove")
 	defer span.Finish()
 
 	for _, endpoint := range ns.Endpoints {
 		// Detach for an endpoint should enter the network namespace
 		// if required.
-		networkLogger().WithField("endpoint-type", endpoint.Type()).WithField("hotunplug", hotunplug).Info("Detaching endpoint")
-		if hotunplug {
-			if err := endpoint.HotDetach(hypervisor, ns.NetNsCreated, ns.NetNsPath); err != nil {
-				return err
-			}
-		} else {
-			if err := endpoint.Detach(ns.NetNsCreated, ns.NetNsPath); err != nil {
-				return err
-			}
+		networkLogger().WithField("endpoint-type", endpoint.Type()).Info("Detaching endpoint")
+		if err := endpoint.Detach(ns.NetNsCreated, ns.NetNsPath); err != nil {
+			return err
 		}
 	}
 

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -727,7 +727,7 @@ func (q *qemu) startSandbox(timeout int) error {
 	var strErr string
 	strErr, err = govmmQemu.LaunchQemu(q.qemuConfig, newQMPLogger())
 	if err != nil {
-		return fmt.Errorf("%s", strErr)
+		return fmt.Errorf("fail to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}
 
 	err = q.waitSandbox(timeout) // the virtiofsd deferred checks err's value

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -91,6 +91,8 @@ type qemu struct {
 	ctx context.Context
 
 	nvdimmCount int
+
+	stopped bool
 }
 
 const (
@@ -821,8 +823,16 @@ func (q *qemu) stopSandbox() error {
 	span, _ := q.trace("stopSandbox")
 	defer span.Finish()
 
-	defer q.cleanupVM()
 	q.Logger().Info("Stopping Sandbox")
+	if q.stopped {
+		q.Logger().Info("Already stopped")
+		return nil
+	}
+
+	defer func() {
+		q.cleanupVM()
+		q.stopped = true
+	}()
 
 	err := q.qmpSetup()
 	if err != nil {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -968,9 +968,7 @@ func (q *qemu) removeDeviceFromBridge(ID string) error {
 	return err
 }
 
-func (q *qemu) hotplugAddBlockDevice(drive *config.BlockDrive, op operation, devID string) error {
-	var err error
-
+func (q *qemu) hotplugAddBlockDevice(drive *config.BlockDrive, op operation, devID string) (err error) {
 	if q.config.BlockDeviceDriver == config.Nvdimm {
 		var blocksize int64
 		file, err := os.Open(drive.File)
@@ -998,12 +996,24 @@ func (q *qemu) hotplugAddBlockDevice(drive *config.BlockDrive, op operation, dev
 		return err
 	}
 
+	defer func() {
+		if err != nil {
+			q.qmpMonitorCh.qmp.ExecuteBlockdevDel(q.qmpMonitorCh.ctx, drive.ID)
+		}
+	}()
+
 	if q.config.BlockDeviceDriver == config.VirtioBlock {
 		driver := "virtio-blk-pci"
 		addr, bridge, err := q.addDeviceToBridge(drive.ID)
 		if err != nil {
 			return err
 		}
+
+		defer func() {
+			if err != nil {
+				q.removeDeviceFromBridge(drive.ID)
+			}
+		}()
 
 		// PCI address is in the format bridge-addr/device-addr eg. "03/02"
 		drive.PCIAddr = fmt.Sprintf("%02x", bridge.Addr) + "/" + addr
@@ -1060,8 +1070,8 @@ func (q *qemu) hotplugBlockDevice(drive *config.BlockDrive, op operation) error 
 	return err
 }
 
-func (q *qemu) hotplugVFIODevice(device *config.VFIODev, op operation) error {
-	err := q.qmpSetup()
+func (q *qemu) hotplugVFIODevice(device *config.VFIODev, op operation) (err error) {
+	err = q.qmpSetup()
 	if err != nil {
 		return err
 	}
@@ -1087,6 +1097,12 @@ func (q *qemu) hotplugVFIODevice(device *config.VFIODev, op operation) error {
 		if err != nil {
 			return err
 		}
+
+		defer func() {
+			if err != nil {
+				q.removeDeviceFromBridge(devID)
+			}
+		}()
 
 		switch device.Type {
 		case config.VFIODeviceNormalType:
@@ -1134,8 +1150,8 @@ func (q *qemu) hotAddNetDevice(name, hardAddr string, VMFds, VhostFds []*os.File
 	return q.qmpMonitorCh.qmp.ExecuteNetdevAddByFds(q.qmpMonitorCh.ctx, "tap", name, VMFdNames, VhostFdNames)
 }
 
-func (q *qemu) hotplugNetDevice(endpoint Endpoint, op operation) error {
-	err := q.qmpSetup()
+func (q *qemu) hotplugNetDevice(endpoint Endpoint, op operation) (err error) {
+	err = q.qmpSetup()
 	if err != nil {
 		return err
 	}
@@ -1154,15 +1170,27 @@ func (q *qemu) hotplugNetDevice(endpoint Endpoint, op operation) error {
 
 	devID := "virtio-" + tap.ID
 	if op == addDevice {
-
 		if err = q.hotAddNetDevice(tap.Name, endpoint.HardwareAddr(), tap.VMFds, tap.VhostFds); err != nil {
 			return err
 		}
+
+		defer func() {
+			if err != nil {
+				q.qmpMonitorCh.qmp.ExecuteNetdevDel(q.qmpMonitorCh.ctx, tap.Name)
+			}
+		}()
 
 		addr, bridge, err := q.addDeviceToBridge(tap.ID)
 		if err != nil {
 			return err
 		}
+
+		defer func() {
+			if err != nil {
+				q.removeDeviceFromBridge(tap.ID)
+			}
+		}()
+
 		pciAddr := fmt.Sprintf("%02x/%s", bridge.Addr, addr)
 		endpoint.SetPciAddr(pciAddr)
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -855,7 +855,7 @@ func (s *Sandbox) removeNetwork() error {
 		}
 	}
 
-	return s.network.Remove(s.ctx, &s.networkNS, s.hypervisor, s.factory != nil)
+	return s.network.Remove(s.ctx, &s.networkNS, s.hypervisor)
 }
 
 func (s *Sandbox) generateNetInfo(inf *vcTypes.Interface) (NetworkInfo, error) {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1092,6 +1092,13 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	// Update sandbox config.
 	s.config.Containers = append(s.config.Containers, contConfig)
 
+	defer func() {
+		if err != nil && len(s.config.Containers) > 0 {
+			// delete container config
+			s.config.Containers = s.config.Containers[:len(s.config.Containers)-1]
+		}
+	}()
+
 	// Sandbox is reponsable to update VM resources needed by Containers
 	err = s.updateResources()
 	if err != nil {
@@ -1104,7 +1111,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	}
 
 	// Add the container to the containers list in the sandbox.
-	if err := s.addContainer(c); err != nil {
+	if err = s.addContainer(c); err != nil {
 		return nil, err
 	}
 
@@ -1114,7 +1121,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 		return nil, err
 	}
 
-	if err := s.updateCgroups(); err != nil {
+	if err = s.updateCgroups(); err != nil {
 		return nil, err
 	}
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1114,10 +1114,6 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 		return nil, err
 	}
 
-	if err := s.store.Store(store.Configuration, *(s.config)); err != nil {
-		return nil, err
-	}
-
 	if err := s.updateCgroups(); err != nil {
 		return nil, err
 	}
@@ -1215,11 +1211,6 @@ func (s *Sandbox) DeleteContainer(containerID string) (VCContainer, error) {
 			s.config.Containers = append(s.config.Containers[:idx], s.config.Containers[idx+1:]...)
 			break
 		}
-	}
-
-	// Store sandbox config
-	if err := s.store.Store(store.Configuration, *(s.config)); err != nil {
-		return nil, err
 	}
 
 	if err = s.storeSandbox(); err != nil {

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1037,6 +1037,12 @@ func TestCreateContainer(t *testing.T) {
 	contConfig := newTestContainerConfigNoop(contID)
 	_, err = s.CreateContainer(contConfig)
 	assert.Nil(t, err, "Failed to create container %+v in sandbox %+v: %v", contConfig, s, err)
+
+	assert.Equal(t, len(s.config.Containers), 1, "Container config list length from sandbox structure should be 1")
+
+	_, err = s.CreateContainer(contConfig)
+	assert.NotNil(t, err, "Should failed to create a duplicated container")
+	assert.Equal(t, len(s.config.Containers), 1, "Container config list length from sandbox structure should be 1")
 }
 
 func TestDeleteContainer(t *testing.T) {

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -1458,6 +1458,9 @@ func TestGetNetNs(t *testing.T) {
 }
 
 func TestStartNetworkMonitor(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test disabled as requires root user")
+	}
 	trueBinPath, err := exec.LookPath("true")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, trueBinPath)


### PR DESCRIPTION
179485f9 v2: Prevent killing all container processes when exec is failed
7e77b754 qemu: fix error message miss
05c8b02f virtcontainers: cleanup the container config once failed
a85252e8 virtcontainers: remove the redundant sandbox config store
5737f803 qemu: do not try to stop qemu multiple times
09036394 agent: add default timeout for grpc requests
6af47f62 network: always cold unplug network devices
7a690b0e container: do not pause a StateReady container
e1be3263 virtcontainers: fix hotplug pci devices execeed max capacity bug
f43e18be versions: kernel: update to 4.19.65
1cf69cd5 network: fix failed to remove network
83bb7b30 pkg/katautils: Do not set `init` in the kernel command line
4179bf7e ut: skip TestBindUnmountContainerRootfsENOENTNotError for non-root
50f48bb8 ut: skip TestStartNetworkMonitor for non-root