### PR TITLE
virtcontainers: add firecracker initrd support

### DIFF
--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -813,3 +813,7 @@ func (a *Acrn) loadInfo() error {
 	}
 	return nil
 }
+
+func (a *Acrn) getVirtDriveOffset() int {
+	return 0
+}

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -1313,5 +1313,8 @@ func (clh *cloudHypervisor) vmInfo() (chclient.VmInfo, error) {
 		clh.Logger().WithError(openAPIClientError(err)).Warn("VmInfoGet failed")
 	}
 	return info, openAPIClientError(err)
+}
 
+func (clh *cloudHypervisor) getVirtDriveOffset() int {
+	return 0
 }

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -34,6 +34,11 @@ type DeviceReceiver interface {
 
 	// this is only for virtio-blk and virtio-scsi support
 	GetAndSetSandboxBlockIndex() (int, error)
+
+	// Offset w.r.t. the sandbox block index, to be used when determining
+	// a virtio-block drive name.
+	GetSandboxBlockOffset() int
+
 	UnsetSandboxBlockIndex(int) error
 	GetHypervisorType() string
 

--- a/virtcontainers/device/api/mockDeviceReceiver.go
+++ b/virtcontainers/device/api/mockDeviceReceiver.go
@@ -41,3 +41,8 @@ func (mockDC *MockDeviceReceiver) AppendDevice(Device) error {
 func (mockDC *MockDeviceReceiver) GetHypervisorType() string {
 	return ""
 }
+
+// GetSandboxBlockOffset returns an offset w.r.t. the sandbox block index
+func (mockDC *MockDeviceReceiver) GetSandboxBlockOffset() int {
+	return 0
+}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -802,4 +802,8 @@ type hypervisor interface {
 
 	// generate the socket to communicate the host and guest
 	generateSocket(id string, useVsock bool) (interface{}, error)
+
+	// virtio-block drive offset for virtio-block hotplugging. The offset takes
+	// into account drives pre-allocated by the hypervisor, e.g. for the rootfs.
+	getVirtDriveOffset() int
 }

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -128,3 +128,7 @@ func (m *mockHypervisor) check() error {
 func (m *mockHypervisor) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return types.Socket{HostPath: "/tmp/socket", Name: "socket"}, nil
 }
+
+func (m *mockHypervisor) getVirtDriveOffset() int {
+	return 0
+}

--- a/virtcontainers/pkg/firecracker/client/models/boot_source.go
+++ b/virtcontainers/pkg/firecracker/client/models/boot_source.go
@@ -20,6 +20,9 @@ type BootSource struct {
 	// Kernel boot arguments
 	BootArgs string `json:"boot_args,omitempty"`
 
+	// Host level path to the initrd image used to boot the guest
+	InitrdPath string `json:"initrd_path,omitempty"`
+
 	// Host level path to the kernel image used to boot the guest
 	// Required: true
 	KernelImagePath *string `json:"kernel_image_path"`

--- a/virtcontainers/pkg/firecracker/firecracker.yaml
+++ b/virtcontainers/pkg/firecracker/firecracker.yaml
@@ -357,8 +357,8 @@ paths:
     put:
       summary: Creates/updates a vsock device.
       description:
-        The first call creates the device with the configuration specified 
-        in body. Subsequent calls will update the device configuration. 
+        The first call creates the device with the configuration specified
+        in body. Subsequent calls will update the device configuration.
         May fail if update is not possible.
       operationId: putGuestVsock
       parameters:
@@ -391,6 +391,9 @@ definitions:
       kernel_image_path:
         type: string
         description: Host level path to the kernel image used to boot the guest
+      initrd_path:
+        type: string
+        description: Host level path to the initrd image used to boot the guest
       boot_args:
         type: string
         description: Kernel boot arguments

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -2268,3 +2268,7 @@ func (q *qemu) check() error {
 func (q *qemu) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return generateVMSocket(id, useVsock, q.store.RunVMStoragePath())
 }
+
+func (q *qemu) getVirtDriveOffset() int {
+	return 0
+}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -2310,3 +2310,11 @@ func (s *Sandbox) getSandboxCPUSet() (string, string, error) {
 
 	return cpuResult.String(), memResult.String(), nil
 }
+
+// GetSandboxBlockOffset returns an offset w.r.t. the sandbox block index, to be
+// used when determining a virtio-block drive name. An offset may be present if
+// specific drive names are reserved, e.g. for a sandbox rootfs, but not
+// included in the BlockIndexMap.
+func (s *Sandbox) GetSandboxBlockOffset() int {
+	return s.hypervisor.getVirtDriveOffset()
+}


### PR DESCRIPTION
Add the ability to boot a firecracker VM using an initrd instead of a
block device.

Fixes: #2093

Signed-off-by: Marco Vedovati <mvedovati@suse.com>