### PR TITLE
rootless: Fix cgroup creation logic for rootless

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -916,7 +916,7 @@ func (c *Container) create() (err error) {
 	}
 	c.process = *process
 
-	if !c.sandbox.config.SandboxCgroupOnly || !rootless.IsRootless() {
+	if !rootless.IsRootless() && !c.sandbox.config.SandboxCgroupOnly {
 		if err = c.cgroupsCreate(); err != nil {
 			return
 		}


### PR DESCRIPTION
We do not want to create cgroups in case of rootless.
Fix the logic to implement this.

Fixes #2177

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>