### PR TITLE
v2: Change the event and error behavior of pause/resume

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -592,17 +592,17 @@ func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (_ *ptypes
 	err = s.sandbox.PauseContainer(r.ID)
 	if err == nil {
 		c.status = task.StatusPaused
+		s.send(&eventstypes.TaskPaused{
+			ContainerID: c.id,
+		})
 		return empty, nil
 	}
 
-	c.status, err = s.getContainerStatus(c.id)
-	if err != nil {
+	if status, err := s.getContainerStatus(c.id); err != nil {
 		c.status = task.StatusUnknown
+	} else {
+		c.status = status
 	}
-
-	s.send(&eventstypes.TaskPaused{
-		ContainerID: c.id,
-	})
 
 	return empty, err
 }
@@ -624,17 +624,17 @@ func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (_ *ptyp
 	err = s.sandbox.ResumeContainer(c.id)
 	if err == nil {
 		c.status = task.StatusRunning
+		s.send(&eventstypes.TaskResumed{
+			ContainerID: c.id,
+		})
 		return empty, nil
 	}
 
-	c.status, err = s.getContainerStatus(c.id)
-	if err != nil {
+	if status, err := s.getContainerStatus(c.id); err != nil {
 		c.status = task.StatusUnknown
+	} else {
+		c.status = status
 	}
-
-	s.send(&eventstypes.TaskResumed{
-		ContainerID: c.id,
-	})
 
 	return empty, err
 }


### PR DESCRIPTION
1. Send the event when the container is paused/resumed successfully
2. Return the error of the pause/resume function rather than `getContainerStatus`.

Fixes #2121

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>