### PR TITLE
virtcontainers: set agent's logs vsock port

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -397,7 +397,7 @@
   revision = "8cba5a8e5f2816f26f9dc34b8ea968279a5a76eb"
 
 [[projects]]
-  digest = "1:54e0385cece7064d8afd967e0987e52cd8b261c8c7e22d84e8b25719d7379e74"
+  digest = "1:903bfb87f41dc18a533d327b5b03fd2f562f34deafcbd0db93d4be3fa8d6099c"
   name = "github.com/kata-containers/agent"
   packages = [
     "pkg/types",
@@ -405,7 +405,7 @@
     "protocols/grpc",
   ]
   pruneopts = "NUT"
-  revision = "3ffb7ca1067565a45ee9fbfcb109eb85e7e899af"
+  revision = "32c87e75c2e4c014961f104c3c59b87f2aee3384"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/kata-containers/agent"
-  revision = "3ffb7ca1067565a45ee9fbfcb109eb85e7e899af"
+  revision = "32c87e75c2e4c014961f104c3c59b87f2aee3384"
 
 [[constraint]]
   name = "github.com/containerd/cri-containerd"

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -69,6 +69,10 @@ const (
 	// CAP_NET_BIND_SERVICE capability may bind to these port numbers.
 	vSockPort = 1024
 
+	// Port where the agent will send the logs. Logs are sent through the vsock in cases
+	// where the hypervisor has no console.sock, i.e firecracker
+	vSockLogsPort = 1025
+
 	// MinHypervisorMemory is the minimum memory required for a VM.
 	MinHypervisorMemory = 256
 )

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -11,7 +11,9 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"strings"
 
+	kataclient "github.com/kata-containers/agent/protocols/client"
 	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/sirupsen/logrus"
 )
@@ -241,7 +243,8 @@ func (p *proxyBuiltin) start(params proxyParams) (int, string, error) {
 
 	// For firecracker, it hasn't support the console watching and it's consoleURL
 	// will be set empty.
-	if params.debug && params.consoleURL != "" {
+	// TODO: add support for hybrid vsocks, see https://github.com/kata-containers/runtime/issues/2098
+	if params.debug && params.consoleURL != "" && !strings.HasPrefix(params.consoleURL, kataclient.HybridVSockScheme) {
 		err := p.watchConsole(buildinProxyConsoleProto, params.consoleURL, params.logger)
 		if err != nil {
 			p.sandboxID = ""


### PR DESCRIPTION
In firecracker, there is no socket connected to /dev/console, so let's
use a vsock port to get agent's logs

fixes #2103

Signed-off-by: Julio Montes <julio.montes@intel.com>