### PR TITLE
qemu-configs: update disable_vhost_net description

### DIFF
--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -212,9 +212,10 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # Default false
 #hotplug_vfio_on_root_bus = true
 
-# If host doesn't support vhost_net, set to true. Thus we won't create vhost fds for nics.
-# Default false
+# If vhost-net backend for virtio-net is not desired, set to true. Default is false, which trades off
+# security (vhost-net runs ring0) for network I/O performance. 
 #disable_vhost_net = true
+
 #
 # Default entropy source.
 # The path to a host source of entropy (including a real hardware RNG)

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -213,9 +213,10 @@ enable_iothreads = @DEFENABLEIOTHREADS@
 # Default false
 #hotplug_vfio_on_root_bus = true
 
-# If host doesn't support vhost_net, set to true. Thus we won't create vhost fds for nics.
-# Default false
+# If vhost-net backend for virtio-net is not desired, set to true. Default is false, which trades off
+# security (vhost-net runs ring0) for network I/O performance. 
 #disable_vhost_net = true
+
 #
 # Default entropy source.
 # The path to a host source of entropy (including a real hardware RNG)


### PR DESCRIPTION
I think we should consider disable vhost-net for QEMU configuration in 1.10, though I'd like to get feedback from users/community here.

In the meantime, let's clarify what this configuration does.

Fixes: ###

Signed-off-by: Eric Ernst <eric.ernst@intel.com>