### PR TITLE
kernel: update to v4.19.73

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -162,7 +162,7 @@ assets:
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
     uscan-url: >-
       https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-(4\.19\..+)\.tar\.gz
-    version: "v4.19.71"
+    version: "v4.19.73"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
This includes fix for CVE-2019-14835

Fixes: # 2062

Signed-off-by: Eric Ernst <eric.ernst@intel.com>