### PR TITLE
vendor: update govmm

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -391,11 +391,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:47de8e5ccb45c6f00a2b4a62327601f7884830016267b470b42688f9c82d4b7d"
+  digest = "1:1a7407072d9447e0e39148aa462f0be26261e29ff14679ccee4fbed106c1a766"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "e6644f4a25ae570a6d1c4c6efe6c3be7526bbaa3"
+  revision = "ee460e3008d48043f8561628d1d5308357d72cf6"
 
 [[projects]]
   digest = "1:22e399f891fccaac4700943a9465f2623bb361653d5e0d4a9974573cd5e69070"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "e6644f4a25ae570a6d1c4c6efe6c3be7526bbaa3"
+  revision = "ee460e3008d48043f8561628d1d5308357d72cf6"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -1761,7 +1761,9 @@ func (config *Config) appendMemoryKnobs() {
 	if config.Memory.Size == "" {
 		return
 	}
-
+	if !isDimmSupported() {
+		return
+	}
 	var objMemParam, numaMemParam string
 	dimmName := "dimm1"
 	if config.Knobs.HugePages {

--- a/vendor/github.com/intel/govmm/qemu/qemu_arch_base.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu_arch_base.go
@@ -105,3 +105,7 @@ func (n NetDeviceType) QemuDeviceParam() DeviceDriver {
 
 	}
 }
+
+func isDimmSupported() bool {
+	return true
+}

--- a/vendor/github.com/intel/govmm/qemu/qemus390x.go
+++ b/vendor/github.com/intel/govmm/qemu/qemus390x.go
@@ -134,3 +134,7 @@ func (n NetDeviceType) QemuNetdevParam() string {
 
 	}
 }
+
+func isDimmSupported() bool {
+	return false
+}


### PR DESCRIPTION
s389x doesn't support dimm and we need to skip it.

Fixes: #2003

detail commit change:

9463486 s390x: dimm not supported

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>