### PR TITLE
virtcontainers: fix the issue of missing watchConsole

### DIFF
--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -126,6 +126,9 @@ type agent interface {
 	// check will check the agent liveness
 	check() error
 
+	// tell whether the agent is long  live connected or not
+	longLiveConn() bool
+
 	// disconnect will disconnect the connection to the agent
 	disconnect() error
 

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -187,9 +187,9 @@ func FetchSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
 		return nil, err
 	}
 
-	// If the proxy is KataBuiltInProxyType type, it needs to restart the proxy to watch the
-	// guest console if it hadn't been watched.
-	if isProxyBuiltIn(s.config.ProxyType) {
+	// If the agent is long live connection, it needs to restart the proxy to
+	// watch the guest console if it hadn't been watched.
+	if s.agent.longLiveConn() {
 		err = s.startProxy()
 		if err != nil {
 			s.Release()

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -224,6 +224,10 @@ func (k *kataAgent) getSharePath(id string) string {
 	return filepath.Join(kataHostSharedDir(), id)
 }
 
+func (k *kataAgent) longLiveConn() bool {
+	return k.keepConn
+}
+
 // KataAgentSetDefaultTraceConfigOptions validates agent trace options and
 // sets defaults.
 func KataAgentSetDefaultTraceConfigOptions(config *KataAgentConfig) error {
@@ -617,6 +621,7 @@ func (k *kataAgent) startProxy(sandbox *Sandbox) error {
 	defer span.Finish()
 
 	var err error
+	var agentURL string
 
 	if k.proxy == nil {
 		return errorMissingProxy
@@ -627,18 +632,25 @@ func (k *kataAgent) startProxy(sandbox *Sandbox) error {
 	}
 
 	if k.state.URL != "" {
-		k.Logger().WithFields(logrus.Fields{
-			"sandbox":   sandbox.id,
-			"proxy-pid": k.state.ProxyPid,
-			"proxy-url": k.state.URL,
-		}).Infof("proxy already started")
-		return nil
-	}
-
-	// Get agent socket path to provide it to the proxy.
-	agentURL, err := k.agentURL()
-	if err != nil {
-		return err
+		// For keepConn case, when k.state.URL isn't nil, it means shimv2 had disconnected from
+		// sandbox and try to relaunch sandbox again. Here it needs to start proxy again to watch
+		// the hypervisor console.
+		if k.keepConn {
+			agentURL = k.state.URL
+		} else {
+			k.Logger().WithFields(logrus.Fields{
+				"sandbox":   sandbox.id,
+				"proxy-pid": k.state.ProxyPid,
+				"proxy-url": k.state.URL,
+			}).Infof("proxy already started")
+			return nil
+		}
+	} else {
+		// Get agent socket path to provide it to the proxy.
+		agentURL, err = k.agentURL()
+		if err != nil {
+			return err
+		}
 	}
 
 	consoleURL, err := sandbox.hypervisor.getSandboxConsole(sandbox.id)

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -32,6 +32,10 @@ func (n *noopAgent) init(ctx context.Context, sandbox *Sandbox, config interface
 	return false, nil
 }
 
+func (n *noopAgent) longLiveConn() bool {
+	return false
+}
+
 // createSandbox is the Noop agent sandbox creation implementation. It does nothing.
 func (n *noopAgent) createSandbox(sandbox *Sandbox) error {
 	return nil


### PR DESCRIPTION
When do the reloading sandbox in shimv2, it's needed to
rewatch the hypervisor's console when debug enabled.

Fixes:#2091

Signed-off-by: lifupan <lifupan@gmail.com>