### PR TITLE
virtcontainers: change firecracker socket permissions

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -599,6 +599,11 @@ func (fc *firecracker) fcStartVM() error {
 		return err
 	}
 
+	// make sure 'others' don't have access to this socket
+	if err := os.Chmod(filepath.Join(fc.jailerRoot, defaultHybridVSocketName), 0640); err != nil {
+		return fmt.Errorf("Could not change socket permissions: %v", err)
+	}
+
 	fc.state.set(vmReady)
 	return nil
 }


### PR DESCRIPTION
For security reasons, let's make sure 'others' don't have access to the
firecracker hybrid vsock

fixes #2101

Signed-off-by: Julio Montes <julio.montes@intel.com>