### PR TITLE
vc: Delete store when new/create container is failed

### DIFF
--- a/virtcontainers/store/vc.go
+++ b/virtcontainers/store/vc.go
@@ -313,3 +313,9 @@ func VCSandboxStoreExists(ctx context.Context, sandboxID string) bool {
 	s := stores.findStore(SandboxConfigurationRoot(sandboxID))
 	return s != nil
 }
+
+// VCContainerStoreExists returns true if a container store already exists.
+func VCContainerStoreExists(ctx context.Context, sandboxID string, containerID string) bool {
+	s := stores.findStore(ContainerConfigurationRoot(sandboxID, containerID))
+	return s != nil
+}


### PR DESCRIPTION
The container store should be deleted when new/create is failed if the store is newly created.

Fixes: #2013
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>