### PR TITLE
CompatOCISpec: limit usage of CompatOCISpec

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -118,7 +118,7 @@ func create(ctx context.Context, containerID, bundlePath, console, pidFilePath s
 		return err
 	}
 
-	containerType, err := ociSpec.ContainerType()
+	containerType, err := oci.ContainerType(ociSpec)
 	if err != nil {
 		return err
 	}

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -322,7 +322,7 @@ func TestCreateInvalidContainerType(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force an invalid container type
@@ -367,7 +367,7 @@ func TestCreateContainerInvalid(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 
 	assert.NoError(err)
 
@@ -432,7 +432,7 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -535,7 +535,7 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -622,7 +622,7 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -697,7 +697,7 @@ func TestCreate(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -128,22 +128,20 @@ func TestDeleteInvalidConfig(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 }
 
-func testConfigSetup(t *testing.T) (rootPath string, configPath string) {
+func testConfigSetup(t *testing.T) (rootPath string, bundlePath string) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
 
-	bundlePath := filepath.Join(tmpdir, "bundle")
+	bundlePath = filepath.Join(tmpdir, "bundle")
 	err = os.MkdirAll(bundlePath, testDirMode)
 	assert.NoError(err)
 
 	err = createOCIConfig(bundlePath)
 	assert.NoError(err)
 
-	// config json path
-	configPath = filepath.Join(bundlePath, "config.json")
-	return tmpdir, configPath
+	return tmpdir, bundlePath
 }
 
 func TestDeleteSandbox(t *testing.T) {
@@ -153,9 +151,9 @@ func TestDeleteSandbox(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -231,9 +229,9 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -270,9 +268,9 @@ func TestDeleteSandboxRunning(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -350,9 +348,9 @@ func TestDeleteRunningContainer(t *testing.T) {
 		},
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.MockContainers[0].ID(), sandbox.MockContainers[0].ID())
@@ -433,9 +431,9 @@ func TestDeleteContainer(t *testing.T) {
 		},
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.MockContainers[0].ID(), sandbox.MockContainers[0].ID())
@@ -533,9 +531,9 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 		},
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -23,7 +23,7 @@ import (
 )
 
 type execParams struct {
-	ociProcess   oci.CompatOCIProcess
+	ociProcess   specs.Process
 	cID          string
 	pidFile      string
 	console      string
@@ -119,7 +119,7 @@ EXAMPLE:
 	},
 }
 
-func generateExecParams(context *cli.Context, specProcess *oci.CompatOCIProcess) (execParams, error) {
+func generateExecParams(context *cli.Context, specProcess *specs.Process) (execParams, error) {
 	ctxArgs := context.Args()
 
 	params := execParams{
@@ -133,7 +133,7 @@ func generateExecParams(context *cli.Context, specProcess *oci.CompatOCIProcess)
 	}
 
 	if context.String("process") != "" {
-		var ociProcess oci.CompatOCIProcess
+		var ociProcess specs.Process
 
 		fileContent, err := ioutil.ReadFile(context.String("process"))
 		if err != nil {

--- a/cli/exec_test.go
+++ b/cli/exec_test.go
@@ -14,13 +14,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	vc "github.com/kata-containers/runtime/virtcontainers"
-	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
-	"github.com/kata-containers/runtime/virtcontainers/types"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
+
+	vc "github.com/kata-containers/runtime/virtcontainers"
+	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 func TestExecCLIFunction(t *testing.T) {
@@ -90,9 +91,9 @@ func TestExecuteErrors(t *testing.T) {
 	assert.False(vcmock.IsMockError(err))
 
 	// Container state undefined
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations = map[string]string{
@@ -149,9 +150,9 @@ func TestExecuteErrorReadingProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -198,9 +199,9 @@ func TestExecuteErrorOpeningConsole(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -265,9 +266,9 @@ func TestExecuteWithFlags(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -355,9 +356,9 @@ func TestExecuteWithFlagsDetached(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -434,9 +435,9 @@ func TestExecuteWithInvalidProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -486,9 +487,9 @@ func TestExecuteWithValidProcessJson(t *testing.T) {
 	flagSet.Parse([]string{testContainerID, "/tmp/foo"})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -587,9 +588,9 @@ func TestExecuteWithEmptyEnvironmentValue(t *testing.T) {
 	flagSet.Parse([]string{testContainerID})
 	ctx := createCLIContext(flagSet)
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	annotations := map[string]string{
@@ -698,7 +699,7 @@ func TestGenerateExecParams(t *testing.T) {
 	flagSet.String("apparmor", apparmor, "")
 
 	ctx := createCLIContext(flagSet)
-	process := &oci.CompatOCIProcess{}
+	process := &specs.Process{}
 	params, err := generateExecParams(ctx, process)
 	assert.NoError(err)
 
@@ -771,7 +772,7 @@ func TestGenerateExecParamsWithProcessJsonFile(t *testing.T) {
 
 	defer os.Remove(processPath)
 
-	process := &oci.CompatOCIProcess{}
+	process := &specs.Process{}
 	params, err := generateExecParams(ctx, process)
 	assert.NoError(err)
 

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -150,10 +150,9 @@ func runUnitTests(m *testing.M) {
 	os.Exit(ret)
 }
 
-// Read fail that should contain a CompatOCISpec and
+// Read fail that should contain a specs.Spec and
 // return its JSON representation on success
-func readOCIConfigJSON(configFile string) (string, error) {
-	bundlePath := filepath.Dir(configFile)
+func readOCIConfigJSON(bundlePath string) (string, error) {
 	ociSpec, err := oci.ParseConfigJSON(bundlePath)
 	if err != nil {
 		return "", nil
@@ -400,30 +399,7 @@ func makeOCIBundle(bundleDir string) error {
 	return nil
 }
 
-// readOCIConfig returns an OCI spec.
-func readOCIConfigFile(configPath string) (oci.CompatOCISpec, error) {
-	if configPath == "" {
-		return oci.CompatOCISpec{}, errors.New("BUG: need config file path")
-	}
-
-	data, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		return oci.CompatOCISpec{}, err
-	}
-
-	var ociSpec oci.CompatOCISpec
-	if err := json.Unmarshal(data, &ociSpec); err != nil {
-		return oci.CompatOCISpec{}, err
-	}
-	caps, err := oci.ContainerCapabilities(ociSpec)
-	if err != nil {
-		return oci.CompatOCISpec{}, err
-	}
-	ociSpec.Process.Capabilities = caps
-	return ociSpec, nil
-}
-
-func writeOCIConfigFile(spec oci.CompatOCISpec, configPath string) error {
+func writeOCIConfigFile(spec specs.Spec, configPath string) error {
 	if configPath == "" {
 		return errors.New("BUG: need config file path")
 	}

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -188,9 +188,6 @@ func testRunContainerSetup(t *testing.T) runContainerData {
 	err = makeOCIBundle(bundlePath)
 	assert.NoError(err)
 
-	// config json path
-	configPath := filepath.Join(bundlePath, specConfig)
-
 	// sandbox id and container id must be the same otherwise delete will not works
 	sandbox := &vcmock.Sandbox{
 		MockID: testContainerID,
@@ -208,7 +205,7 @@ func testRunContainerSetup(t *testing.T) runContainerData {
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, consolePath, true)
 	assert.NoError(err)
 
-	configJSON, err := readOCIConfigJSON(configPath)
+	configJSON, err := readOCIConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	return runContainerData{

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -13,13 +13,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
-	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
 )
 
 func TestStartInvalidArgs(t *testing.T) {
@@ -61,7 +62,7 @@ func TestStartSandbox(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(oci.CompatOCISpec{})
+	ociSpecJSON, err := json.Marshal(specs.Spec{})
 	assert.NoError(err)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
@@ -139,7 +140,7 @@ func TestStartContainerSucessFailure(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(oci.CompatOCISpec{})
+	ociSpecJSON, err := json.Marshal(specs.Spec{})
 	assert.NoError(err)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
@@ -217,7 +218,7 @@ func TestStartCLIFunctionSuccess(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(oci.CompatOCISpec{})
+	ociSpecJSON, err := json.Marshal(specs.Spec{})
 	assert.NoError(err)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {

--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -11,15 +11,15 @@ import (
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
+	"github.com/opencontainers/runtime-spec/specs-go"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 )
 
 type container struct {
 	s        *service
 	ttyio    *ttyIO
-	spec     *oci.CompatOCISpec
+	spec     *specs.Spec
 	exitTime time.Time
 	execs    map[string]*exec
 	exitIOch chan struct{}
@@ -35,14 +35,14 @@ type container struct {
 	terminal bool
 }
 
-func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.ContainerType, spec *oci.CompatOCISpec) (*container, error) {
+func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.ContainerType, spec *specs.Spec) (*container, error) {
 	if r == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrInvalidArgument, " CreateTaskRequest points to nil")
 	}
 
 	// in order to avoid deferencing a nil pointer in test
 	if spec == nil {
-		spec = &oci.CompatOCISpec{}
+		spec = &specs.Spec{}
 	}
 
 	c := &container{

--- a/containerd-shim-v2/create.go
+++ b/containerd-shim-v2/create.go
@@ -46,7 +46,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		return nil, err
 	}
 
-	containerType, err := ociSpec.ContainerType()
+	containerType, err := oci.ContainerType(*ociSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 	return container, nil
 }
 
-func loadSpec(r *taskAPI.CreateTaskRequest) (*oci.CompatOCISpec, string, error) {
+func loadSpec(r *taskAPI.CreateTaskRequest) (*specs.Spec, string, error) {
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	bundlePath, err := validBundle(r.ID, r.Bundle)
 	if err != nil {

--- a/containerd-shim-v2/create_test.go
+++ b/containerd-shim-v2/create_test.go
@@ -15,14 +15,14 @@ import (
 
 	"github.com/containerd/containerd/namespaces"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
-
-	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/stretchr/testify/assert"
+	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 )
 
 func TestCreateSandboxSuccess(t *testing.T) {
@@ -62,7 +62,7 @@ func TestCreateSandboxSuccess(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -120,7 +120,7 @@ func TestCreateSandboxFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	err = writeOCIConfigFile(spec, ociConfigFile)
@@ -167,7 +167,7 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	quota := int64(0)
@@ -231,7 +231,7 @@ func TestCreateContainerSuccess(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set expected container type and sandboxID
@@ -280,7 +280,7 @@ func TestCreateContainerFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	spec.Annotations = make(map[string]string)
@@ -340,7 +340,7 @@ func TestCreateContainerConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := readOCIConfigFile(ociConfigFile)
+	spec, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set the error containerType

--- a/containerd-shim-v2/delete_test.go
+++ b/containerd-shim-v2/delete_test.go
@@ -13,8 +13,10 @@ import (
 	"testing"
 
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 )
 
 func TestDeleteContainerSuccessAndFail(t *testing.T) {
@@ -24,9 +26,9 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	rootPath, configPath := testConfigSetup(t)
+	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	_, err := readOCIConfigJSON(configPath)
+	_, err := oci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	s := &service{
@@ -42,20 +44,18 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 	assert.NoError(err)
 }
 
-func testConfigSetup(t *testing.T) (rootPath string, configPath string) {
+func testConfigSetup(t *testing.T) (rootPath string, bundlePath string) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
 
-	bundlePath := filepath.Join(tmpdir, "bundle")
+	bundlePath = filepath.Join(tmpdir, "bundle")
 	err = os.MkdirAll(bundlePath, testDirMode)
 	assert.NoError(err)
 
 	err = createOCIConfig(bundlePath)
 	assert.NoError(err)
 
-	// config json path
-	configPath = filepath.Join(bundlePath, "config.json")
-	return tmpdir, configPath
+	return tmpdir, bundlePath
 }

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -296,7 +296,7 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 		return nil, err
 	}
 
-	containerType, err := ociSpec.ContainerType()
+	containerType, err := oci.ContainerType(ociSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 			return nil, err
 		}
 	case vc.PodContainer:
-		sandboxID, err := ociSpec.SandboxID()
+		sandboxID, err := oci.SandboxID(ociSpec)
 		if err != nil {
 			return nil, err
 		}

--- a/containerd-shim-v2/utils.go
+++ b/containerd-shim-v2/utils.go
@@ -92,13 +92,13 @@ func getAddress(ctx context.Context, bundlePath, id string) (string, error) {
 		return "", err
 	}
 
-	containerType, err := ociSpec.ContainerType()
+	containerType, err := oci.ContainerType(ociSpec)
 	if err != nil {
 		return "", err
 	}
 
 	if containerType == vc.PodContainer {
-		sandboxID, err := ociSpec.SandboxID()
+		sandboxID, err := oci.SandboxID(ociSpec)
 		if err != nil {
 			return "", err
 		}
@@ -124,7 +124,7 @@ func noNeedForOutput(detach bool, tty bool) bool {
 	return true
 }
 
-func removeNamespace(s *oci.CompatOCISpec, nsType specs.LinuxNamespaceType) {
+func removeNamespace(s *specs.Spec, nsType specs.LinuxNamespaceType) {
 	for i, n := range s.Linux.Namespaces {
 		if n.Type == nsType {
 			s.Linux.Namespaces = append(s.Linux.Namespaces[:i], s.Linux.Namespaces[i+1:]...)

--- a/pkg/katautils/hook.go
+++ b/pkg/katautils/hook.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sirupsen/logrus"
@@ -111,7 +110,7 @@ func runHooks(ctx context.Context, hooks []specs.Hook, cid, bundlePath, hookType
 }
 
 // PreStartHooks run the hooks before start container
-func PreStartHooks(ctx context.Context, spec oci.CompatOCISpec, cid, bundlePath string) error {
+func PreStartHooks(ctx context.Context, spec specs.Spec, cid, bundlePath string) error {
 	// If no hook available, nothing needs to be done.
 	if spec.Hooks == nil {
 		return nil
@@ -121,7 +120,7 @@ func PreStartHooks(ctx context.Context, spec oci.CompatOCISpec, cid, bundlePath 
 }
 
 // PostStartHooks run the hooks just after start container
-func PostStartHooks(ctx context.Context, spec oci.CompatOCISpec, cid, bundlePath string) error {
+func PostStartHooks(ctx context.Context, spec specs.Spec, cid, bundlePath string) error {
 	// If no hook available, nothing needs to be done.
 	if spec.Hooks == nil {
 		return nil
@@ -131,7 +130,7 @@ func PostStartHooks(ctx context.Context, spec oci.CompatOCISpec, cid, bundlePath
 }
 
 // PostStopHooks run the hooks after stop container
-func PostStopHooks(ctx context.Context, spec oci.CompatOCISpec, cid, bundlePath string) error {
+func PostStopHooks(ctx context.Context, spec specs.Spec, cid, bundlePath string) error {
 	// If no hook available, nothing needs to be done.
 	if spec.Hooks == nil {
 		return nil

--- a/pkg/katautils/hook_test.go
+++ b/pkg/katautils/hook_test.go
@@ -13,7 +13,6 @@ import (
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	. "github.com/kata-containers/runtime/virtcontainers/pkg/mock"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -96,26 +95,22 @@ func TestPreStartHooks(t *testing.T) {
 	ctx := context.Background()
 
 	// Hooks field is nil
-	spec := oci.CompatOCISpec{}
+	spec := specs.Spec{}
 	err := PreStartHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Hooks list is empty
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{},
-		},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{},
 	}
 	err = PreStartHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Run with timeout 0
 	hook := createHook(0)
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Prestart: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Prestart: []specs.Hook{hook},
 		},
 	}
 	err = PreStartHooks(ctx, spec, testSandboxID, testBundlePath)
@@ -123,11 +118,9 @@ func TestPreStartHooks(t *testing.T) {
 
 	// Failure due to wrong hook
 	hook = createWrongHook()
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Prestart: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Prestart: []specs.Hook{hook},
 		},
 	}
 	err = PreStartHooks(ctx, spec, testSandboxID, testBundlePath)
@@ -144,26 +137,22 @@ func TestPostStartHooks(t *testing.T) {
 	ctx := context.Background()
 
 	// Hooks field is nil
-	spec := oci.CompatOCISpec{}
+	spec := specs.Spec{}
 	err := PostStartHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Hooks list is empty
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{},
-		},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{},
 	}
 	err = PostStartHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Run with timeout 0
 	hook := createHook(0)
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Poststart: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Poststart: []specs.Hook{hook},
 		},
 	}
 	err = PostStartHooks(ctx, spec, testSandboxID, testBundlePath)
@@ -171,11 +160,9 @@ func TestPostStartHooks(t *testing.T) {
 
 	// Failure due to wrong hook
 	hook = createWrongHook()
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Poststart: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Poststart: []specs.Hook{hook},
 		},
 	}
 	err = PostStartHooks(ctx, spec, testSandboxID, testBundlePath)
@@ -192,26 +179,22 @@ func TestPostStopHooks(t *testing.T) {
 	ctx := context.Background()
 
 	// Hooks field is nil
-	spec := oci.CompatOCISpec{}
+	spec := specs.Spec{}
 	err := PostStopHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Hooks list is empty
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{},
-		},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{},
 	}
 	err = PostStopHooks(ctx, spec, "", "")
 	assert.NoError(err)
 
 	// Run with timeout 0
 	hook := createHook(0)
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Poststop: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Poststop: []specs.Hook{hook},
 		},
 	}
 	err = PostStopHooks(ctx, spec, testSandboxID, testBundlePath)
@@ -219,11 +202,9 @@ func TestPostStopHooks(t *testing.T) {
 
 	// Failure due to wrong hook
 	hook = createWrongHook()
-	spec = oci.CompatOCISpec{
-		Spec: specs.Spec{
-			Hooks: &specs.Hooks{
-				Poststop: []specs.Hook{hook},
-			},
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			Poststop: []specs.Hook{hook},
 		},
 	}
 	err = PostStopHooks(ctx, spec, testSandboxID, testBundlePath)

--- a/virtcontainers/types/sandbox.go
+++ b/virtcontainers/types/sandbox.go
@@ -8,6 +8,8 @@ package types
 import (
 	"fmt"
 	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // StateString is a string representing a sandbox state.
@@ -225,21 +227,6 @@ type EnvVar struct {
 	Value string
 }
 
-// LinuxCapabilities specify the capabilities to keep when executing
-// the process inside the container.
-type LinuxCapabilities struct {
-	// Bounding is the set of capabilities checked by the kernel.
-	Bounding []string
-	// Effective is the set of capabilities checked by the kernel.
-	Effective []string
-	// Inheritable is the capabilities preserved across execve.
-	Inheritable []string
-	// Permitted is the limiting superset for effective capabilities.
-	Permitted []string
-	// Ambient is the ambient set of capabilities that are kept.
-	Ambient []string
-}
-
 // Cmd represents a command to execute in a running container.
 type Cmd struct {
 	Args                []string
@@ -272,7 +259,7 @@ type Cmd struct {
 	PrimaryGroup string
 	WorkDir      string
 	Console      string
-	Capabilities LinuxCapabilities
+	Capabilities *specs.LinuxCapabilities
 
 	Interactive     bool
 	Detach          bool


### PR DESCRIPTION
Fixes: #2023 

CompatOCISpec is used to gurantee backward compatbility for old runtime
specs, after we convert CompatOCISpec to standard specs.Spec, we should
use specs.Spec instead of CompatOCISpec, and CompatOCISpec should be
useless from then.

Spread usage of CompatOCISpec can make code structure confusing and making
the runtime spec usage non-standard. Besides, this can be the very first
step of removing CompatOCISpec from config's Annotations field.

Signed-off-by: Wei Zhang <weizhang555.zw@gmail.com>