### PR TITLE
Remove annotation config json key

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/urfave/cli"
 )
@@ -113,7 +114,7 @@ func create(ctx context.Context, containerID, bundlePath, console, pidFilePath s
 		return err
 	}
 
-	ociSpec, err := oci.ParseConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	if err != nil {
 		return err
 	}

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -18,6 +18,7 @@ import (
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -322,7 +323,7 @@ func TestCreateInvalidContainerType(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force an invalid container type
@@ -367,7 +368,7 @@ func TestCreateContainerInvalid(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 
 	assert.NoError(err)
 
@@ -432,7 +433,7 @@ func TestCreateProcessCgroupsPathSuccessful(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -535,7 +536,7 @@ func TestCreateCreateCgroupsFilesFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -622,7 +623,7 @@ func TestCreateCreateCreatePidFileFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -697,7 +698,7 @@ func TestCreate(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -13,13 +13,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	"github.com/kata-containers/runtime/virtcontainers/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
 )
 
 func testRemoveCgroupsPathSuccessful(t *testing.T, cgroupsPathList []string) {
@@ -153,7 +155,8 @@ func TestDeleteSandbox(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -165,11 +168,11 @@ func TestDeleteSandbox(t *testing.T) {
 			ID: sandbox.ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "ready",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 
@@ -231,7 +234,7 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -243,11 +246,11 @@ func TestDeleteInvalidContainerType(t *testing.T) {
 			ID: sandbox.ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: "InvalidType",
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "created",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 
@@ -270,7 +273,7 @@ func TestDeleteSandboxRunning(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -282,11 +285,11 @@ func TestDeleteSandboxRunning(t *testing.T) {
 			ID: sandbox.ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "running",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 
@@ -350,7 +353,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.MockContainers[0].ID(), sandbox.MockContainers[0].ID())
@@ -362,11 +365,11 @@ func TestDeleteRunningContainer(t *testing.T) {
 			ID: sandbox.MockContainers[0].ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "running",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 
@@ -433,7 +436,7 @@ func TestDeleteContainer(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.MockContainers[0].ID(), sandbox.MockContainers[0].ID())
@@ -445,11 +448,11 @@ func TestDeleteContainer(t *testing.T) {
 			ID: sandbox.MockContainers[0].ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "ready",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 
@@ -533,7 +536,7 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	configJSON, err := readOCIConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	path, err := createTempContainerIDMapping(sandbox.ID(), sandbox.ID())
@@ -545,11 +548,11 @@ func TestDeleteCLIFunctionSuccess(t *testing.T) {
 			ID: sandbox.ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-				vcAnnotations.ConfigJSONKey:    configJSON,
 			},
 			State: types.ContainerState{
 				State: "ready",
 			},
+			Spec: &ociSpec,
 		}, nil
 	}
 

--- a/cli/kill_test.go
+++ b/cli/kill_test.go
@@ -13,11 +13,13 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	"github.com/kata-containers/runtime/virtcontainers/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -81,7 +83,7 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -100,7 +102,7 @@ func testKillCLIFunctionTerminationSignalSuccessful(t *testing.T, sig string) {
 	}
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	testingImpl.StopContainerFunc = nil
@@ -134,7 +136,7 @@ func TestKillCLIFunctionNotTerminationSignalSuccessful(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -167,7 +169,7 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -186,7 +188,7 @@ func TestKillCLIFunctionNoSignalSuccessful(t *testing.T) {
 	}
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	testingImpl.StopContainerFunc = nil
@@ -223,7 +225,7 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -243,7 +245,7 @@ func TestKillCLIFunctionEnableAllSuccessful(t *testing.T) {
 	}
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, annotations), nil
+		return newSingleContainerStatus(testContainerID, state, annotations, &specs.Spec{}), nil
 	}
 
 	testingImpl.StopContainerFunc = nil
@@ -300,7 +302,7 @@ func TestKillCLIFunctionInvalidSignalFailure(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -330,7 +332,7 @@ func TestKillCLIFunctionStatePausedSuccessful(t *testing.T) {
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return newSingleContainerStatus(testContainerID, state,
-			map[string]string{string(vcAnnotations.ContainerTypeKey): string(vc.PodContainer)}), nil
+			map[string]string{string(vcAnnotations.ContainerTypeKey): string(vc.PodContainer)}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -359,7 +361,7 @@ func TestKillCLIFunctionInvalidStateStoppedFailure(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -385,7 +387,7 @@ func TestKillCLIFunctionKillContainerFailure(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -412,7 +414,7 @@ func TestKillCLIFunctionInvalidStateStoppedAllSuccess(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -25,6 +25,7 @@ import (
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	"github.com/kata-containers/runtime/virtcontainers/types"
@@ -148,20 +149,6 @@ func runUnitTests(m *testing.M) {
 	os.RemoveAll(testDir)
 
 	os.Exit(ret)
-}
-
-// Read fail that should contain a specs.Spec and
-// return its JSON representation on success
-func readOCIConfigJSON(bundlePath string) (string, error) {
-	ociSpec, err := oci.ParseConfigJSON(bundlePath)
-	if err != nil {
-		return "", nil
-	}
-	ociSpecJSON, err := json.Marshal(ociSpec)
-	if err != nil {
-		return "", err
-	}
-	return string(ociSpecJSON), err
 }
 
 // TestMain is the common main function used by ALL the test functions
@@ -347,7 +334,7 @@ func realMakeOCIBundle(bundleDir string) error {
 
 	// Note the unusual parameter (a directory, not the config
 	// file to parse!)
-	spec, err := oci.ParseConfigJSON(bundleDir)
+	spec, err := compatoci.ParseConfigJSON(bundleDir)
 	if err != nil {
 		return err
 	}
@@ -412,11 +399,12 @@ func writeOCIConfigFile(spec specs.Spec, configPath string) error {
 	return ioutil.WriteFile(configPath, bytes, testFileMode)
 }
 
-func newSingleContainerStatus(containerID string, containerState types.ContainerState, annotations map[string]string) vc.ContainerStatus {
+func newSingleContainerStatus(containerID string, containerState types.ContainerState, annotations map[string]string, spec *specs.Spec) vc.ContainerStatus {
 	return vc.ContainerStatus{
 		ID:          containerID,
 		State:       containerState,
 		Annotations: annotations,
+		Spec:        spec,
 	}
 }
 

--- a/cli/network_test.go
+++ b/cli/network_test.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"testing"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -54,7 +56,7 @@ func TestNetworkCliFunction(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {

--- a/cli/pause_test.go
+++ b/cli/pause_test.go
@@ -12,9 +12,11 @@ import (
 	"os"
 	"testing"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -41,7 +43,7 @@ func TestPauseCLIFunctionSuccessful(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -87,7 +89,7 @@ func TestPauseCLIFunctionPauseContainerFailure(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -114,7 +116,7 @@ func TestResumeCLIFunctionSuccessful(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {
@@ -159,7 +161,7 @@ func TestResumeCLIFunctionPauseContainerFailure(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
-		return newSingleContainerStatus(testContainerID, state, map[string]string{}), nil
+		return newSingleContainerStatus(testContainerID, state, map[string]string{}, &specs.Spec{}), nil
 	}
 
 	defer func() {

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"os"
@@ -62,16 +61,13 @@ func TestStartSandbox(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(specs.Spec{})
-	assert.NoError(err)
-
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return vc.ContainerStatus{
 			ID: sandbox.ID(),
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodSandbox),
-				vcAnnotations.ConfigJSONKey:    string(ociSpecJSON),
 			},
+			Spec: &specs.Spec{},
 		}, nil
 	}
 
@@ -140,16 +136,13 @@ func TestStartContainerSucessFailure(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(specs.Spec{})
-	assert.NoError(err)
-
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return vc.ContainerStatus{
 			ID: testContainerID,
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-				vcAnnotations.ConfigJSONKey:    string(ociSpecJSON),
 			},
+			Spec: &specs.Spec{},
 		}, nil
 	}
 
@@ -218,16 +211,13 @@ func TestStartCLIFunctionSuccess(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
-	ociSpecJSON, err := json.Marshal(specs.Spec{})
-	assert.NoError(err)
-
 	testingImpl.StatusContainerFunc = func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStatus, error) {
 		return vc.ContainerStatus{
 			ID: testContainerID,
 			Annotations: map[string]string{
 				vcAnnotations.ContainerTypeKey: string(vc.PodContainer),
-				vcAnnotations.ConfigJSONKey:    string(ociSpecJSON),
 			},
+			Spec: &specs.Spec{},
 		}, nil
 	}
 

--- a/containerd-shim-v2/create.go
+++ b/containerd-shim-v2/create.go
@@ -13,22 +13,21 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/typeurl"
-	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
-	"github.com/pkg/errors"
-
-	taskAPI "github.com/containerd/containerd/runtime/v2/task"
-
-	"github.com/kata-containers/runtime/pkg/katautils"
-	"github.com/opencontainers/runtime-spec/specs-go"
-
 	containerd_types "github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/mount"
+	taskAPI "github.com/containerd/containerd/runtime/v2/task"
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	// only register the proto type
 	_ "github.com/containerd/containerd/runtime/linux/runctypes"
 	crioption "github.com/containerd/cri-containerd/pkg/api/runtimeoptions/v1"
+
+	"github.com/kata-containers/runtime/pkg/katautils"
+	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 )
 
 func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*container, error) {
@@ -132,7 +131,7 @@ func loadSpec(r *taskAPI.CreateTaskRequest) (*specs.Spec, string, error) {
 		return nil, "", err
 	}
 
-	ociSpec, err := oci.ParseConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	if err != nil {
 		return nil, "", err
 	}

--- a/containerd-shim-v2/create_test.go
+++ b/containerd-shim-v2/create_test.go
@@ -21,7 +21,7 @@ import (
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 )
 
@@ -62,7 +62,7 @@ func TestCreateSandboxSuccess(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Force sandbox-type container
@@ -120,7 +120,7 @@ func TestCreateSandboxFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	err = writeOCIConfigFile(spec, ociConfigFile)
@@ -167,7 +167,7 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	quota := int64(0)
@@ -231,7 +231,7 @@ func TestCreateContainerSuccess(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set expected container type and sandboxID
@@ -280,7 +280,7 @@ func TestCreateContainerFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	spec.Annotations = make(map[string]string)
@@ -340,7 +340,7 @@ func TestCreateContainerConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(katautils.FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set the error containerType

--- a/containerd-shim-v2/delete_test.go
+++ b/containerd-shim-v2/delete_test.go
@@ -15,7 +15,7 @@ import (
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 )
 
@@ -28,7 +28,7 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 
 	rootPath, bundlePath := testConfigSetup(t)
 	defer os.RemoveAll(rootPath)
-	_, err := oci.ParseConfigJSON(bundlePath)
+	_, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	s := &service{

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -15,24 +15,25 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
 	cdruntime "github.com/containerd/containerd/runtime"
 	cdshim "github.com/containerd/containerd/runtime/v2/shim"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
-	"github.com/kata-containers/runtime/pkg/katautils"
-	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
-	"github.com/kata-containers/runtime/virtcontainers/types"
-	"github.com/opencontainers/runtime-spec/specs-go"
-
-	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	"github.com/kata-containers/runtime/pkg/katautils"
+	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 const (
@@ -291,7 +292,7 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 		return nil, err
 	}
 
-	ociSpec, err := oci.ParseConfigJSON(path)
+	ociSpec, err := compatoci.ParseConfigJSON(path)
 	if err != nil {
 		return nil, err
 	}

--- a/containerd-shim-v2/utils.go
+++ b/containerd-shim-v2/utils.go
@@ -17,6 +17,7 @@ import (
 	cdshim "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -87,7 +88,7 @@ func getAddress(ctx context.Context, bundlePath, id string) (string, error) {
 		return "", err
 	}
 
-	ociSpec, err := oci.ParseConfigJSON(bundlePath)
+	ociSpec, err := compatoci.ParseConfigJSON(bundlePath)
 	if err != nil {
 		return "", err
 	}

--- a/containerd-shim-v2/utils_test.go
+++ b/containerd-shim-v2/utils_test.go
@@ -22,6 +22,7 @@ import (
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 )
@@ -236,7 +237,7 @@ func realMakeOCIBundle(bundleDir string) error {
 
 	// Note the unusual parameter (a directory, not the config
 	// file to parse!)
-	spec, err := oci.ParseConfigJSON(bundleDir)
+	spec, err := compatoci.ParseConfigJSON(bundleDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/katautils/create_test.go
+++ b/pkg/katautils/create_test.go
@@ -21,6 +21,7 @@ import (
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/vcmock"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -275,7 +276,7 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	quota := int64(0)
@@ -323,7 +324,7 @@ func TestCreateSandboxFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	rootFs := vc.RootFs{Mounted: true}
@@ -353,7 +354,7 @@ func TestCreateContainerContainerConfigFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// Set invalid container type
@@ -396,7 +397,7 @@ func TestCreateContainerFail(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set expected container type and sandboxID
@@ -446,7 +447,7 @@ func TestCreateContainer(t *testing.T) {
 	ociConfigFile := filepath.Join(bundlePath, "config.json")
 	assert.True(FileExists(ociConfigFile))
 
-	spec, err := oci.ParseConfigJSON(bundlePath)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 
 	// set expected container type and sandboxID

--- a/pkg/katautils/utils_test.go
+++ b/pkg/katautils/utils_test.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,7 +124,7 @@ func realMakeOCIBundle(bundleDir string) error {
 
 	// Note the unusual parameter (a directory, not the config
 	// file to parse!)
-	spec, err := oci.ParseConfigJSON(bundleDir)
+	spec, err := compatoci.ParseConfigJSON(bundleDir)
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -613,6 +613,7 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 				PID:         container.process.Pid,
 				StartTime:   container.process.StartTime,
 				RootFs:      container.config.RootFs.Target,
+				Spec:        container.GetOCISpec(),
 				Annotations: container.config.Annotations,
 			}, nil
 		}

--- a/virtcontainers/cgroups_test.go
+++ b/virtcontainers/cgroups_test.go
@@ -174,6 +174,7 @@ func TestUpdateCgroups(t *testing.T) {
 			},
 			config: &ContainerConfig{
 				Annotations: containerAnnotations,
+				Spec:        newEmptySpec(),
 			},
 		},
 		"xyz": {
@@ -182,6 +183,7 @@ func TestUpdateCgroups(t *testing.T) {
 			},
 			config: &ContainerConfig{
 				Annotations: containerAnnotations,
+				Spec:        newEmptySpec(),
 			},
 		},
 	}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -30,7 +29,6 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
-	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
@@ -747,13 +745,10 @@ func TestAgentCreateContainer(t *testing.T) {
 			Fstype: "xfs",
 		},
 		config: &ContainerConfig{
+			Spec:        &specs.Spec{},
 			Annotations: map[string]string{},
 		},
 	}
-
-	ociSpec, err := json.Marshal(&specs.Spec{})
-	assert.Nil(err)
-	container.config.Annotations[vcAnnotations.ConfigJSONKey] = string(ociSpec[:])
 
 	impl := &gRPCProxy{}
 

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -47,9 +47,6 @@ const (
 	// AssetHashType is the hash type used for assets verification
 	AssetHashType = vcAnnotationsPrefix + "AssetHashType"
 
-	// ConfigJSONKey is the annotation key to fetch the OCI configuration.
-	ConfigJSONKey = vcAnnotationsPrefix + "pkg.oci.config"
-
 	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
 	BundlePathKey = vcAnnotationsPrefix + "pkg.oci.bundle_path"
 

--- a/virtcontainers/pkg/compatoci/utils.go
+++ b/virtcontainers/pkg/compatoci/utils.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package compatoci
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
+	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+)
+
+var ociLog = logrus.WithFields(logrus.Fields{
+	"source":    "virtcontainers",
+	"subsystem": "compatoci",
+})
+
+// compatOCIProcess is a structure inheriting from specs.Process defined
+// in runtime-spec/specs-go package. The goal is to be compatible with
+// both v1.0.0-rc4 and v1.0.0-rc5 since the latter introduced a change
+// about the type of the Capabilities field.
+// Refer to: https://github.com/opencontainers/runtime-spec/commit/37391fb
+type compatOCIProcess struct {
+	specs.Process
+	Capabilities interface{} `json:"capabilities,omitempty" platform:"linux"` //nolint:govet
+}
+
+// compatOCISpec is a structure inheriting from specs.Spec defined
+// in runtime-spec/specs-go package. It relies on the compatOCIProcess
+// structure declared above, in order to be compatible with both
+// v1.0.0-rc4 and v1.0.0-rc5.
+// Refer to: https://github.com/opencontainers/runtime-spec/commit/37391fb
+type compatOCISpec struct {
+	specs.Spec
+	Process *compatOCIProcess `json:"process,omitempty"` //nolint:govet
+}
+
+func containerCapabilities(s compatOCISpec) (specs.LinuxCapabilities, error) {
+	capabilities := s.Process.Capabilities
+	var c specs.LinuxCapabilities
+
+	// In spec v1.0.0-rc4, capabilities was a list of strings. This was changed
+	// to an object with v1.0.0-rc5.
+	// Check for the interface type to support both the versions.
+	switch caps := capabilities.(type) {
+	case map[string]interface{}:
+		for key, value := range caps {
+			switch val := value.(type) {
+			case []interface{}:
+				var list []string
+
+				for _, str := range val {
+					list = append(list, str.(string))
+				}
+
+				switch key {
+				case "bounding":
+					c.Bounding = list
+				case "effective":
+					c.Effective = list
+				case "inheritable":
+					c.Inheritable = list
+				case "ambient":
+					c.Ambient = list
+				case "permitted":
+					c.Permitted = list
+				}
+
+			default:
+				return c, fmt.Errorf("Unexpected format for capabilities: %v", caps)
+			}
+		}
+	case []interface{}:
+		var list []string
+		for _, str := range caps {
+			list = append(list, str.(string))
+		}
+
+		c = specs.LinuxCapabilities{
+			Bounding:    list,
+			Effective:   list,
+			Inheritable: list,
+			Ambient:     list,
+			Permitted:   list,
+		}
+	case nil:
+		ociLog.Debug("Empty capabilities have been passed")
+		return c, nil
+	default:
+		return c, fmt.Errorf("Unexpected format for capabilities: %v", caps)
+	}
+
+	return c, nil
+}
+
+// ContainerCapabilities return a LinuxCapabilities for virtcontainer
+func ContainerCapabilities(s compatOCISpec) (specs.LinuxCapabilities, error) {
+	if s.Process == nil {
+		return specs.LinuxCapabilities{}, fmt.Errorf("ContainerCapabilities, Process is nil")
+	}
+	return containerCapabilities(s)
+}
+
+// getConfigPath returns the full config path from the bundle
+// path provided.
+func getConfigPath(bundlePath string) string {
+	return filepath.Join(bundlePath, "config.json")
+}
+
+// ParseConfigJSON unmarshals the config.json file.
+func ParseConfigJSON(bundlePath string) (specs.Spec, error) {
+	configPath := getConfigPath(bundlePath)
+	ociLog.Debugf("converting %s", configPath)
+
+	configByte, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return specs.Spec{}, err
+	}
+
+	var compSpec compatOCISpec
+	if err := json.Unmarshal(configByte, &compSpec); err != nil {
+		return specs.Spec{}, err
+	}
+
+	caps, err := ContainerCapabilities(compSpec)
+	if err != nil {
+		return specs.Spec{}, err
+	}
+
+	compSpec.Spec.Process = &compSpec.Process.Process
+	compSpec.Spec.Process.Capabilities = &caps
+
+	return compSpec.Spec, nil
+}
+
+func GetContainerSpec(annotations map[string]string) (specs.Spec, error) {
+	if bundlePath, ok := annotations[vcAnnotations.BundlePathKey]; ok {
+		return ParseConfigJSON(bundlePath)
+	}
+
+	ociLog.Errorf("Annotations[%s] not found, cannot find container spec",
+		vcAnnotations.BundlePathKey)
+	return specs.Spec{}, fmt.Errorf("Could not find container spec")
+}

--- a/virtcontainers/pkg/compatoci/utils_test.go
+++ b/virtcontainers/pkg/compatoci/utils_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package compatoci
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tempBundlePath        = "/tmp/virtc/ocibundle/"
+	capabilitiesSpecArray = `
+		{
+		    "ociVersion": "1.0.0-rc2-dev",
+		    "process": {
+		        "capabilities": [
+		            "CAP_CHOWN",
+		            "CAP_DAC_OVERRIDE",
+		            "CAP_FSETID"
+		        ]
+		    }
+		}`
+
+	capabilitiesSpecStruct = `
+		{
+		    "ociVersion": "1.0.0-rc5",
+		    "process": {
+		        "capabilities": {
+		            "bounding": [
+		                "CAP_CHOWN",
+		                "CAP_DAC_OVERRIDE",
+		                "CAP_FSETID"
+		            ],
+		            "effective": [
+		                "CAP_CHOWN",
+		                "CAP_DAC_OVERRIDE",
+		                "CAP_FSETID"
+		            ],
+		            "inheritable": [
+		                "CAP_CHOWN",
+		                "CAP_DAC_OVERRIDE",
+		                "CAP_FSETID"
+		            ],
+		            "permitted": [
+		                "CAP_CHOWN",
+		                "CAP_DAC_OVERRIDE",
+		                "CAP_FSETID"
+		            ]
+		        }
+		    }
+		}`
+)
+
+func TestContainerCapabilities(t *testing.T) {
+	var ociSpec compatOCISpec
+
+	ociSpec.Process = &compatOCIProcess{}
+	ociSpec.Process.Capabilities = map[string]interface{}{
+		"bounding":    []interface{}{"CAP_KILL"},
+		"effective":   []interface{}{"CAP_KILL", "CAP_LEASE"},
+		"permitted":   []interface{}{"CAP_SETUID"},
+		"inheritable": []interface{}{"CAP_KILL", "CAP_LEASE", "CAP_SYS_ADMIN"},
+		"ambient":     []interface{}{""},
+	}
+
+	c, err := ContainerCapabilities(ociSpec)
+	assert.Nil(t, err)
+	assert.Equal(t, c.Bounding, []string{"CAP_KILL"})
+	assert.Equal(t, c.Effective, []string{"CAP_KILL", "CAP_LEASE"})
+	assert.Equal(t, c.Permitted, []string{"CAP_SETUID"})
+	assert.Equal(t, c.Inheritable, []string{"CAP_KILL", "CAP_LEASE", "CAP_SYS_ADMIN"})
+	assert.Equal(t, c.Ambient, []string{""})
+
+	ociSpec.Process.Capabilities = []interface{}{"CAP_LEASE", "CAP_SETUID"}
+
+	c, err = ContainerCapabilities(ociSpec)
+	assert.Nil(t, err)
+	assert.Equal(t, c.Bounding, []string{"CAP_LEASE", "CAP_SETUID"})
+	assert.Equal(t, c.Effective, []string{"CAP_LEASE", "CAP_SETUID"})
+	assert.Equal(t, c.Permitted, []string{"CAP_LEASE", "CAP_SETUID"})
+	assert.Equal(t, c.Inheritable, []string{"CAP_LEASE", "CAP_SETUID"})
+	assert.Equal(t, c.Ambient, []string{"CAP_LEASE", "CAP_SETUID"})
+
+	ociSpec.Process.Capabilities = nil
+
+	c, err = ContainerCapabilities(ociSpec)
+	assert.Nil(t, err)
+	assert.Equal(t, c.Bounding, []string(nil))
+	assert.Equal(t, c.Effective, []string(nil))
+	assert.Equal(t, c.Permitted, []string(nil))
+	assert.Equal(t, c.Inheritable, []string(nil))
+	assert.Equal(t, c.Ambient, []string(nil))
+}
+
+// use specs.Spec to decode the spec, the content of capabilities is [] string
+func TestCompatOCISpecWithArray(t *testing.T) {
+	compatOCISpec := compatOCISpec{}
+	err := json.Unmarshal([]byte(capabilitiesSpecArray), &compatOCISpec)
+	assert.Nil(t, err, "use compatOCISpec to decode capabilitiesSpecArray failed")
+
+	ociSpecJSON, err := json.Marshal(compatOCISpec)
+	assert.Nil(t, err, "encode compatOCISpec failed")
+
+	// use specs.Spec to decode the spec, specs.Spec' capabilities is struct,
+	// but the content of spec' capabilities is [] string
+	ociSpec := specs.Spec{}
+	err = json.Unmarshal(ociSpecJSON, &ociSpec)
+	assert.NotNil(t, err, "This test should fail")
+
+	caps, err := ContainerCapabilities(compatOCISpec)
+	assert.Nil(t, err, "decode capabilities failed")
+	compatOCISpec.Process.Capabilities = caps
+
+	ociSpecJSON, err = json.Marshal(compatOCISpec)
+	assert.Nil(t, err, "encode compatOCISpec failed")
+
+	// capabilities has been chaged to struct
+	err = json.Unmarshal(ociSpecJSON, &ociSpec)
+	assert.Nil(t, err, "This test should fail")
+}
+
+// use specs.Spec to decode the spec, the content of capabilities is struct
+func TestCompatOCISpecWithStruct(t *testing.T) {
+	compatOCISpec := compatOCISpec{}
+	err := json.Unmarshal([]byte(capabilitiesSpecStruct), &compatOCISpec)
+	assert.Nil(t, err, "use compatOCISpec to decode capabilitiesSpecStruct failed")
+
+	ociSpecJSON, err := json.Marshal(compatOCISpec)
+	assert.Nil(t, err, "encode compatOCISpec failed")
+
+	ociSpec := specs.Spec{}
+	err = json.Unmarshal(ociSpecJSON, &ociSpec)
+	assert.Nil(t, err, "This test should not fail")
+}
+
+func TestGetConfigPath(t *testing.T) {
+	expected := filepath.Join(tempBundlePath, "config.json")
+	configPath := getConfigPath(tempBundlePath)
+	assert.Equal(t, configPath, expected)
+}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -649,6 +649,7 @@ func TestContainerStateSetFstype(t *testing.T) {
 		{
 			ID:          "100",
 			Annotations: containerAnnotations,
+			Spec:        newEmptySpec(),
 		},
 	}
 
@@ -1517,44 +1518,24 @@ func TestSandboxExperimentalFeature(t *testing.T) {
 	assert.True(t, sconfig.valid())
 }
 
-/*
-func TestSandbox_joinSandboxCgroup(t *testing.T) {
-
-	mockValidCgroup := &Sandbox{}
-	mockValidCgroup.state.CgroupPath = "/my/cgroup"
-
-	tests := []struct {
-		name    string
-		s       *Sandbox
-		wantErr bool
-	}{
-		{"New Config", &Sandbox{}, false},
-		{"Mock cgroup path", mockValidCgroup, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.s.joinSandboxCgroup(); (err != nil) != tt.wantErr {
-				t.Errorf("Sandbox.joinSandboxCgroup() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-*/
-
 func TestSandbox_SetupSandboxCgroup(t *testing.T) {
 	sandboxContainer := ContainerConfig{}
 	sandboxContainer.Annotations = make(map[string]string)
 	sandboxContainer.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)
 
-	emptyJSONLinux := ContainerConfig{}
+	emptyJSONLinux := ContainerConfig{
+		Spec: newEmptySpec(),
+	}
 	emptyJSONLinux.Annotations = make(map[string]string)
 	emptyJSONLinux.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)
-	emptyJSONLinux.Annotations[annotations.ConfigJSONKey] = "{}"
 
-	successfulContainer := ContainerConfig{}
+	cloneSpec1 := newEmptySpec()
+	cloneSpec1.Linux.CgroupsPath = "/myRuntime/myContainer"
+	successfulContainer := ContainerConfig{
+		Spec: cloneSpec1,
+	}
 	successfulContainer.Annotations = make(map[string]string)
 	successfulContainer.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)
-	successfulContainer.Annotations[annotations.ConfigJSONKey] = "{\"linux\": { \"cgroupsPath\": \"/myRuntime/myContainer\" }}"
 
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This is a WIP PR trying to remove ConfigJSONKey annotation.

Currently we have several places saving the OCI spec in configurations which bing a lot of redundancy and confusion, the plan is removing them all and only keep "bundle/config.json" from upper level components.

Fixes: #2023

We can get OCI spec config from bundle instead of annotations, so this
field isn't necessary.

Signed-off-by: Wei Zhang <weizhang555.zw@gmail.com>