### PR TITLE
virtcontainers/annotations: use right domain name for kata annotations

### DIFF
--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -6,7 +6,7 @@
 package annotations
 
 const (
-	kataAnnotationsPrefix     = "io.kata-containers."
+	kataAnnotationsPrefix     = "io.katacontainers."
 	kataConfAnnotationsPrefix = kataAnnotationsPrefix + "config."
 	kataAnnotHypervisorPrefix = kataConfAnnotationsPrefix + "hypervisor."
 


### PR DESCRIPTION
The domain name should be used as prefix for the annotations, for
kata containers the domain name is katacontainers.io, not kata-containers.io

fixes #2123

Signed-off-by: Julio Montes <julio.montes@intel.com>