### PR TITLE
s390x: Share image between qemu instances

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -390,11 +390,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:1a7407072d9447e0e39148aa462f0be26261e29ff14679ccee4fbed106c1a766"
+  digest = "1:b3ab3b3615583d7a374d4803ea2b71f173a4d8f4d594210e0fc8e9fc7c5a49c9"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "ee460e3008d48043f8561628d1d5308357d72cf6"
+  revision = "8cba5a8e5f2816f26f9dc34b8ea968279a5a76eb"
 
 [[projects]]
   digest = "1:22e399f891fccaac4700943a9465f2623bb361653d5e0d4a9974573cd5e69070"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "ee460e3008d48043f8561628d1d5308357d72cf6"
+  revision = "8cba5a8e5f2816f26f9dc34b8ea968279a5a76eb"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -728,6 +728,9 @@ type BlockDevice struct {
 
 	// DevNo identifies the ccw devices for s390x architecture
 	DevNo string
+
+	// ShareRW enables multiple qemu instances to share the File
+	ShareRW bool
 }
 
 // Valid returns true if the BlockDevice structure is valid and complete.
@@ -764,6 +767,10 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 
 	if isVirtioCCW[blkdev.Driver] {
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", blkdev.DevNo))
+	}
+
+	if blkdev.ShareRW {
+		deviceParams = append(deviceParams, fmt.Sprintf(",share-rw=on"))
 	}
 
 	blkParams = append(blkParams, fmt.Sprintf("id=%s", blkdev.ID))

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -144,6 +144,9 @@ type BlockDrive struct {
 
 	// DevNo identifies the css bus id for virtio-blk-ccw
 	DevNo string
+
+	// ShareRW enables multiple qemu instances to share the File
+	ShareRW bool
 }
 
 // VFIODeviceType indicates VFIO device type

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -548,6 +548,7 @@ func genericBlockDevice(drive config.BlockDrive, nestedRun bool) (govmmQemu.Bloc
 		Format:        govmmQemu.BlockDeviceFormat(drive.Format),
 		Interface:     "none",
 		DisableModern: nestedRun,
+		ShareRW:       drive.ShareRW,
 	}, nil
 }
 

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -131,6 +131,7 @@ func (q *qemuS390x) appendImage(devices []govmmQemu.Device, path string) ([]govm
 	if err != nil {
 		return nil, err
 	}
+	drive.ShareRW = true
 	devices, err = q.appendBlockDevice(devices, drive)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit enables the `share-rw` flag for the image file in s390x.
This enables multiple instances of qemu to share the same image.

Fixes: #2049

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>