### PR TITLE
ci: travis: Fix check when VERSION has not changed

### DIFF
--- a/.ci/versions_checker.sh
+++ b/.ci/versions_checker.sh
@@ -12,7 +12,10 @@
 # This ensures that the rest
 # of the components are merged before the runtime
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
 
 GOPATH=${GOPATH:-${HOME}/go}
 
@@ -22,7 +25,10 @@ KATA_BRANCH=${target_branch:-master}
 
 go get -d "${PACKAGING_REPO}" || true
 
-check_changes=$(git diff --name-only "origin/${KATA_BRANCH}" | grep VERSION)
+if ! check_changes=$(git diff --name-only "origin/${KATA_BRANCH}" | grep VERSION); then
+	echo "No changes in VERSION file - this is not a bump - nothing to check"
+	exit 0
+fi
 version_to_check=$(cat "${GOPATH}/src/${RUNTIME_REPO}/VERSION")
 
 if [ ! -z "$check_changes" ]; then


### PR DESCRIPTION
When VERSION file is not updated, the script should not fail.

Fixes #1581

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>