### PR TITLE
cli: add kata-overhead subcommand

### DIFF
--- a/cli/kata-overhead.go
+++ b/cli/kata-overhead.go
@@ -1,0 +1,136 @@
+// +build cgo,linux
+// Copyright (c) 2014,2015,2016 Docker, Inc.
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kata-containers/runtime/pkg/katautils"
+	"github.com/kata-containers/runtime/virtcontainers/types"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var kataOverheadCLICommand = cli.Command{
+	Name:  "kata-overhead",
+	Usage: "provides kata overhead at sandbox level",
+	ArgsUsage: `<sandbox-id> [sandbox-id...]
+
+   <sandbox-id> is your name for the instance of the sandbox.`,
+
+	Description: `The kata-overhead command shows the overhead of a running Kata sandbox. Overhead 
+       is calculated as the sum of pod resource utilization as measured on host cgroup minus the total
+       container usage measured inside the Kata guest for each container's cgroup.`,
+
+	Action: func(context *cli.Context) error {
+		ctx, err := cliContextToContext(context)
+		if err != nil {
+			return err
+		}
+
+		args := context.Args()
+		if !args.Present() {
+			return fmt.Errorf("Missing container ID, should at least provide one")
+		}
+
+		for _, cID := range []string(args) {
+			if err := overhead(ctx, cID); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func overhead(ctx context.Context, containerID string) error {
+	span, _ := katautils.Trace(ctx, "overhead")
+	defer span.Finish()
+
+	kataLog = kataLog.WithField("container", containerID)
+	setExternalLoggers(ctx, kataLog)
+	span.SetTag("container", containerID)
+
+	status, sandboxID, err := getExistingContainerInfo(ctx, containerID)
+	if err != nil {
+		return err
+	}
+
+	containerID = status.ID
+
+	kataLog = kataLog.WithFields(logrus.Fields{
+		"container": containerID,
+		"sandbox":   sandboxID,
+	})
+
+	setExternalLoggers(ctx, kataLog)
+	span.SetTag("container", containerID)
+	span.SetTag("sandbox", sandboxID)
+
+	if status.State.State == types.StateStopped {
+		return fmt.Errorf("container with id %s is not running", status.ID)
+	}
+
+	initTime := time.Now().UnixNano()
+
+	initialSandboxStats, initialContainerStats, err := vci.StatsSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+
+	hostInitCPU := initialSandboxStats.CgroupStats.CPUStats.CPUUsage.TotalUsage
+	guestInitCPU := uint64(0)
+	for _, cs := range initialContainerStats {
+		guestInitCPU += cs.CgroupStats.CPUStats.CPUUsage.TotalUsage
+	}
+
+	// Wait for 1 second to calculate CPU usage
+	time.Sleep(time.Second * 1)
+	finishtTime := time.Now().UnixNano()
+
+	finishSandboxStats, finishContainersStats, err := vci.StatsSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+
+	hostFinalCPU := finishSandboxStats.CgroupStats.CPUStats.CPUUsage.TotalUsage
+	guestFinalCPU := uint64(0)
+	for _, cs := range finishContainersStats {
+		guestFinalCPU += cs.CgroupStats.CPUStats.CPUUsage.TotalUsage
+	}
+
+	var guestMemoryUsage uint64
+	for _, cs := range finishContainersStats {
+		guestMemoryUsage += cs.CgroupStats.MemoryStats.Usage.Usage
+	}
+
+	hostMemoryUsage := finishSandboxStats.CgroupStats.MemoryStats.Usage.Usage
+	deltaTime := finishtTime - initTime
+
+	cpuUsageGuest := float64(guestFinalCPU-guestInitCPU) / float64(deltaTime) * 100
+	cpuUsageHost := float64(hostFinalCPU-hostInitCPU) / float64(deltaTime) * 100
+
+	fmt.Printf("Sandbox overhead for container: %s\n", containerID)
+	fmt.Printf("cpu_overhead=%f\n", cpuUsageHost-cpuUsageGuest)
+	fmt.Printf("memory_overhead_bytes=%d\n\n", hostMemoryUsage-guestMemoryUsage)
+	fmt.Printf(" --CPU details--\n")
+	fmt.Printf("cpu_host=%f\n", cpuUsageHost)
+	fmt.Printf("\tcpu_host_init=%d\n", hostInitCPU)
+	fmt.Printf("\tcpu_host_final=%d\n", hostFinalCPU)
+	fmt.Printf("cpu_guest=%f\n", cpuUsageGuest)
+	fmt.Printf("\tcpu_guest_init=%d\n", guestInitCPU)
+	fmt.Printf("\tcpu_guest_final=%d\n", guestFinalCPU)
+	fmt.Printf("Number of available vCPUs=%d\n", finishSandboxStats.Cpus)
+	fmt.Printf(" --Memory details--\n")
+	fmt.Printf("memory_host_bytes=%d\n", hostMemoryUsage)
+	fmt.Printf("memory_guest_bytes=%d\n\n", guestMemoryUsage)
+
+	return nil
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -134,6 +134,7 @@ var runtimeCommands = []cli.Command{
 	kataCheckCLICommand,
 	kataEnvCLICommand,
 	kataNetworkCLICommand,
+	kataOverheadCLICommand,
 	factoryCLICommand,
 }
 

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -717,7 +717,7 @@ func (c *Container) createBlockDevices() error {
 }
 
 // newContainer creates a Container structure from a sandbox and a container configuration.
-func newContainer(sandbox *Sandbox, contConfig ContainerConfig) (*Container, error) {
+func newContainer(sandbox *Sandbox, contConfig *ContainerConfig) (*Container, error) {
 	span, _ := sandbox.trace("newContainer")
 	defer span.Finish()
 
@@ -729,7 +729,7 @@ func newContainer(sandbox *Sandbox, contConfig ContainerConfig) (*Container, err
 		id:            contConfig.ID,
 		sandboxID:     sandbox.id,
 		rootFs:        contConfig.RootFs,
-		config:        &contConfig,
+		config:        contConfig,
 		sandbox:       sandbox,
 		runPath:       store.ContainerRuntimeRootPath(sandbox.id, contConfig.ID),
 		configPath:    store.ContainerConfigurationRootPath(sandbox.id, contConfig.ID),
@@ -812,7 +812,7 @@ func (c *Container) createMounts() error {
 	return nil
 }
 
-func (c *Container) createDevices(contConfig ContainerConfig) error {
+func (c *Container) createDevices(contConfig *ContainerConfig) error {
 	// If sandbox supports "newstore", only newly created container can reach this function,
 	// so we don't call restore when `supportNewStore` is true
 	if !c.sandbox.supportNewStore() {

--- a/virtcontainers/implementation.go
+++ b/virtcontainers/implementation.go
@@ -122,6 +122,11 @@ func (impl *VCImpl) StatsContainer(ctx context.Context, sandboxID, containerID s
 	return StatsContainer(ctx, sandboxID, containerID)
 }
 
+// StatsSandbox implements the VC function of the same name.
+func (impl *VCImpl) StatsSandbox(ctx context.Context, sandboxID string) (SandboxStats, []ContainerStats, error) {
+	return StatsSandbox(ctx, sandboxID)
+}
+
 // KillContainer implements the VC function of the same name.
 func (impl *VCImpl) KillContainer(ctx context.Context, sandboxID, containerID string, signal syscall.Signal, all bool) error {
 	return KillContainer(ctx, sandboxID, containerID, signal, all)

--- a/virtcontainers/interfaces.go
+++ b/virtcontainers/interfaces.go
@@ -41,6 +41,7 @@ type VC interface {
 	StartContainer(ctx context.Context, sandboxID, containerID string) (VCContainer, error)
 	StatusContainer(ctx context.Context, sandboxID, containerID string) (ContainerStatus, error)
 	StatsContainer(ctx context.Context, sandboxID, containerID string) (ContainerStats, error)
+	StatsSandbox(ctx context.Context, sandboxID string) (SandboxStats, []ContainerStats, error)
 	StopContainer(ctx context.Context, sandboxID, containerID string) (VCContainer, error)
 	ProcessListContainer(ctx context.Context, sandboxID, containerID string, options ProcessListOptions) (ProcessList, error)
 	UpdateContainer(ctx context.Context, sandboxID, containerID string, resources specs.LinuxResources) error

--- a/virtcontainers/pkg/vcmock/mock.go
+++ b/virtcontainers/pkg/vcmock/mock.go
@@ -200,6 +200,15 @@ func (m *VCMock) StatsContainer(ctx context.Context, sandboxID, containerID stri
 	return vc.ContainerStats{}, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerID: %v", mockErrorPrefix, getSelf(), m, sandboxID, containerID)
 }
 
+// StatsSandbox implements the VC function of the same name.
+func (m *VCMock) StatsSandbox(ctx context.Context, sandboxID string) (vc.SandboxStats, []vc.ContainerStats, error) {
+	if m.StatsContainerFunc != nil {
+		return m.StatsSandboxFunc(ctx, sandboxID)
+	}
+
+	return vc.SandboxStats{}, []vc.ContainerStats{}, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
+}
+
 // KillContainer implements the VC function of the same name.
 func (m *VCMock) KillContainer(ctx context.Context, sandboxID, containerID string, signal syscall.Signal, all bool) error {
 	if m.KillContainerFunc != nil {

--- a/virtcontainers/pkg/vcmock/types.go
+++ b/virtcontainers/pkg/vcmock/types.go
@@ -54,6 +54,7 @@ type VCMock struct {
 	StartSandboxFunc   func(ctx context.Context, sandboxID string) (vc.VCSandbox, error)
 	StatusSandboxFunc  func(ctx context.Context, sandboxID string) (vc.SandboxStatus, error)
 	StatsContainerFunc func(ctx context.Context, sandboxID, containerID string) (vc.ContainerStats, error)
+	StatsSandboxFunc   func(ctx context.Context, sandboxID string) (vc.SandboxStats, []vc.ContainerStats, error)
 	StopSandboxFunc    func(ctx context.Context, sandboxID string, force bool) (vc.VCSandbox, error)
 
 	CreateContainerFunc      func(ctx context.Context, sandboxID string, containerConfig vc.ContainerConfig) (vc.VCSandbox, vc.VCContainer, error)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1099,7 +1099,7 @@ func (s *Sandbox) fetchContainers() error {
 		contConfig.Spec = &spec
 		s.config.Containers[i] = contConfig
 
-		c, err := newContainer(s, contConfig)
+		c, err := newContainer(s, &s.config.Containers[i])
 		if err != nil {
 			return err
 		}
@@ -1118,7 +1118,7 @@ func (s *Sandbox) fetchContainers() error {
 func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, error) {
 	storeAlreadyExists := store.VCContainerStoreExists(s.ctx, s.id, contConfig.ID)
 	// Create the container.
-	c, err := newContainer(s, contConfig)
+	c, err := newContainer(s, &contConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1417,7 +1417,7 @@ func (s *Sandbox) createContainers() error {
 
 	for _, contConfig := range s.config.Containers {
 
-		c, err := newContainer(s, contConfig)
+		c, err := newContainer(s, &contConfig)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -621,7 +621,7 @@ func TestSandboxGetContainer(t *testing.T) {
 
 	contID := "999"
 	contConfig := newTestContainerConfigNoop(contID)
-	nc, err := newContainer(p, contConfig)
+	nc, err := newContainer(p, &contConfig)
 	assert.NoError(err)
 
 	err = p.addContainer(nc)
@@ -1043,7 +1043,7 @@ func TestDeleteStoreWhenNewContainerFail(t *testing.T) {
 			DevType:       "",
 		},
 	}
-	_, err = newContainer(p, contConfig)
+	_, err = newContainer(p, &contConfig)
 	assert.NotNil(t, err, "New container with invalid device info should fail")
 	storePath := store.ContainerConfigurationRootPath(testSandboxID, contID)
 	_, err = os.Stat(storePath)


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

With the introduction of sandbox_cgroup_only configuration option for kata-runtime now is possible to calculate the overhead of a kata sandbox by calculating the differnce usage of the containers running in the guest and the resource of the Sandbox cgroup.

Consider add kata-runtime kata-overhead to provide overhead of kata for CPU and memory.

Having this will help users to calculate their own overhead uses-cases.

#### Describe the solution you'd like
```
kata-runtime kata-overhead  <sandbox-id|container-id>
cpu_overhead=120
memory_overhead=1000
```