### PR TITLE
Hypervisor: UUID fix for acrn hypevisor

### DIFF
--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -172,7 +172,7 @@ func newHypervisor(hType HypervisorType) (hypervisor, error) {
 	case FirecrackerHypervisor:
 		return &firecracker{}, nil
 	case AcrnHypervisor:
-		return &acrn{}, nil
+		return &Acrn{}, nil
 	case MockHypervisor:
 		return &mockHypervisor{}, nil
 	default:

--- a/virtcontainers/store/filesystem_backend.go
+++ b/virtcontainers/store/filesystem_backend.go
@@ -46,6 +46,9 @@ const (
 
 	// DevicesFile is the file name storing a container's devices.
 	DevicesFile = "devices.json"
+
+	// uuidFile is the file name storing a guest VM uuid state.
+	uuidFile = "uuid.json"
 )
 
 // DirMode is the permission bits used for creating a directory
@@ -63,6 +66,9 @@ const SandboxPathSuffix = "sbs"
 // VMPathSuffix is the suffix used for guest VMs.
 const VMPathSuffix = "vm"
 
+// UUIDPathSuffix is the suffix used for uuid storage
+const UUIDPathSuffix = "uuid"
+
 // ConfigStoragePath is the sandbox configuration directory.
 // It will contain one config.json file for each created sandbox.
 var ConfigStoragePath = filepath.Join("/var/lib", StoragePathSuffix, SandboxPathSuffix)
@@ -74,6 +80,10 @@ var RunStoragePath = filepath.Join("/run", StoragePathSuffix, SandboxPathSuffix)
 // RunVMStoragePath is the vm directory.
 // It will contain all guest vm sockets and shared mountpoints.
 var RunVMStoragePath = filepath.Join("/run", StoragePathSuffix, VMPathSuffix)
+
+// VMUUIDStoragePath is the uuid directory.
+// It will contain all uuid info used by guest vm.
+var VMUUIDStoragePath = filepath.Join("/var/lib", StoragePathSuffix, UUIDPathSuffix)
 
 func itemToFile(item Item) (string, error) {
 	switch item {
@@ -95,6 +105,8 @@ func itemToFile(item Item) (string, error) {
 		return MountsFile, nil
 	case Devices, DeviceIDs:
 		return DevicesFile, nil
+	case UUID:
+		return uuidFile, nil
 	}
 
 	return "", fmt.Errorf("Unknown item %s", item)

--- a/virtcontainers/store/manager.go
+++ b/virtcontainers/store/manager.go
@@ -48,6 +48,9 @@ const (
 
 	// DeviceIDs represents a set of reference IDs item to be stored.
 	DeviceIDs
+
+	// UUID represents a set of uuids item to be stored.
+	UUID
 )
 
 func (i Item) String() string {


### PR DESCRIPTION
This patch adds support for getting the kata UUID from
acrn hypervisor and using these UUID to create a VM.

Fixes: #1785
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>