### PR TITLE
virtcontainers: unmount host mounts if container can't be created

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -857,6 +857,12 @@ func (c *Container) rollbackFailingContainerCreation() {
 	if err := c.removeDrive(); err != nil {
 		c.Logger().WithError(err).Error("rollback failed removeDrive()")
 	}
+	if err := c.unmountHostMounts(); err != nil {
+		c.Logger().WithError(err).Error("rollback failed unmountHostMounts()")
+	}
+	if err := bindUnmountContainerRootfs(c.ctx, kataHostSharedDir(), c.sandbox.id, c.id); err != nil {
+		c.Logger().WithError(err).Error("rollback failed bindUnmountContainerRootfs()")
+	}
 }
 
 func (c *Container) checkBlockDeviceSupport() bool {


### PR DESCRIPTION
Mount points, like `resolv.conf` and `hostname` are left in the
host when the cgroup creation fails.
Use `unmountHostMounts()` in the rollback function that is called
when container's creation fails.

fixes #2108

Signed-off-by: Julio Montes <julio.montes@intel.com>

cc @crobinso