### PR TITLE
virtcontainers: fix the issue of missing qemu error logs

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -763,7 +763,15 @@ func (q *qemu) startSandbox(timeout int) error {
 	var strErr string
 	strErr, err = govmmQemu.LaunchQemu(q.qemuConfig, newQMPLogger())
 	if err != nil {
-		return fmt.Errorf("fail to launch qemu: %s, error messages from qemu log: %s", err, strErr)
+		if q.config.Debug && q.qemuConfig.LogFile != "" {
+			b, err := ioutil.ReadFile(q.qemuConfig.LogFile)
+			if err == nil {
+				strErr += string(b)
+			}
+		}
+
+		q.Logger().WithError(err).Errorf("failed to launch qemu: %s", strErr)
+		return fmt.Errorf("failed to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}
 
 	err = q.waitSandbox(timeout) // the virtiofsd deferred checks err's value


### PR DESCRIPTION
When 'debug' is enabled, qemu's debug info is output
into qemu's log file. When lauching qemu failed, it's
better to return those debug info for debugging.

Fixes:#2042

Signed-off-by: lifupan <lifupan@gmail.com>