### PR TITLE
Add annotations to provide custom configs

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -304,7 +304,7 @@ func (h hypervisor) defaultMaxVCPUs() uint32 {
 }
 
 func (h hypervisor) defaultMemSz() uint32 {
-	if h.MemorySize < 8 {
+	if h.MemorySize < vc.MinHypervisorMemory {
 		return defaultMemSize // MiB
 	}
 

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
@@ -69,7 +70,7 @@ func newBasicTestCmd() types.Cmd {
 
 func newTestSandboxConfigNoop() SandboxConfig {
 	bundlePath := filepath.Join(testDir, testBundle)
-	containerAnnotations["com.github.containers.virtcontainers.pkg.oci.bundle_path"] = bundlePath
+	containerAnnotations[annotations.BundlePathKey] = bundlePath
 	// containerAnnotations["com.github.containers.virtcontainers.pkg.oci.container_type"] = "pod_sandbox"
 
 	emptySpec := newEmptySpec()

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -63,6 +63,9 @@ const (
 	// port numbers below 1024 are called privileged ports. Only a process with
 	// CAP_NET_BIND_SERVICE capability may bind to these port numbers.
 	vSockPort = 1024
+
+	// MinHypervisorMemory is the minimum memory required for a VM.
+	MinHypervisorMemory = 256
 )
 
 // In some architectures the maximum number of vCPUs depends on the number of physical cores.

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -6,52 +6,56 @@
 package annotations
 
 const (
-	vcAnnotationsPrefix = "com.github.containers.virtcontainers."
+	kataAnnotationsPrefix     = "io.kata-containers."
+	kataConfAnnotationsPrefix = kataAnnotationsPrefix + "config."
+	kataAnnotHypervisorPrefix = kataConfAnnotationsPrefix + "hypervisor."
+	kataAnnotAgentPrefix      = kataConfAnnotationsPrefix + "agent."
+	kataAnnotRuntimePrefix    = kataConfAnnotationsPrefix + "runtime." // nolint: unused
 
 	// KernelPath is a sandbox annotation for passing a per container path pointing at the kernel needed to boot the container VM.
-	KernelPath = vcAnnotationsPrefix + "KernelPath"
+	KernelPath = kataAnnotHypervisorPrefix + "kernel"
 
 	// ImagePath is a sandbox annotation for passing a per container path pointing at the guest image that will run in the container VM.
-	ImagePath = vcAnnotationsPrefix + "ImagePath"
+	ImagePath = kataAnnotHypervisorPrefix + "image"
 
 	// InitrdPath is a sandbox annotation for passing a per container path pointing at the guest initrd image that will run in the container VM.
-	InitrdPath = vcAnnotationsPrefix + "InitrdPath"
+	InitrdPath = kataAnnotHypervisorPrefix + "initrd"
 
 	// HypervisorPath is a sandbox annotation for passing a per container path pointing at the hypervisor that will run the container VM.
-	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
+	HypervisorPath = kataAnnotHypervisorPrefix + "path"
 
 	// JailerPath is a sandbox annotation for passing a per container path pointing at the jailer that will constrain the container VM.
-	JailerPath = vcAnnotationsPrefix + "JailerPath"
+	JailerPath = kataAnnotHypervisorPrefix + "jailer_path"
 
 	// FirmwarePath is a sandbox annotation for passing a per container path pointing at the guest firmware that will run the container VM.
-	FirmwarePath = vcAnnotationsPrefix + "FirmwarePath"
+	FirmwarePath = kataAnnotHypervisorPrefix + "firmware"
 
 	// KernelHash is a sandbox annotation for passing a container kernel image SHA-512 hash value.
-	KernelHash = vcAnnotationsPrefix + "KernelHash"
+	KernelHash = kataAnnotHypervisorPrefix + "kernel_hash"
 
 	// ImageHash is an sandbox annotation for passing a container guest image SHA-512 hash value.
-	ImageHash = vcAnnotationsPrefix + "ImageHash"
+	ImageHash = kataAnnotHypervisorPrefix + "image_hash"
 
 	// InitrdHash is an sandbox annotation for passing a container guest initrd SHA-512 hash value.
-	InitrdHash = vcAnnotationsPrefix + "InitrdHash"
+	InitrdHash = kataAnnotHypervisorPrefix + "initrd_hash"
 
 	// HypervisorHash is an sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
-	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"
+	HypervisorHash = kataAnnotHypervisorPrefix + "hypervisor_hash"
 
 	// JailerHash is an sandbox annotation for passing a jailer binary SHA-512 hash value.
-	JailerHash = vcAnnotationsPrefix + "JailerHash"
+	JailerHash = kataAnnotHypervisorPrefix + "jailer_hash"
 
 	// FirmwareHash is an sandbox annotation for passing a container guest firmware SHA-512 hash value.
-	FirmwareHash = vcAnnotationsPrefix + "FirmwareHash"
+	FirmwareHash = kataAnnotHypervisorPrefix + "firmware_hash"
 
 	// AssetHashType is the hash type used for assets verification
-	AssetHashType = vcAnnotationsPrefix + "AssetHashType"
+	AssetHashType = kataAnnotationsPrefix + "asset_hash_type"
 
 	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
-	BundlePathKey = vcAnnotationsPrefix + "pkg.oci.bundle_path"
+	BundlePathKey = kataAnnotationsPrefix + "pkg.oci.bundle_path"
 
 	// ContainerTypeKey is the annotation key to fetch container type.
-	ContainerTypeKey = vcAnnotationsPrefix + "pkg.oci.container_type"
+	ContainerTypeKey = kataAnnotationsPrefix + "pkg.oci.container_type"
 
 	// KernelModules is the annotation key for passing the list of kernel
 	// modules and their parameters that will be loaded in the guest kernel.
@@ -60,11 +64,11 @@ const (
 	// The following example can be used to load two kernel modules with parameters
 	///
 	//   annotations:
-	//     com.github.containers.virtcontainers.KernelModules: "e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0"
+	//     io.kata-containers.config.agent.kernel_modules: "e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0"
 	//
 	// The first word is considered as the module name and the rest as its parameters.
 	//
-	KernelModules = vcAnnotationsPrefix + "KernelModules"
+	KernelModules = kataAnnotAgentPrefix + "kernel_modules"
 )
 
 const (

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -181,6 +181,26 @@ const (
 )
 
 const (
+	kataAnnotRuntimePrefix = kataConfAnnotationsPrefix + "runtime."
+
+	// DisableGuestSeccomp is a sandbox annotation that determines if seccomp should be applied inside guest.
+	DisableGuestSeccomp = kataAnnotRuntimePrefix + "disable_guest_seccomp"
+
+	// SandboxCgroupOnly is a sandbox annotation that determines if kata processes are managed only in sandbox cgroup.
+	SandboxCgroupOnly = kataAnnotRuntimePrefix + "sandbox_cgroup_only"
+
+	// Experimental is a sandbox annotation that determines if experimental features enabled.
+	Experimental = kataAnnotRuntimePrefix + "experimental"
+
+	// InterNetworkModel is a sandbox annotaion that determines how the VM should be connected to the
+	//the container network interface.
+	InterNetworkModel = kataAnnotRuntimePrefix + "internetworking_model"
+
+	// DisableNewNetNs is a sandbox annotation that determines if create a netns for hypervisor process.
+	DisableNewNetNs = kataAnnotRuntimePrefix + "disable_new_netns"
+)
+
+const (
 	kataAnnotAgentPrefix = kataConfAnnotationsPrefix + "agent."
 
 	// KernelModules is the annotation key for passing the list of kernel

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -69,6 +69,18 @@ const (
 	// The first word is considered as the module name and the rest as its parameters.
 	//
 	KernelModules = kataAnnotAgentPrefix + "kernel_modules"
+
+	// DefaultVCPUs is a sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
+	DefaultVCPUs = kataAnnotHypervisorPrefix + "default_vcpus"
+
+	// DefaultVCPUs is a sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
+	DefaultMaxVCPUs = kataAnnotHypervisorPrefix + "default_max_vcpus"
+
+	// DefaultMemory is a sandbox annotation for the memory assigned for a VM by the hypervisor.
+	DefaultMemory = kataAnnotHypervisorPrefix + "default_memory"
+
+	// KernelParams is a sandbox annotation for passing additional guest kernel parameters.
+	KernelParams = kataAnnotHypervisorPrefix + "kernel_params"
 )
 
 const (

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -9,8 +9,23 @@ const (
 	kataAnnotationsPrefix     = "io.kata-containers."
 	kataConfAnnotationsPrefix = kataAnnotationsPrefix + "config."
 	kataAnnotHypervisorPrefix = kataConfAnnotationsPrefix + "hypervisor."
-	kataAnnotAgentPrefix      = kataConfAnnotationsPrefix + "agent."
-	kataAnnotRuntimePrefix    = kataConfAnnotationsPrefix + "runtime." // nolint: unused
+
+	//
+	// OCI
+	//
+
+	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
+	BundlePathKey = kataAnnotationsPrefix + "pkg.oci.bundle_path"
+
+	// ContainerTypeKey is the annotation key to fetch container type.
+	ContainerTypeKey = kataAnnotationsPrefix + "pkg.oci.container_type"
+)
+
+// Annotations related to Hypervisor configuration
+const (
+	//
+	// Assets
+	//
 
 	// KernelPath is a sandbox annotation for passing a per container path pointing at the kernel needed to boot the container VM.
 	KernelPath = kataAnnotHypervisorPrefix + "kernel"
@@ -51,11 +66,122 @@ const (
 	// AssetHashType is the hash type used for assets verification
 	AssetHashType = kataAnnotationsPrefix + "asset_hash_type"
 
-	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
-	BundlePathKey = kataAnnotationsPrefix + "pkg.oci.bundle_path"
+	//
+	//	Generic annotations
+	//
 
-	// ContainerTypeKey is the annotation key to fetch container type.
-	ContainerTypeKey = kataAnnotationsPrefix + "pkg.oci.container_type"
+	// KernelParams is a sandbox annotation for passing additional guest kernel parameters.
+	KernelParams = kataAnnotHypervisorPrefix + "kernel_params"
+
+	// MachineType is a sandbox annotation to specify the type of machine being emulated by the hypervisor.
+	MachineType = kataAnnotHypervisorPrefix + "machine_type"
+
+	// MachineAccelerators is a sandbox annotation to specify machine specific accelerators for the hypervisor.
+	MachineAccelerators = kataAnnotHypervisorPrefix + "machine_accelerators"
+
+	// DisableVhostNet is a sandbox annotation to specify if vhost-net is not available on the host.
+	DisableVhostNet = kataAnnotHypervisorPrefix + "disable_vhost_net"
+
+	// GuestHookPath is a sandbox annotation to specify the path within the VM that will be used for 'drop-in' hooks.
+	GuestHookPath = kataAnnotHypervisorPrefix + "guest_hook_path"
+
+	// UseVSock is a sandbox annotation to specify use of vsock for agent communication.
+	UseVSock = kataAnnotHypervisorPrefix + "use_vsock"
+
+	// HotplugVFIOOnRootBus is a sandbox annotation used to indicate if devices need to be hotplugged on the
+	// root bus instead of a bridge.
+	HotplugVFIOOnRootBus = kataAnnotHypervisorPrefix + "hotplug_vfio_on_root_bus"
+
+	// EntropySource is a sandbox annotation to specify the path to a host source of
+	// entropy (/dev/random, /dev/urandom or real hardware RNG device)
+	EntropySource = kataAnnotHypervisorPrefix + "entropy_source"
+
+	//
+	//	CPU Annotations
+	//
+
+	// DefaultVCPUs is a sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
+	DefaultVCPUs = kataAnnotHypervisorPrefix + "default_vcpus"
+
+	// DefaultVCPUs is a sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
+	DefaultMaxVCPUs = kataAnnotHypervisorPrefix + "default_max_vcpus"
+
+	//
+	//	Memory related annotations
+	//
+
+	// DefaultMemory is a sandbox annotation for the memory assigned for a VM by the hypervisor.
+	DefaultMemory = kataAnnotHypervisorPrefix + "default_memory"
+
+	// MemSlots is a sandbox annotation to specify the memory slots assigned to the VM by the hypervisor.
+	MemSlots = kataAnnotHypervisorPrefix + "memory_slots"
+
+	// MemOffset is a sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
+	MemOffset = kataAnnotHypervisorPrefix + "memory_offset"
+
+	// MemPrealloc is a sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
+	MemPrealloc = kataAnnotHypervisorPrefix + "enable_mem_prealloc"
+
+	// EnableSwap is a sandbox annotation to enable swap of vm memory.
+	// The behaviour is undefined if mem_prealloc is also set to true
+	EnableSwap = kataAnnotHypervisorPrefix + "enable_swap"
+
+	// HugePages is a sandbox annotation to specify if the memory should be pre-allocated from huge pages
+	HugePages = kataAnnotHypervisorPrefix + "enable_hugepages"
+
+	// FileBackedMemRootDir is a sandbox annotation to soecify file based memory backend root directory
+	FileBackedMemRootDir = kataAnnotHypervisorPrefix + "file_mem_backend"
+
+	//
+	//	Shared File System related annotations
+	//
+
+	// Msize9p is a sandbox annotation to specify as the msize for 9p shares
+	Msize9p = kataAnnotHypervisorPrefix + "msize_9p"
+
+	// SharedFs is a sandbox annotation to specify the shared file system type, either virtio-9p or virtio-fs.
+	SharedFS = kataAnnotHypervisorPrefix + "shared_fs"
+
+	// VirtioFSDaemon is a sandbox annotations to specify virtio-fs vhost-user daemon path
+	VirtioFSDaemon = kataAnnotHypervisorPrefix + "virtio_fs_daemon"
+
+	// VirtioFSCache is a sandbox annotation to specify the cache mode for fs version cache or "none"
+	VirtioFSCache = kataAnnotHypervisorPrefix + "virtio_fs_cache"
+
+	// VirtioFSCacheSize is a sandbox annotation to specify the DAX cache size in MiB
+	VirtioFSCacheSize = kataAnnotHypervisorPrefix + "virtio_fs_cache_size"
+
+	// VirtioFSExtraArgs is a sandbox annotation to pass options to virtiofsd daemon
+	VirtioFSExtraArgs = kataAnnotHypervisorPrefix + "virtio_fs_extra_args"
+
+	//
+	//	Block Device related annotations
+	//
+
+	// BlockDeviceDriver specifies the driver to be used for block device either VirtioSCSI or VirtioBlock
+	BlockDeviceDriver = kataAnnotHypervisorPrefix + "block_device_driver"
+
+	// DisableBlockDeviceUse  is a sandbox annotation that disallows a block device from being used.
+	DisableBlockDeviceUse = kataAnnotHypervisorPrefix + "disable_block_device_use"
+
+	// EnableIOThreads is a sandbox annotation to enable IO to be processed in a separate thread.
+	// Supported currently for virtio-scsi driver.
+	EnableIOThreads = kataAnnotHypervisorPrefix + "enable_iothreads"
+
+	// BlockDeviceCacheSet is a sandbox annotation that specifies cache-related options will be set to block devices or not.
+	BlockDeviceCacheSet = kataAnnotHypervisorPrefix + "block_device_cache_set"
+
+	// BlockDeviceCacheDirect is a sandbox annotation that specifies cache-related options for block devices.
+	// Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+	BlockDeviceCacheDirect = kataAnnotHypervisorPrefix + "block_device_cache_direct"
+
+	// BlockDeviceCacheNoflush is a sandbox annotation that specifies cache-related options for block devices.
+	// Denotes whether flush requests for the device are ignored.
+	BlockDeviceCacheNoflush = kataAnnotHypervisorPrefix + "block_device_cache_noflush"
+)
+
+const (
+	kataAnnotAgentPrefix = kataConfAnnotationsPrefix + "agent."
 
 	// KernelModules is the annotation key for passing the list of kernel
 	// modules and their parameters that will be loaded in the guest kernel.
@@ -69,18 +195,6 @@ const (
 	// The first word is considered as the module name and the rest as its parameters.
 	//
 	KernelModules = kataAnnotAgentPrefix + "kernel_modules"
-
-	// DefaultVCPUs is a sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
-	DefaultVCPUs = kataAnnotHypervisorPrefix + "default_vcpus"
-
-	// DefaultVCPUs is a sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
-	DefaultMaxVCPUs = kataAnnotHypervisorPrefix + "default_max_vcpus"
-
-	// DefaultMemory is a sandbox annotation for the memory assigned for a VM by the hypervisor.
-	DefaultMemory = kataAnnotHypervisorPrefix + "default_memory"
-
-	// KernelParams is a sandbox annotation for passing additional guest kernel parameters.
-	KernelParams = kataAnnotHypervisorPrefix + "kernel_params"
 )
 
 const (

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -180,6 +180,7 @@ const (
 	BlockDeviceCacheNoflush = kataAnnotHypervisorPrefix + "block_device_cache_noflush"
 )
 
+// Agent related annotations
 const (
 	kataAnnotRuntimePrefix = kataConfAnnotationsPrefix + "runtime."
 
@@ -215,6 +216,15 @@ const (
 	// The first word is considered as the module name and the rest as its parameters.
 	//
 	KernelModules = kataAnnotAgentPrefix + "kernel_modules"
+
+	// AgentTrace is a sandbox annotation to enable tracing for the agent.
+	AgentTrace = kataAnnotAgentPrefix + "enable_tracing"
+
+	// AgentTraceMode is a sandbox annotation to specify the trace mode for the agent.
+	AgentTraceMode = kataAnnotAgentPrefix + "trace_mode"
+
+	// AgentTraceMode is a sandbox annotation to specify the trace type for the agent.
+	AgentTraceType = kataAnnotAgentPrefix + "trace_type"
 )
 
 const (

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -714,13 +714,34 @@ func addRuntimeConfigOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig) e
 }
 
 func addAgentConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) error {
-	if value, ok := ocispec.Annotations[vcAnnotations.KernelModules]; ok {
-		if c, ok := config.AgentConfig.(vc.KataAgentConfig); ok {
-			modules := strings.Split(value, KernelModulesSeparator)
-			c.KernelModules = modules
-			config.AgentConfig = c
-		}
+	c, ok := config.AgentConfig.(vc.KataAgentConfig)
+	if !ok {
+		return nil
 	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.KernelModules]; ok {
+		modules := strings.Split(value, KernelModulesSeparator)
+		c.KernelModules = modules
+		config.AgentConfig = c
+	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.AgentTrace]; ok {
+		trace, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("Error parsing annotation for agent.trace: Please specify boolean value 'true|false'")
+		}
+		c.Trace = trace
+	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.AgentTraceMode]; ok {
+		c.TraceMode = value
+	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.AgentTraceType]; ok {
+		c.TraceType = value
+	}
+
+	config.AgentConfig = c
 
 	return nil
 }

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -446,8 +446,12 @@ func addHypervisorConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) 
 func addHypervisorMemoryOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig) error {
 	if value, ok := ocispec.Annotations[vcAnnotations.DefaultMemory]; ok {
 		memorySz, err := strconv.ParseUint(value, 10, 32)
-		if err != nil || memorySz < 8 {
+		if err != nil {
 			return fmt.Errorf("Error encountered parsing annotation for default_memory: %v, please specify positive numeric value greater than 8", err)
+		}
+
+		if memorySz < vc.MinHypervisorMemory {
+			return fmt.Errorf("Memory specified in annotation %s is less than minimum required %d, please specify a larger value", vcAnnotations.DefaultMemory, vc.MinHypervisorMemory)
 		}
 
 		sbConfig.HypervisorConfig.MemorySize = uint32(memorySz)

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -326,8 +326,11 @@ func addAssetAnnotations(ocispec specs.Spec, config *vc.SandboxConfig) {
 		vcAnnotations.KernelPath,
 		vcAnnotations.ImagePath,
 		vcAnnotations.InitrdPath,
+		vcAnnotations.FirmwarePath,
 		vcAnnotations.KernelHash,
 		vcAnnotations.ImageHash,
+		vcAnnotations.InitrdHash,
+		vcAnnotations.FirmwareHash,
 		vcAnnotations.AssetHashType,
 	}
 


### PR DESCRIPTION
  annotations: Support annotations to customise kata config
    
    Add support for annotations that allow us to custimise a subset
    of the configurations provided in kata conf toml file.
    This initial commit adds support for customising vcpus, default max
    vcpus, memory and the kernel command line passed as Hypervisor
    config.
    
    Replaces #1695
    Fixes #1655
