### PR TITLE
s390x: add appendVSock with devno

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1584,7 +1584,7 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 		q.qemuConfig.Devices = q.arch.appendSocket(q.qemuConfig.Devices, v)
 	case kataVSOCK:
 		q.fds = append(q.fds, v.vhostFd)
-		q.qemuConfig.Devices = q.arch.appendVSockPCI(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices, err = q.arch.appendVSock(q.qemuConfig.Devices, v)
 	case Endpoint:
 		q.qemuConfig.Devices = q.arch.appendNetwork(q.qemuConfig.Devices, v)
 	case config.BlockDrive:

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -79,8 +79,8 @@ type qemuArch interface {
 	// appendSocket appends a socket to devices
 	appendSocket(devices []govmmQemu.Device, socket types.Socket) []govmmQemu.Device
 
-	// appendVSockPCI appends a vsock PCI to devices
-	appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOCK) []govmmQemu.Device
+	// appendVSock appends a vsock PCI to devices
+	appendVSock(devices []govmmQemu.Device, vsock kataVSOCK) ([]govmmQemu.Device, error)
 
 	// appendNetwork appends a endpoint device to devices
 	appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device
@@ -447,7 +447,7 @@ func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket types.Soc
 	return devices
 }
 
-func (q *qemuArchBase) appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOCK) []govmmQemu.Device {
+func (q *qemuArchBase) appendVSock(devices []govmmQemu.Device, vsock kataVSOCK) ([]govmmQemu.Device, error) {
 	devices = append(devices,
 		govmmQemu.VSOCKDevice{
 			ID:            fmt.Sprintf("vsock-%d", vsock.contextID),
@@ -457,7 +457,7 @@ func (q *qemuArchBase) appendVSockPCI(devices []govmmQemu.Device, vsock kataVSOC
 		},
 	)
 
-	return devices
+	return devices, nil
 
 }
 


### PR DESCRIPTION
Reimplementation of appendVSock in order to assign the devno to the vsock device.

Fixes: #2033
Signed-off-by: Alice Frosi <afrosi@de.ibm.com>
