### PR TITLE
Support "Configuration" in "newstore" feature

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -13,6 +13,7 @@ import (
 
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
@@ -307,7 +308,14 @@ func ListSandbox(ctx context.Context) ([]SandboxStatus, error) {
 	span, ctx := trace(ctx, "ListSandbox")
 	defer span.Finish()
 
-	dir, err := os.Open(store.ConfigStoragePath())
+	var sbsdir string
+	if supportNewStore(ctx) {
+		sbsdir = fs.RunStoragePath()
+	} else {
+		sbsdir = store.RunStoragePath()
+	}
+
+	dir, err := os.Open(sbsdir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No sandbox directory is not an error

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -417,6 +417,7 @@ func (c *Container) storeContainer() error {
 		if err := c.sandbox.Save(); err != nil {
 			return err
 		}
+		return nil
 	}
 	return c.store.Store(store.Configuration, *(c.config))
 }

--- a/virtcontainers/experimental/experimental.go
+++ b/virtcontainers/experimental/experimental.go
@@ -6,6 +6,7 @@
 package experimental
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 )
@@ -22,8 +23,11 @@ type Feature struct {
 	ExpRelease string
 }
 
+type contextKey struct{}
+
 var (
 	supportedFeatures = make(map[string]Feature)
+	expContextKey     = contextKey{}
 )
 
 // Register register a new experimental feature
@@ -60,4 +64,17 @@ func validateFeature(feature Feature) error {
 	}
 
 	return nil
+}
+
+func ContextWithExp(ctx context.Context, names []string) context.Context {
+	return context.WithValue(ctx, expContextKey, names)
+}
+
+func ExpFromContext(ctx context.Context) []string {
+	value := ctx.Value(expContextKey)
+	if value == nil {
+		return nil
+	}
+	names := value.([]string)
+	return names
 }


### PR DESCRIPTION
Store the configuration file in persist.go.

This is the last file we should support for "newstore" feature, after this, we can safely remove old persistence storage drivers.