### PR TITLE
virtcontainers/store: make VCStoreUUIDPath rootless

### DIFF
--- a/virtcontainers/store/filesystem_backend.go
+++ b/virtcontainers/store/filesystem_backend.go
@@ -105,7 +105,14 @@ var RunVMStoragePath = func() string {
 
 // VMUUIDStoragePath is the uuid directory.
 // It will contain all uuid info used by guest vm.
-var VMUUIDStoragePath = filepath.Join("/var/lib", StoragePathSuffix, UUIDPathSuffix)
+var VMUUIDStoragePath = func() string {
+	path := filepath.Join("/var/lib", StoragePathSuffix, UUIDPathSuffix)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
+
+}
 
 func itemToFile(item Item) (string, error) {
 	switch item {

--- a/virtcontainers/store/vc.go
+++ b/virtcontainers/store/vc.go
@@ -271,7 +271,7 @@ func SandboxConfigurationItemPath(id string, item Item) (string, error) {
 
 // VCStoreUUIDPath returns a virtcontainers runtime uuid URL.
 func VCStoreUUIDPath() string {
-	return filesystemScheme + "://" + filepath.Join(VCStorePrefix, VMUUIDStoragePath)
+	return filesystemScheme + "://" + filepath.Join(VCStorePrefix, VMUUIDStoragePath())
 }
 
 // SandboxRuntimeRoot returns a virtcontainers sandbox runtime root URL.


### PR DESCRIPTION
The uuid file shouldn't be created at `/var` if running rootless.
Modify `VMUUIDStoragePath` to get a path accessible for non-root users
if running rootless.

fixes #2133

Signed-off-by: Julio Montes <julio.montes@intel.com>