### PR TITLE
clh: fix build

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -109,7 +109,7 @@ var clhDebugKernelParams = []Param{
 //
 //###########################################################
 
-func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore) error {
+func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore, stateful bool) error {
 	clh.ctx = ctx
 
 	span, _ := clh.trace("createSandbox")


### PR DESCRIPTION
PR #2202 changed createSandbox() interface but didn't get a chance
to match with cloud hypervisor change.

Fixes: #2213

This just fixes build. Actual support for debug log on cloud hypervisor should be added later.