### PR TITLE
rootless: Fix rangeUID parsing (Backport to 1.9)

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -90,7 +90,7 @@ func setRootless() error {
 		if err != nil {
 			return parseError
 		}
-		rangeUID, err := strconv.ParseUint(ids[1], 10, 0)
+		rangeUID, err := strconv.ParseUint(ids[2], 10, 0)
 		if err != nil || rangeUID == 0 {
 			return parseError
 		}

--- a/pkg/rootless/rootless_test.go
+++ b/pkg/rootless/rootless_test.go
@@ -119,6 +119,7 @@ func TestIsRootless(t *testing.T) {
 			uidMap: []uidMapping{
 				{0, 0, 0},
 				{1, 0, 0},
+				{0, 1, 0},
 				{1, 1000, 0},
 				{1000, 1000, 0},
 			},


### PR DESCRIPTION
`rangeUID` should be parsed as ids[2] rather than ids[1]

Fixes: #2173
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>
(cherry picked from commit 3f1a39c442b7786b028b05c81c381acee4edb1a9)