### PR TITLE
hypervisor: Fix MacVTap internetworking support in ACRN

### DIFF
--- a/virtcontainers/acrn_arch_base.go
+++ b/virtcontainers/acrn_arch_base.go
@@ -427,6 +427,7 @@ func (netdev NetDevice) AcrnNetdevParam() []string {
 		deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", netdev.MACAddress))
 	case MACVTAP:
 		deviceParams = append(deviceParams, netdev.IFName)
+		deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", netdev.MACAddress))
 	default:
 		deviceParams = append(deviceParams, netdev.IFName)
 


### PR DESCRIPTION
With MacVTap internetworking, Kata fails to launch containers
with ACRN hypervisor. This was due to missing MAC address as
part of virtio-net device when launching VM. This patch fixes
this issue by adding the MAC address.

Fixes: #2029

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>