### PR TITLE
config: Disable jailer by default for firecracker

### DIFF
--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -16,7 +16,9 @@ path = "@FCPATH@"
 # If the jailer path is not set kata will launch firecracker
 # without a jail. If the jailer is set firecracker will be
 # launched in a jailed enviornment created by the jailer
-jailer_path = "@FCJAILERPATH@"
+# This is disabled by default as additional setup is required
+# for this feature today.
+#jailer_path = "@FCJAILERPATH@"
 kernel = "@KERNELPATH_FC@"
 image = "@IMAGEPATH@"
 


### PR DESCRIPTION
Comment out jailer path so that it is disabled by default.

Fixes #2228

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>