### PR TITLE
versions: update containerd version to 1.2.9 in versions.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -209,7 +209,7 @@ externals:
       Containerd Plugin for Kubernetes Container Runtime Interface.
     url: "github.com/containerd/cri"
     tarball_url: "https://storage.googleapis.com/cri-containerd-release"
-    version: "1.2.7"
+    version: "1.2.9"
 
   docker:
     description: "Moby project container manager"


### PR DESCRIPTION
Update cri-containerd version to latest stable v1.2.9.

fixes: #2070

Signed-off-by: zhanghj.lc <zhanghj.lc@inspur.com>