### PR TITLE
virtcontainers: fix kernel modules annotations

### DIFF
--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -455,9 +455,10 @@ func addAssetAnnotations(ocispec CompatOCISpec, config *vc.SandboxConfig) {
 	}
 
 	if value, ok := ocispec.Annotations[vcAnnotations.KernelModules]; ok {
-		if c, ok := config.AgentConfig.(*vc.KataAgentConfig); ok {
+		if c, ok := config.AgentConfig.(vc.KataAgentConfig); ok {
 			modules := strings.Split(value, KernelModulesSeparator)
 			c.KernelModules = modules
+			config.AgentConfig = c
 		}
 	}
 }


### PR DESCRIPTION
Casting in golang doesn't return a pointer to the structure, instead a new
structure is instantiated. This patch is to update the old structure with
the new one in order to apply the changes.

fixes #2016

Signed-off-by: Julio Montes <julio.montes@intel.com>