### PR TITLE
fc: config: vhost-net not supported

### DIFF
--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -160,9 +160,6 @@ use_vsock = true
 # Default false
 #hotplug_vfio_on_root_bus = true
 
-# If host doesn't support vhost_net, set to true. Thus we won't create vhost fds for nics.
-# Default false
-#disable_vhost_net = true
 #
 # Default entropy source.
 # The path to a host source of entropy (including a real hardware RNG)

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -533,6 +533,7 @@ func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DisableNestingChecks:  h.DisableNestingChecks,
 		BlockDeviceDriver:     blockDriver,
 		EnableIOThreads:       h.EnableIOThreads,
+		DisableVhostNet:       true, // vhost-net backend is not supported in Firecracker
 		UseVSock:              true,
 		GuestHookPath:         h.guestHookPath(),
 	}, nil


### PR DESCRIPTION
vhost-net backend is not supported by the Firecracker VMM. It doesn't
make sense to have this in the configuration, and we should explicitly
disable it.

Fixes: #2192

Signed-off-by: Eric Ernst <eric.ernst@intel.com>