### PR TITLE
s390x: Add appendImage function to qemu_s390x.go

### DIFF
--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -126,6 +126,18 @@ func (q *qemuS390x) appendConsole(devices []govmmQemu.Device, path string) ([]go
 	return devices, nil
 }
 
+func (q *qemuS390x) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	drive, err := genericImage(path)
+	if err != nil {
+		return nil, err
+	}
+	devices, err = q.appendBlockDevice(devices, drive)
+	if err != nil {
+		return nil, err
+	}
+	return devices, nil
+}
+
 func (q *qemuS390x) appendBlockDevice(devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error) {
 	d, err := genericBlockDevice(drive, false)
 	if err != nil {


### PR DESCRIPTION
Add appendImage function to struct qemuS390x, so that a call of
appendImage results in a call to the appendBlockDevice function of
qemuS390x instead of qemuArchBase.

Fixes: #2043

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>