### PR TITLE
Land experimental "newstore" as formal feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /cli/config/configuration-nemu.toml
 /cli/config/configuration-qemu.toml
 /cli/config/configuration-qemu-virtiofs.toml
+/cli/config/configuration-clh.toml
 /cli/config-generated.go
 /cli/coverage.html
 /containerd-shim-kata-v2

--- a/cli/config/configuration-acrn.toml.in
+++ b/cli/config/configuration-acrn.toml.in
@@ -231,9 +231,7 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
-# They may break compatibility, and are prepared for a big version bump.
+# they may break compatibility, and are prepared for a big version bump.
 # Supported experimental features:
-# 1. "newstore": new persist storage driver which breaks backward compatibility,
-#				expected to move out of experimental in 2.0.0.
 # (default: [])
 experimental=@DEFAULTEXPFEATURES@

--- a/cli/config/configuration-clh.toml.in
+++ b/cli/config/configuration-clh.toml.in
@@ -207,9 +207,7 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
-# They may break compatibility, and are prepared for a big version bump.
+# they may break compatibility, and are prepared for a big version bump.
 # Supported experimental features:
-# 1. "newstore": new persist storage driver which breaks backward compatibility,
-#				expected to move out of experimental in 2.0.0.
 # (default: [])
 experimental=@DEFAULTEXPFEATURES@

--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -333,9 +333,7 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
-# They may break compatibility, and are prepared for a big version bump.
+# they may break compatibility, and are prepared for a big version bump.
 # Supported experimental features:
-# 1. "newstore": new persist storage driver which breaks backward compatibility,
-#				expected to move out of experimental in 2.0.0.
 # (default: [])
 experimental=@DEFAULTEXPFEATURES@

--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -435,9 +435,7 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
-# They may break compatibility, and are prepared for a big version bump.
+# they may break compatibility, and are prepared for a big version bump.
 # Supported experimental features:
-# 1. "newstore": new persist storage driver which breaks backward compatibility,
-#                               expected to move out of experimental in 2.0.0.
 # (default: [])
 experimental=@DEFAULTEXPFEATURES@

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -430,9 +430,7 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
-# They may break compatibility, and are prepared for a big version bump.
+# they may break compatibility, and are prepared for a big version bump.
 # Supported experimental features:
-# 1. "newstore": new persist storage driver which breaks backward compatibility,
-#				expected to move out of experimental in 2.0.0.
 # (default: [])
 experimental=@DEFAULTEXPFEATURES@

--- a/cli/kata-check_amd64.go
+++ b/cli/kata-check_amd64.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"unsafe"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/sirupsen/logrus"
 )
 
@@ -238,12 +236,7 @@ func acrnIsUsable() error {
 	kataLog.WithField("device", acrnDevice).Info("device available")
 
 	acrnInst := vc.Acrn{}
-	vcStore, err := store.NewVCSandboxStore(context.Background(), "kata-check")
-	if err != nil {
-		return err
-	}
-
-	uuidStr, err := acrnInst.GetNextAvailableUUID(vcStore)
+	uuidStr, err := acrnInst.GetNextAvailableUUID()
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -7,6 +7,7 @@ package virtcontainers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
@@ -27,6 +29,25 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
+
+// Since ACRN is using the store in a quite abnormal way, let's first draw it back from store to here
+
+// UUIDPathSuffix is the suffix used for uuid storage
+const (
+	UUIDPathSuffix = "uuid"
+	uuidFile       = "uuid.json"
+)
+
+// VMUUIDStoragePath is the uuid directory.
+// It will contain all uuid info used by guest vm.
+var VMUUIDStoragePath = func() string {
+	path := filepath.Join("/run/vc", UUIDPathSuffix)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
+
+}
 
 // ACRN currently supports only known UUIDs for security
 // reasons (FuSa). When launching VM, only these pre-defined
@@ -73,7 +94,6 @@ type AcrnState struct {
 // Acrn is an Hypervisor interface implementation for the Linux acrn hypervisor.
 type Acrn struct {
 	id         string
-	store      *store.VCStore
 	config     HypervisorConfig
 	acrnConfig Config
 	state      AcrnState
@@ -276,7 +296,7 @@ func (a *Acrn) buildDevices(imagePath string) ([]Device, error) {
 }
 
 // setup sets the Acrn structure up.
-func (a *Acrn) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore) error {
+func (a *Acrn) setup(id string, hypervisorConfig *HypervisorConfig) error {
 	span, _ := a.trace("setup")
 	defer span.Finish()
 
@@ -286,24 +306,19 @@ func (a *Acrn) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *sto
 	}
 
 	a.id = id
-	a.store = vcStore
 	a.config = *hypervisorConfig
 	a.arch = newAcrnArch(a.config)
 
 	var create bool
 	var uuid string
 
-	if a.store != nil { //use old store
-		if err = a.store.Load(store.Hypervisor, &a.state); err != nil {
-			create = true
-		}
-	} else if a.state.UUID == "" { // new store
+	if a.state.UUID == "" {
 		create = true
 	}
 
 	if create {
 		a.Logger().Debug("Setting UUID")
-		if uuid, err = a.GetNextAvailableUUID(nil); err != nil {
+		if uuid, err = a.GetNextAvailableUUID(); err != nil {
 			return err
 		}
 		a.state.UUID = uuid
@@ -313,10 +328,6 @@ func (a *Acrn) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *sto
 		// The path might already exist, but in case of VM templating,
 		// we have to create it since the sandbox has not created it yet.
 		if err = os.MkdirAll(store.SandboxRuntimeRootPath(id), store.DirMode); err != nil {
-			return err
-		}
-
-		if err = a.storeState(); err != nil {
 			return err
 		}
 
@@ -348,14 +359,14 @@ func (a *Acrn) createDummyVirtioBlkDev(devices []Device) ([]Device, error) {
 }
 
 // createSandbox is the Hypervisor sandbox creation.
-func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, store *store.VCStore, stateful bool) error {
+func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, stateful bool) error {
 	// Save the tracing context
 	a.ctx = ctx
 
 	span, _ := a.trace("createSandbox")
 	defer span.Finish()
 
-	if err := a.setup(id, hypervisorConfig, store); err != nil {
+	if err := a.setup(id, hypervisorConfig); err != nil {
 		return err
 	}
 
@@ -458,11 +469,6 @@ func (a *Acrn) startSandbox(timeoutSecs int) error {
 		return err
 	}
 
-	//Store VMM information
-	if err = a.storeState(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -499,7 +505,7 @@ func (a *Acrn) stopSandbox() (err error) {
 	uuid := a.state.UUID
 	Idx := acrnUUIDsToIdx[uuid]
 
-	if err = a.store.Load(store.UUID, &a.info); err != nil {
+	if err = a.loadInfo(); err != nil {
 		a.Logger().Info("Failed to load UUID availabiity info")
 		return err
 	}
@@ -698,7 +704,7 @@ func (a *Acrn) getPids() []int {
 	return []int{a.state.PID}
 }
 
-func (a *Acrn) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {
+func (a *Acrn) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {
 	return errors.New("acrn is not supported by VM cache")
 }
 
@@ -737,20 +743,14 @@ func (a *Acrn) GetACRNUUIDBytes(uid string) (uuid.UUID, error) {
 
 // GetNextAvailableUUID returns next available UUID VM creation
 // If no validl UUIDs are available it returns err.
-func (a *Acrn) GetNextAvailableUUID(uuidstore *store.VCStore) (string, error) {
+func (a *Acrn) GetNextAvailableUUID() (string, error) {
 	var MaxVMSupported uint8
 	var Idx uint8
 	var uuidStr string
 	var err error
 
-	if uuidstore == nil {
-		uuidstore = a.store
-	}
-
-	if uuidstore != nil { //use old store
-		if err = uuidstore.Load(store.UUID, &a.info); err != nil {
-			a.Logger().Infof("Load UUID store failed")
-		}
+	if err = a.loadInfo(); err != nil {
+		a.Logger().Infof("Load UUID store failed")
 	}
 
 	if MaxVMSupported, err = a.GetMaxSupportedACRNVM(); err != nil {
@@ -795,22 +795,79 @@ func (a *Acrn) GetMaxSupportedACRNVM() (uint8, error) {
 	return platformInfo.maxKataContainers, nil
 }
 
-func (a *Acrn) storeState() error {
-	if a.store != nil {
-		if err := a.store.Store(store.Hypervisor, a.state); err != nil {
-			a.Logger().WithError(err).Error("failed to store acrn state")
+func (a *Acrn) storeInfo() error {
+	dirPath := VMUUIDStoragePath()
+
+	_, err := os.Stat(dirPath)
+	if os.IsNotExist(err) {
+		// Root directory
+		a.Logger().WithField("path", dirPath).Debugf("Creating UUID directory")
+		if err := os.MkdirAll(dirPath, store.DirMode); err != nil {
 			return err
 		}
+	} else if err != nil {
+		return err
 	}
+
+	dirf, err := os.Open(dirPath)
+	if err != nil {
+		return err
+	}
+	defer dirf.Close()
+
+	if err := syscall.Flock(int(dirf.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return err
+	}
+
+	// write data
+	f, err := os.OpenFile(filepath.Join(dirPath, uuidFile), os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to store information into uuid.json: %v", err)
+	}
+	defer f.Close()
+
+	jsonOut, err := json.Marshal(a.info)
+	if err != nil {
+		return fmt.Errorf("Could not marshall data: %s", err)
+	}
+	f.Write(jsonOut)
 	return nil
 }
 
-func (a *Acrn) storeInfo() error {
-	if a.store != nil {
-		if err := a.store.Store(store.UUID, a.info); err != nil {
-			a.Logger().WithError(err).Error("failed to store acrn info")
-			return err
-		}
+func (a *Acrn) loadInfo() error {
+	dirPath := VMUUIDStoragePath()
+
+	_, err := os.Stat(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to load ACRN information: %v", err)
+	}
+
+	dirf, err := os.Open(dirPath)
+	if err != nil {
+		return err
+	}
+
+	if err := syscall.Flock(int(dirf.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		dirf.Close()
+		return err
+	}
+
+	defer dirf.Close()
+
+	// write data
+	f, err := os.Open(filepath.Join(dirPath, uuidFile))
+	if err != nil {
+		return fmt.Errorf("failed to load information into uuid.json: %v", err)
+	}
+
+	dec := json.NewDecoder(f)
+	if dec != nil {
+		return fmt.Errorf("failed to create json decoder")
+	}
+
+	err = dec.Decode(&a.info)
+	if err != nil {
+		return fmt.Errorf("could not decode data: %v", err)
 	}
 	return nil
 }

--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -805,7 +805,7 @@ func (a *Acrn) storeInfo() error {
 
 	jsonOut, err := json.Marshal(a.info)
 	if err != nil {
-		return fmt.Errorf("Could not marshall data: %s", err)
+		return fmt.Errorf("Could not marshal data: %s", err)
 	}
 
 	if err := store.GlobalWrite(relPath, jsonOut); err != nil {

--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -24,8 +24,8 @@ import (
 	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -327,7 +327,7 @@ func (a *Acrn) setup(id string, hypervisorConfig *HypervisorConfig) error {
 
 		// The path might already exist, but in case of VM templating,
 		// we have to create it since the sandbox has not created it yet.
-		if err = os.MkdirAll(store.SandboxRuntimeRootPath(id), store.DirMode); err != nil {
+		if err = os.MkdirAll(filepath.Join(fs.RunStoragePath(), id), DirMode); err != nil {
 			return err
 		}
 
@@ -443,8 +443,8 @@ func (a *Acrn) startSandbox(timeoutSecs int) error {
 		a.Logger().WithField("default-kernel-parameters", formatted).Debug()
 	}
 
-	vmPath := filepath.Join(store.RunVMStoragePath(), a.id)
-	err := os.MkdirAll(vmPath, store.DirMode)
+	vmPath := filepath.Join(fs.RunVMStoragePath(), a.id)
+	err := os.MkdirAll(vmPath, DirMode)
 	if err != nil {
 		return err
 	}
@@ -657,7 +657,7 @@ func (a *Acrn) getSandboxConsole(id string) (string, error) {
 	span, _ := a.trace("getSandboxConsole")
 	defer span.Finish()
 
-	return utils.BuildSocketPath(store.RunVMStoragePath(), id, acrnConsoleSocket)
+	return utils.BuildSocketPath(fs.RunVMStoragePath(), id, acrnConsoleSocket)
 }
 
 func (a *Acrn) saveSandbox() error {
@@ -802,7 +802,7 @@ func (a *Acrn) storeInfo() error {
 	if os.IsNotExist(err) {
 		// Root directory
 		a.Logger().WithField("path", dirPath).Debugf("Creating UUID directory")
-		if err := os.MkdirAll(dirPath, store.DirMode); err != nil {
+		if err := os.MkdirAll(dirPath, DirMode); err != nil {
 			return err
 		}
 	} else if err != nil {

--- a/virtcontainers/acrn_arch_base_test.go
+++ b/virtcontainers/acrn_arch_base_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -106,7 +106,7 @@ func TestAcrnArchBaseAppendConsoles(t *testing.T) {
 	assert := assert.New(t)
 	acrnArchBase := newAcrnArchBase()
 
-	path := filepath.Join(store.SandboxRuntimeRootPath(sandboxID), consoleSocket)
+	path := filepath.Join(filepath.Join(fs.RunStoragePath(), sandboxID), consoleSocket)
 
 	expectedOut := []Device{
 		ConsoleDevice{

--- a/virtcontainers/acrn_test.go
+++ b/virtcontainers/acrn_test.go
@@ -230,7 +230,7 @@ func TestAcrnCreateSandbox(t *testing.T) {
 	//set PID to 1 to ignore hypercall to get UUID and set a random UUID
 	a.state.PID = 1
 	a.state.UUID = "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-	err = a.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil, false)
+	err = a.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 	assert.Exactly(acrnConfig, a.config)
 }

--- a/virtcontainers/acrn_test.go
+++ b/virtcontainers/acrn_test.go
@@ -218,11 +218,7 @@ func TestAcrnCreateSandbox(t *testing.T) {
 		},
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.NoError(err)
-	sandbox.store = vcStore
-
-	err = globalSandboxList.addSandbox(sandbox)
+	err := globalSandboxList.addSandbox(sandbox)
 	assert.NoError(err)
 
 	defer globalSandboxList.removeSandbox(sandbox.id)

--- a/virtcontainers/acrn_test.go
+++ b/virtcontainers/acrn_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -198,7 +198,7 @@ func TestAcrnGetSandboxConsole(t *testing.T) {
 		ctx: context.Background(),
 	}
 	sandboxID := "testSandboxID"
-	expected := filepath.Join(store.RunVMStoragePath(), sandboxID, consoleSocket)
+	expected := filepath.Join(fs.RunVMStoragePath(), sandboxID, consoleSocket)
 
 	result, err := a.getSandboxConsole(sandboxID)
 	assert.NoError(err)

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -50,7 +49,6 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 	virtLog = logger.WithFields(fields)
 
 	deviceApi.SetLogger(virtLog)
-	store.SetLogger(virtLog)
 	compatoci.SetLogger(virtLog)
 }
 

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -139,7 +139,7 @@ func TestCreateSandboxNoopAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 }
@@ -176,7 +176,7 @@ func TestCreateSandboxKataAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 }
@@ -203,7 +203,7 @@ func TestDeleteSandboxNoopAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -248,7 +248,7 @@ func TestDeleteSandboxKataAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -264,7 +264,7 @@ func TestDeleteSandboxFailing(t *testing.T) {
 	defer cleanUp()
 	assert := assert.New(t)
 
-	sandboxDir := store.SandboxConfigurationRootPath(testSandboxID)
+	sandboxDir := store.SandboxRuntimeRootPath(testSandboxID)
 	os.Remove(sandboxDir)
 
 	p, err := DeleteSandbox(context.Background(), testSandboxID)
@@ -328,7 +328,7 @@ func TestStartSandboxFailing(t *testing.T) {
 	defer cleanUp()
 	assert := assert.New(t)
 
-	sandboxDir := store.SandboxConfigurationRootPath(testSandboxID)
+	sandboxDir := store.SandboxRuntimeRootPath(testSandboxID)
 	os.Remove(sandboxDir)
 
 	p, err := StartSandbox(context.Background(), testSandboxID)
@@ -395,7 +395,7 @@ func TestStopSandboxKataAgentSuccessful(t *testing.T) {
 func TestStopSandboxFailing(t *testing.T) {
 	defer cleanUp()
 
-	sandboxDir := store.SandboxConfigurationRootPath(testSandboxID)
+	sandboxDir := store.SandboxRuntimeRootPath(testSandboxID)
 	os.Remove(sandboxDir)
 
 	p, err := StopSandbox(context.Background(), testSandboxID, false)
@@ -413,7 +413,7 @@ func TestRunSandboxNoopAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 }
@@ -451,7 +451,7 @@ func TestRunSandboxKataAgentSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -680,7 +680,7 @@ func TestCreateContainerSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -734,7 +734,7 @@ func TestDeleteContainerSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -778,7 +778,7 @@ func TestDeleteContainerFailingNoContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -835,7 +835,7 @@ func TestStartContainerFailingNoContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -856,7 +856,7 @@ func TestStartContainerFailingSandboxNotStarted(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -936,7 +936,7 @@ func TestStopContainerFailingNoContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -1040,7 +1040,7 @@ func TestEnterContainerFailingNoContainer(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -1093,7 +1093,7 @@ func TestStatusContainerSuccessful(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -1136,7 +1136,7 @@ func TestStatusContainerStateReady(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -1199,7 +1199,7 @@ func TestStatusContainerStateRunning(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 
@@ -1414,7 +1414,7 @@ func createAndStartSandbox(ctx context.Context, config SandboxConfig) (sandbox V
 		return nil, "", err
 	}
 
-	sandboxDir = store.SandboxConfigurationRootPath(sandbox.ID())
+	sandboxDir = store.SandboxRuntimeRootPath(sandbox.ID())
 	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		return nil, "", err
@@ -1699,7 +1699,7 @@ func TestCleanupContainer(t *testing.T) {
 		CleanupContainer(ctx, p.ID(), c.ID(), true)
 	}
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := store.SandboxRuntimeRootPath(p.ID())
 
 	_, err = os.Stat(sandboxDir)
 	if err == nil {

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
@@ -517,12 +518,12 @@ func TestStatusSandboxSuccessfulStateReady(t *testing.T) {
 	expectedStatus := SandboxStatus{
 		ID: testSandboxID,
 		State: types.SandboxState{
-			State: types.StateReady,
+			State:          types.StateReady,
+			PersistVersion: 2,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 		Agent:            NoopAgentType,
-		Annotations:      sandboxAnnotations,
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
@@ -576,12 +577,12 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 	expectedStatus := SandboxStatus{
 		ID: testSandboxID,
 		State: types.SandboxState{
-			State: types.StateRunning,
+			State:          types.StateRunning,
+			PersistVersion: 2,
 		},
 		Hypervisor:       MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 		Agent:            NoopAgentType,
-		Annotations:      sandboxAnnotations,
 		ContainersStatus: []ContainerStatus{
 			{
 				ID: containerID,
@@ -615,6 +616,8 @@ func TestStatusSandboxSuccessfulStateRunning(t *testing.T) {
 
 	assert.Exactly(status, expectedStatus)
 }
+
+/*FIXME: replace DeleteAll with newstore.Destroy
 
 func TestStatusSandboxFailingFetchSandboxConfig(t *testing.T) {
 	defer cleanUp()
@@ -650,7 +653,7 @@ func TestStatusPodSandboxFailingFetchSandboxState(t *testing.T) {
 
 	_, err = StatusSandbox(ctx, p.ID())
 	assert.Error(err)
-}
+}*/
 
 func newTestContainerConfigNoop(contID string) ContainerConfig {
 	// Define the container command and bundle.
@@ -708,7 +711,7 @@ func TestCreateContainerFailingNoSandbox(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(p)
 
-	sandboxDir := store.SandboxConfigurationRootPath(p.ID())
+	sandboxDir := filepath.Join(fs.RunStoragePath(), p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.Error(err)
 
@@ -1243,6 +1246,7 @@ func TestStatusContainerStateRunning(t *testing.T) {
 	assert.Exactly(status, expectedStatus)
 }
 
+/* FIXME: replace DeleteAll with newstore.Destroy
 func TestStatusContainerFailing(t *testing.T) {
 	defer cleanUp()
 	assert := assert.New(t)
@@ -1260,7 +1264,7 @@ func TestStatusContainerFailing(t *testing.T) {
 
 	_, err = StatusContainer(ctx, p.ID(), contID)
 	assert.Error(err)
-}
+}*/
 
 func TestStatsContainerFailing(t *testing.T) {
 	defer cleanUp()

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -1364,7 +1364,6 @@ func TestProcessListContainer(t *testing.T) {
 
 	pImpl, ok := p.(*Sandbox)
 	assert.True(ok)
-	// defer store.DeleteAll()
 
 	contConfig := newTestContainerConfigNoop(contID)
 	_, c, err := CreateContainer(ctx, p.ID(), contConfig)

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	chclient "github.com/kata-containers/runtime/virtcontainers/pkg/cloud-hypervisor/client"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -184,7 +184,7 @@ func TestCloudHypervisorCleanupVM(t *testing.T) {
 		t.Errorf("cloudHypervisor.cleanupVM() expected error != %v", err)
 	}
 
-	dir := filepath.Join(store.RunVMStoragePath(), clh.id)
+	dir := filepath.Join(fs.RunVMStoragePath(), clh.id)
 	os.MkdirAll(dir, os.ModePerm)
 
 	if err := clh.cleanupVM(false); err != nil {

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -219,18 +219,8 @@ func TestClhCreateSandbox(t *testing.T) {
 		},
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
+	err = clh.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
-
-	sandbox.store = vcStore
-
-	// Create parent dir path for hypervisor.json
-	parentDir := store.SandboxConfigurationRootPath(sandbox.id)
-	assert.NoError(os.MkdirAll(parentDir, store.DirMode))
-
-	err = clh.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
-	assert.NoError(err)
-	assert.NoError(os.RemoveAll(parentDir))
 	assert.Exactly(clhConfig, clh.config)
 }
 
@@ -244,23 +234,6 @@ func TestClooudHypervisorStartSandbox(t *testing.T) {
 		APIClient: &clhClientMock{},
 		virtiofsd: &virtiofsdMock{},
 	}
-
-	sandbox := &Sandbox{
-		ctx: context.Background(),
-		id:  "testSandbox",
-		config: &SandboxConfig{
-			HypervisorConfig: clhConfig,
-		},
-	}
-
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.NoError(err)
-
-	sandbox.store = vcStore
-
-	// Create parent dir path for hypervisor.json
-	parentDir := store.SandboxConfigurationRootPath(sandbox.id)
-	assert.NoError(os.MkdirAll(parentDir, store.DirMode))
 
 	err = clh.startSandbox(10)
 	assert.NoError(err)

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 )
 
 // https://github.com/torvalds/linux/blob/master/include/uapi/linux/major.h
@@ -335,6 +336,8 @@ type Container struct {
 	systemMountsInfo SystemMountsInfo
 
 	ctx context.Context
+
+	store *store.VCStore
 }
 
 // ID returns the container identifier string.
@@ -426,9 +429,17 @@ func (c *Container) setContainerState(state types.StateString) error {
 	// update in-memory state
 	c.state.State = state
 
-	// flush data to storage
-	if err := c.sandbox.Save(); err != nil {
-		return err
+	if useOldStore(c.sandbox.ctx) {
+		// experimental runtime use "persist.json" which doesn't need "state.json" anymore
+		// update on-disk state
+		if err := c.store.Store(store.State, c.state); err != nil {
+			return err
+		}
+	} else {
+		// flush data to storage
+		if err := c.sandbox.Save(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -678,31 +689,76 @@ func newContainer(sandbox *Sandbox, contConfig *ContainerConfig) (*Container, er
 		ctx:           sandbox.ctx,
 	}
 
-	// experimental runtime use "persist.json" instead of legacy "state.json" as storage
-	err := c.Restore()
-	if err == nil {
-		//container restored
-		return c, nil
-	}
+	if useOldStore(sandbox.ctx) {
+		ctrStore, err := store.NewVCContainerStore(sandbox.ctx, c.sandboxID, c.id)
+		if err != nil {
+			return nil, err
+		}
+		c.store = ctrStore
+		state, err := c.store.LoadContainerState()
+		if err == nil {
+			c.state = state
+		}
 
-	// Unexpected error
-	if !os.IsNotExist(err) && err != errContainerPersistNotExist {
-		return nil, err
+		var process Process
+		if err := c.store.Load(store.Process, &process); err == nil {
+			c.process = process
+		}
+	} else {
+		// experimental runtime use "persist.json" instead of legacy "state.json" as storage
+		err := c.Restore()
+		if err == nil {
+			//container restored
+			return c, nil
+		}
+
+		// Unexpected error
+		if !os.IsNotExist(err) && err != errContainerPersistNotExist {
+			return nil, err
+		}
 	}
 
 	// Go to next step for first created container
-	if err = c.createMounts(); err != nil {
+	if err := c.createMounts(); err != nil {
 		return nil, err
 	}
 
-	if err = c.createDevices(contConfig); err != nil {
+	if err := c.createDevices(contConfig); err != nil {
 		return nil, err
 	}
 
 	return c, nil
 }
 
+func (c *Container) loadMounts() ([]Mount, error) {
+	var mounts []Mount
+	if err := c.store.Load(store.Mounts, &mounts); err != nil {
+		return []Mount{}, err
+	}
+
+	return mounts, nil
+}
+
+func (c *Container) loadDevices() ([]ContainerDevice, error) {
+	var devices []ContainerDevice
+
+	if err := c.store.Load(store.DeviceIDs, &devices); err != nil {
+		return []ContainerDevice{}, err
+	}
+
+	return devices, nil
+}
+
 func (c *Container) createMounts() error {
+	if useOldStore(c.sandbox.ctx) {
+		mounts, err := c.loadMounts()
+		if err == nil {
+			// restore mounts from disk
+			c.mounts = mounts
+			return nil
+		}
+	}
+
 	// Create block devices for newly created container
 	if err := c.createBlockDevices(); err != nil {
 		return err
@@ -712,6 +768,18 @@ func (c *Container) createMounts() error {
 }
 
 func (c *Container) createDevices(contConfig *ContainerConfig) error {
+	// If sandbox supports "newstore", only newly created container can reach this function,
+	// so we don't call restore when `supportNewStore` is true
+	if useOldStore(c.sandbox.ctx) {
+		// Devices will be found in storage after create stage has completed.
+		// We load devices from storage at all other stages.
+		storedDevices, err := c.loadDevices()
+		if err == nil {
+			c.devices = storedDevices
+			return nil
+		}
+	}
+
 	// If devices were not found in storage, create Device implementations
 	// from the configuration. This should happen at create.
 	var storedDevices []ContainerDevice

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 )
 
 // https://github.com/torvalds/linux/blob/master/include/uapi/linux/major.h
@@ -322,8 +321,6 @@ type Container struct {
 
 	sandbox *Sandbox
 
-	runPath       string
-	configPath    string
 	containerPath string
 	rootfsSuffix  string
 
@@ -673,8 +670,6 @@ func newContainer(sandbox *Sandbox, contConfig *ContainerConfig) (*Container, er
 		rootFs:        contConfig.RootFs,
 		config:        contConfig,
 		sandbox:       sandbox,
-		runPath:       store.ContainerRuntimeRootPath(sandbox.id, contConfig.ID),
-		configPath:    store.ContainerConfigurationRootPath(sandbox.id, contConfig.ID),
 		containerPath: filepath.Join(sandbox.id, contConfig.ID),
 		rootfsSuffix:  "rootfs",
 		state:         types.ContainerState{},

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -968,10 +968,8 @@ func (c *Container) stop(force bool) error {
 	defer func() {
 		// Save device and drive data.
 		// TODO: can we merge this saving with setContainerState()?
-		if c.sandbox.supportNewStore() {
-			if err := c.sandbox.Save(); err != nil {
-				c.Logger().WithError(err).Info("save container state failed")
-			}
+		if err := c.sandbox.Save(); err != nil {
+			c.Logger().WithError(err).Info("save container state failed")
 		}
 	}()
 

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
 	"github.com/kata-containers/runtime/virtcontainers/persist"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -267,7 +266,7 @@ func testSetupFakeRootfs(t *testing.T) (testRawFile, loopDev, mntDir string, err
 	assert.NoError(err)
 
 	mntDir = filepath.Join(tmpDir, "rootfs")
-	err = os.Mkdir(mntDir, store.DirMode)
+	err = os.Mkdir(mntDir, DirMode)
 	assert.NoError(err)
 
 	err = syscall.Mount(loopDev, mntDir, "ext4", uintptr(0), "")

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -341,18 +341,6 @@ func TestContainerAddDriveDir(t *testing.T) {
 		rootFs:  RootFs{Target: fakeRootfs, Mounted: true},
 	}
 
-	containerStore, err := store.NewVCContainerStore(sandbox.ctx, sandbox.id, container.id)
-	assert.Nil(err)
-	container.store = containerStore
-
-	// create state file
-	path := store.ContainerRuntimeRootPath(testSandboxID, container.ID())
-	stateFilePath := filepath.Join(path, store.StateFile)
-	os.Remove(stateFilePath)
-
-	_, err = os.Create(stateFilePath)
-	assert.NoError(err)
-
 	// Make the checkStorageDriver func variable point to a fake check function
 	savedFunc := checkStorageDriver
 	checkStorageDriver = func(major, minor int) (bool, error) {
@@ -405,11 +393,6 @@ func TestContainerRootfsPath(t *testing.T) {
 		rootFs:       RootFs{Target: fakeRootfs, Mounted: true},
 		rootfsSuffix: "rootfs",
 	}
-	cvcstore, err := store.NewVCContainerStore(context.Background(),
-		sandbox.id,
-		container.id)
-	assert.Nil(t, err)
-	container.store = cvcstore
 
 	container.hotplugDrive()
 	assert.Empty(t, container.rootfsSuffix)

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -92,18 +92,13 @@ func TestContainerRemoveDrive(t *testing.T) {
 		config:     &SandboxConfig{},
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(t, err)
-
-	sandbox.store = vcStore
-
 	container := Container{
 		sandbox: sandbox,
 		id:      "testContainer",
 	}
 
 	container.state.Fstype = ""
-	err = container.removeDrive()
+	err := container.removeDrive()
 
 	// hotplugRemoveDevice for hypervisor should not be called.
 	// test should pass without a hypervisor created for the container's sandbox.
@@ -123,8 +118,6 @@ func TestContainerRemoveDrive(t *testing.T) {
 	_, ok := device.(*drivers.BlockDevice)
 	assert.True(t, ok)
 	err = device.Attach(devReceiver)
-	assert.Nil(t, err)
-	err = sandbox.storeSandboxDevices()
 	assert.Nil(t, err)
 
 	container.state.Fstype = "xfs"
@@ -324,15 +317,11 @@ func TestContainerAddDriveDir(t *testing.T) {
 		},
 	}
 
-	defer store.DeleteAll()
-
-	sandboxStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(err)
-	sandbox.store = sandboxStore
-
 	sandbox.newStore, err = persist.GetDriver("fs")
 	assert.NoError(err)
 	assert.NotNil(sandbox.newStore)
+
+	defer sandbox.newStore.Destroy(sandbox.id)
 
 	contID := "100"
 	container := Container{
@@ -384,9 +373,7 @@ func TestContainerRootfsPath(t *testing.T) {
 			},
 		},
 	}
-	vcstore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	sandbox.store = vcstore
-	assert.Nil(t, err)
+
 	container := Container{
 		id:           "rootfstestcontainerid",
 		sandbox:      sandbox,

--- a/virtcontainers/factory/cache/cache_test.go
+++ b/virtcontainers/factory/cache/cache_test.go
@@ -8,6 +8,7 @@ package cache
 import (
 	"context"
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,10 +35,14 @@ func TestTemplateFactory(t *testing.T) {
 
 	ctx := context.Background()
 
-	var savedStorePath = store.VCStorePrefix
-	store.VCStorePrefix = testDir
+	ConfigStoragePathSaved := store.ConfigStoragePath
+	RunStoragePathSaved := store.RunStoragePath
+	// allow the tests to run without affecting the host system.
+	store.ConfigStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "config") }
+	store.RunStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "run") }
 	defer func() {
-		store.VCStorePrefix = savedStorePath
+		store.ConfigStoragePath = ConfigStoragePathSaved
+		store.RunStoragePath = RunStoragePathSaved
 	}()
 
 	// New

--- a/virtcontainers/factory/cache/cache_test.go
+++ b/virtcontainers/factory/cache/cache_test.go
@@ -15,7 +15,7 @@ import (
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory/direct"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 )
 
 func TestTemplateFactory(t *testing.T) {
@@ -35,14 +35,11 @@ func TestTemplateFactory(t *testing.T) {
 
 	ctx := context.Background()
 
-	ConfigStoragePathSaved := store.ConfigStoragePath
-	RunStoragePathSaved := store.RunStoragePath
+	runPathSave := fs.RunStoragePath()
+	fs.TestSetRunStoragePath(filepath.Join(testDir, "vc", "run"))
 	// allow the tests to run without affecting the host system.
-	store.ConfigStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "config") }
-	store.RunStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "run") }
 	defer func() {
-		store.ConfigStoragePath = ConfigStoragePathSaved
-		store.RunStoragePath = RunStoragePathSaved
+		fs.TestSetRunStoragePath(runPathSave)
 	}()
 
 	// New

--- a/virtcontainers/factory/cache/cache_test.go
+++ b/virtcontainers/factory/cache/cache_test.go
@@ -8,6 +8,7 @@ package cache
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,10 +19,19 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 )
 
+var rootPathSave = fs.StorageRootPath()
+
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,

--- a/virtcontainers/factory/direct/direct_test.go
+++ b/virtcontainers/factory/direct/direct_test.go
@@ -9,23 +9,36 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 )
+
+var rootPathSave = fs.StorageRootPath()
 
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
-	assert.Nil(err)
-	store.VCStorePrefix = testDir
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
 	defer func() {
 		os.RemoveAll(testDir)
-		store.VCStorePrefix = ""
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
+	assert.Nil(err)
+
+	runPathSave := fs.RunStoragePath()
+	fs.TestSetRunStoragePath(filepath.Join(testDir, "vc", "run"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetRunStoragePath(runPathSave)
 	}()
 
 	hyperConfig := vc.HypervisorConfig{

--- a/virtcontainers/factory/factory_test.go
+++ b/virtcontainers/factory/factory_test.go
@@ -9,16 +9,20 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory/base"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 const testDisabledAsNonRoot = "Test disabled as requires root privileges"
+
+var rootPathSave = fs.StorageRootPath()
 
 func TestNewFactory(t *testing.T) {
 	var config Config
@@ -41,6 +45,12 @@ func TestNewFactory(t *testing.T) {
 	assert.Error(err)
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
 
 	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
 		KernelPath: testDir,
@@ -110,6 +120,12 @@ func TestVMConfigValid(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
 
 	config := vc.VMConfig{
 		HypervisorType: vc.MockHypervisor,
@@ -159,6 +175,13 @@ func TestCheckVMConfig(t *testing.T) {
 	assert.Nil(err)
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
 	config1.HypervisorConfig = vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,
@@ -178,6 +201,13 @@ func TestFactoryGetVM(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,
@@ -337,6 +367,13 @@ func TestDeepCompare(t *testing.T) {
 		ProxyType:      vc.NoopProxyType,
 	}
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
 	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,

--- a/virtcontainers/factory/template/template_test.go
+++ b/virtcontainers/factory/template/template_test.go
@@ -9,15 +9,19 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 )
 
 const testDisabledAsNonRoot = "Test disabled as requires root privileges"
+
+var rootPathSave = fs.StorageRootPath()
 
 func TestTemplateFactory(t *testing.T) {
 	if os.Geteuid() != 0 {
@@ -29,6 +33,13 @@ func TestTemplateFactory(t *testing.T) {
 	templateWaitForAgent = 1 * time.Microsecond
 
 	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
+
+	defer func() {
+		os.RemoveAll(testDir)
+		fs.TestSetStorageRootPath(rootPathSave)
+	}()
+
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -38,7 +38,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/containerd/console"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -76,6 +75,8 @@ const (
 	fcMetricsFifo = "metrics.fifo"
 
 	defaultFcConfig = "fcConfig.json"
+	// storagePathSuffix mirrors persist/fs/fs.go:storagePathSuffix
+	storagePathSuffix = "vc"
 )
 
 // Specify the minimum version of firecracker supported
@@ -244,8 +245,8 @@ func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS N
 	// Also jailer based on the id implicitly sets up cgroups under
 	// <cgroups_base>/<exec_file_name>/<id>/
 	hypervisorName := filepath.Base(hypervisorConfig.HypervisorPath)
-	//store.ConfigStoragePath cannot be used as we need exec perms
-	fc.chrootBaseDir = filepath.Join("/var/lib/", store.StoragePathSuffix)
+	//fs.RunStoragePath cannot be used as we need exec perms
+	fc.chrootBaseDir = filepath.Join("/run", storagePathSuffix)
 
 	fc.vmPath = filepath.Join(fc.chrootBaseDir, hypervisorName, fc.id)
 	fc.jailerRoot = filepath.Join(fc.vmPath, "root") // auto created by jailer
@@ -374,7 +375,7 @@ func (fc *firecracker) fcInit(timeout int) error {
 	}
 
 	// Fetch sandbox network to be able to access it from the sandbox structure.
-	err := os.MkdirAll(fc.jailerRoot, store.DirMode)
+	err := os.MkdirAll(fc.jailerRoot, DirMode)
 	if err != nil {
 		return err
 	}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -720,7 +720,7 @@ func generateVMSocket(id string, useVsock bool) (interface{}, error) {
 		}, nil
 	}
 
-	path, err := utils.BuildSocketPath(filepath.Join(store.RunVMStoragePath(), id), defaultSocketName)
+	path, err := utils.BuildSocketPath(filepath.Join(fs.RunVMStoragePath(), id), defaultSocketName)
 	if err != nil {
 		return nil, err
 	}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -736,7 +736,7 @@ func generateVMSocket(id string, useVsock bool) (interface{}, error) {
 // hypervisor is the virtcontainers hypervisor interface.
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
-	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, store *store.VCStore, stateful bool) error
+	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, stateful bool) error
 	startSandbox(timeout int) error
 	stopSandbox() error
 	pauseSandbox() error
@@ -756,7 +756,7 @@ type hypervisor interface {
 	// getPids returns a slice of hypervisor related process ids.
 	// The hypervisor pid must be put at index 0.
 	getPids() []int
-	fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error
+	fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error
 	toGrpc() ([]byte, error)
 	check() error
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -31,6 +31,7 @@ import (
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -317,6 +318,12 @@ func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config interface
 
 	k.proxyBuiltIn = isProxyBuiltIn(sandbox.config.ProxyType)
 
+	// Fetch agent runtime info.
+	if useOldStore(sandbox.ctx) {
+		if err := sandbox.store.Load(store.Agent, &k.state); err != nil {
+			k.Logger().Debug("Could not retrieve anything from storage")
+		}
+	}
 	return disableVMShutdown, nil
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1444,13 +1444,6 @@ func (k *kataAgent) handleBlockVolumes(c *Container) ([]*grpc.Storage, error) {
 		// device is detached with detachDevices() for a container.
 		c.devices = append(c.devices, ContainerDevice{ID: id, ContainerPath: m.Destination})
 
-		if !c.sandbox.supportNewStore() {
-			if err := c.storeDevices(); err != nil {
-				k.Logger().WithField("device", id).WithError(err).Error("store device failed")
-				return nil, err
-			}
-		}
-
 		vol := &grpc.Storage{}
 
 		device := c.sandbox.devManager.GetDeviceByID(id)

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -317,13 +317,6 @@ func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config interface
 
 	k.proxyBuiltIn = isProxyBuiltIn(sandbox.config.ProxyType)
 
-	// Fetch agent runtime info.
-	if !sandbox.supportNewStore() {
-		if err := sandbox.store.Load(store.Agent, &k.state); err != nil {
-			k.Logger().Debug("Could not retrieve anything from storage")
-		}
-	}
-
 	return disableVMShutdown, nil
 }
 
@@ -730,12 +723,6 @@ func (k *kataAgent) setProxy(sandbox *Sandbox, proxy proxy, pid int, url string)
 	k.proxy = proxy
 	k.state.ProxyPid = pid
 	k.state.URL = url
-	if sandbox != nil && !sandbox.supportNewStore() {
-		if err := sandbox.store.Store(store.Agent, k.state); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -952,13 +939,6 @@ func (k *kataAgent) stopSandbox(sandbox *Sandbox) error {
 	// clean up agent state
 	k.state.ProxyPid = -1
 	k.state.URL = ""
-	if !sandbox.supportNewStore() {
-		if err := sandbox.store.Store(store.Agent, k.state); err != nil {
-			// ignore error
-			k.Logger().WithError(err).WithField("sandbox", sandbox.id).Error("failed to clean up agent state")
-		}
-	}
-
 	return nil
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -26,11 +26,11 @@ import (
 	"github.com/kata-containers/runtime/pkg/rootless"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	ns "github.com/kata-containers/runtime/virtcontainers/pkg/nsenter"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -217,7 +217,7 @@ func (k *kataAgent) Logger() *logrus.Entry {
 }
 
 func (k *kataAgent) getVMPath(id string) string {
-	return filepath.Join(store.RunVMStoragePath(), id)
+	return filepath.Join(fs.RunVMStoragePath(), id)
 }
 
 func (k *kataAgent) getSharePath(id string) string {
@@ -402,7 +402,7 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 		HostPath: sharePath,
 	}
 
-	if err = os.MkdirAll(sharedVolume.HostPath, store.DirMode); err != nil {
+	if err = os.MkdirAll(sharedVolume.HostPath, DirMode); err != nil {
 		return err
 	}
 
@@ -2126,7 +2126,7 @@ func (k *kataAgent) copyFile(src, dst string) error {
 
 	cpReq := &grpc.CopyFileRequest{
 		Path:     dst,
-		DirMode:  uint32(store.DirMode),
+		DirMode:  uint32(DirMode),
 		FileMode: st.Mode,
 		FileSize: fileSize,
 		Uid:      int32(st.Uid),

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
+	"github.com/kata-containers/runtime/virtcontainers/persist"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/mock"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
@@ -714,10 +714,10 @@ func TestAgentCreateContainer(t *testing.T) {
 		hypervisor: &mockHypervisor{},
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(err)
-
-	sandbox.store = vcStore
+	newStore, err := persist.GetDriver("fs")
+	assert.NoError(err)
+	assert.NotNil(newStore)
+	sandbox.newStore = newStore
 
 	container := &Container{
 		ctx:       sandbox.ctx,
@@ -815,12 +815,7 @@ func TestKataAgentSetProxy(t *testing.T) {
 		id:  "foobar",
 	}
 
-	vcStore, err := store.NewVCSandboxStore(s.ctx, s.id)
-	assert.Nil(err)
-
-	s.store = vcStore
-
-	err = k.setProxy(s, p, 0, "")
+	err := k.setProxy(s, p, 0, "")
 	assert.Error(err)
 }
 

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
@@ -27,7 +26,7 @@ func (m *mockHypervisor) hypervisorConfig() HypervisorConfig {
 	return HypervisorConfig{}
 }
 
-func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, store *store.VCStore, stateful bool) error {
+func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, stateful bool) error {
 	err := hypervisorConfig.valid()
 	if err != nil {
 		return err
@@ -108,7 +107,7 @@ func (m *mockHypervisor) getPids() []int {
 	return []int{m.mockPid}
 }
 
-func (m *mockHypervisor) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {
+func (m *mockHypervisor) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {
 	return errors.New("mockHypervisor is not supported by VM cache")
 }
 

--- a/virtcontainers/mock_hypervisor_test.go
+++ b/virtcontainers/mock_hypervisor_test.go
@@ -31,7 +31,7 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 	ctx := context.Background()
 
 	// wrong config
-	err := m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil, false)
+	err := m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.Error(err)
 
 	sandbox.config.HypervisorConfig = HypervisorConfig{
@@ -40,7 +40,7 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
 	}
 
-	err = m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, nil, false)
+	err = m.createSandbox(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 }
 

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -6,12 +6,14 @@
 package virtcontainers
 
 import (
+	"context"
 	"errors"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/api"
 	exp "github.com/kata-containers/runtime/virtcontainers/experimental"
 	"github.com/kata-containers/runtime/virtcontainers/persist"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/mitchellh/mapstructure"
 )
@@ -558,4 +560,26 @@ func loadSandboxConfig(id string) (*SandboxConfig, error) {
 		})
 	}
 	return sconfig, nil
+}
+
+var oldstoreKey = struct{}{}
+
+func loadSandboxConfigFromOldStore(ctx context.Context, sid string) (*SandboxConfig, context.Context, error) {
+	var config SandboxConfig
+	// We're bootstrapping
+	vcStore, err := store.NewVCSandboxStore(ctx, sid)
+	if err != nil {
+		return nil, ctx, err
+	}
+
+	if err := vcStore.Load(store.Configuration, &config); err != nil {
+		return nil, ctx, err
+	}
+
+	return &config, context.WithValue(ctx, oldstoreKey, true), nil
+}
+
+func useOldStore(ctx context.Context) bool {
+	v := ctx.Value(oldstoreKey)
+	return v != nil
 }

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -444,12 +444,7 @@ func (c *Container) Restore() error {
 }
 
 func (s *Sandbox) supportNewStore() bool {
-	for _, f := range s.config.Experimental {
-		if f == persist.NewStoreFeature && exp.Get("newstore") != nil {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 func loadSandboxConfig(id string) (*SandboxConfig, error) {

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -443,10 +443,6 @@ func (c *Container) Restore() error {
 	return nil
 }
 
-func (s *Sandbox) supportNewStore() bool {
-	return true
-}
-
 func loadSandboxConfig(id string) (*SandboxConfig, error) {
 	store, err := persist.GetDriver("fs")
 	if err != nil || store == nil {

--- a/virtcontainers/persist/api/config.go
+++ b/virtcontainers/persist/api/config.go
@@ -173,13 +173,6 @@ type KataAgentConfig struct {
 	UseVSock     bool
 }
 
-// HyperstartConfig is a structure storing information needed for
-// hyperstart agent initialization.
-type HyperstartConfig struct {
-	SockCtlName string
-	SockTtyName string
-}
-
 // ProxyConfig is a structure storing information needed from any
 // proxy in order to be properly initialized.
 type ProxyConfig struct {

--- a/virtcontainers/persist/api/interface.go
+++ b/virtcontainers/persist/api/interface.go
@@ -17,4 +17,12 @@ type PersistDriver interface {
 	// Lock locks the persist driver, "exclusive" decides whether the lock is exclusive or shared.
 	// It returns Unlock Function and errors
 	Lock(sid string, exclusive bool) (func() error, error)
+
+	// GlobalWrite writes "data" to "StorageRootPath"/"relativePath";
+	// GlobalRead reads "data" from "StorageRootPath"/"relativePath";
+	// these functions are used for writing/reading some global data,
+	// they are specially designed for ACRN so far.
+	// Don't use them too much unless you have no other choice! @weizhang555
+	GlobalWrite(relativePath string, data []byte) error
+	GlobalRead(relativePath string) ([]byte, error)
 }

--- a/virtcontainers/persist/api/interface.go
+++ b/virtcontainers/persist/api/interface.go
@@ -13,5 +13,8 @@ type PersistDriver interface {
 	// We only support get data for one whole sandbox
 	FromDisk(sid string) (SandboxState, map[string]ContainerState, error)
 	// Destroy will remove everything from storage
-	Destroy() error
+	Destroy(sid string) error
+	// Lock locks the persist driver, "exclusive" decides whether the lock is exclusive or shared.
+	// It returns Unlock Function and errors
+	Lock(sid string, exclusive bool) (func() error, error)
 }

--- a/virtcontainers/persist/fs/fs.go
+++ b/virtcontainers/persist/fs/fs.go
@@ -264,9 +264,9 @@ func (fs *FS) Lock(sandboxID string, exclusive bool) (func() error, error) {
 
 	var lockType int
 	if exclusive {
-		lockType = syscall.LOCK_EX | syscall.LOCK_NB
+		lockType = syscall.LOCK_EX
 	} else {
-		lockType = syscall.LOCK_SH | syscall.LOCK_NB
+		lockType = syscall.LOCK_SH
 	}
 
 	if err := syscall.Flock(int(f.Fd()), lockType); err != nil {

--- a/virtcontainers/persist/fs/fs.go
+++ b/virtcontainers/persist/fs/fs.go
@@ -69,6 +69,12 @@ func TestSetRunStoragePath(path string) {
 	}
 }
 
+func TestSetStorageRootPath(path string) {
+	StorageRootPath = func() string {
+		return path
+	}
+}
+
 // FS storage driver implementation
 type FS struct {
 	sandboxState   *persistapi.SandboxState
@@ -319,7 +325,7 @@ func (fs *FS) GlobalWrite(relativePath string, data []byte) error {
 	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, dirMode); err != nil {
-			fs.Logger().WithError(err).Errorf("failed to create dir %q", dir)
+			fs.Logger().WithError(err).WithField("directory", dir).Error("failed to create dir")
 			return err
 		}
 	} else if err != nil {
@@ -328,13 +334,13 @@ func (fs *FS) GlobalWrite(relativePath string, data []byte) error {
 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, fileMode)
 	if err != nil {
-		fs.Logger().WithError(err).Errorf("failed to open file %q for writting", path)
+		fs.Logger().WithError(err).WithField("file", path).Error("failed to open file for writting")
 		return err
 	}
 	defer f.Close()
 
 	if _, err := f.Write(data); err != nil {
-		fs.Logger().WithError(err).Errorf("failed to write file %q: %v ", path, err)
+		fs.Logger().WithError(err).WithField("file", path).Error("failed to write file")
 		return err
 	}
 	return nil
@@ -349,14 +355,14 @@ func (fs *FS) GlobalRead(relativePath string) ([]byte, error) {
 
 	f, err := os.Open(path)
 	if err != nil {
-		fs.Logger().WithError(err).Errorf("failed to open file %q for reading", path)
+		fs.Logger().WithError(err).WithField("file", path).Error("failed to open file for reading")
 		return nil, err
 	}
 	defer f.Close()
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		fs.Logger().WithError(err).Errorf("failed to read file %q: %v ", path, err)
+		fs.Logger().WithError(err).WithField("file", path).Error("failed to read file")
 		return nil, err
 	}
 	return data, nil

--- a/virtcontainers/persist/fs/fs.go
+++ b/virtcontainers/persist/fs/fs.go
@@ -37,10 +37,24 @@ const storagePathSuffix = "vc"
 // sandboxPathSuffix is the suffix used for sandbox storage
 const sandboxPathSuffix = "sbs"
 
+// vmPathSuffix is the suffix used for guest VMs.
+const vmPathSuffix = "vm"
+
 // RunStoragePath is the sandbox runtime directory.
 // It will contain one state.json and one lock file for each created sandbox.
 var RunStoragePath = func() string {
 	path := filepath.Join("/run", storagePathSuffix, sandboxPathSuffix)
+	if rootless.IsRootless() {
+		return filepath.Join(rootless.GetRootlessDir(), path)
+	}
+	return path
+}
+
+// RunVMStoragePath is the vm directory.
+// It will contain all guest vm sockets and shared mountpoints.
+// The function is declared this way for mocking in unit tests
+var RunVMStoragePath = func() string {
+	path := filepath.Join("/run", storagePathSuffix, vmPathSuffix)
 	if rootless.IsRootless() {
 		return filepath.Join(rootless.GetRootlessDir(), path)
 	}

--- a/virtcontainers/persist/fs/fs_test.go
+++ b/virtcontainers/persist/fs/fs_test.go
@@ -33,16 +33,12 @@ func initTestDir() func() {
 	testDir, _ := ioutil.TempDir("", "vc-tmp-")
 	// allow the tests to run without affecting the host system.
 	rootSave := StorageRootPath()
-	StorageRootPath = func() string {
-		return filepath.Join(testDir, "vc")
-	}
+	TestSetStorageRootPath(filepath.Join(testDir, "vc"))
 
 	os.MkdirAll(testDir, dirMode)
 
 	return func() {
-		StorageRootPath = func() string {
-			return rootSave
-		}
+		TestSetStorageRootPath(rootSave)
 		os.RemoveAll(testDir)
 	}
 }
@@ -53,13 +49,6 @@ func TestFsLockShared(t *testing.T) {
 	fs, err := getFsDriver()
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
-
-	testDir, err := ioutil.TempDir("", "fs-tmp-")
-	assert.Nil(t, err)
-	TestSetRunStoragePath(testDir)
-	defer func() {
-		os.RemoveAll(testDir)
-	}()
 
 	sid := "test-fs-driver"
 	fs.sandboxState.SandboxContainer = sid
@@ -115,13 +104,6 @@ func TestFsDriver(t *testing.T) {
 	fs, err := getFsDriver()
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
-
-	testDir, err := ioutil.TempDir("", "fs-tmp-")
-	assert.Nil(t, err)
-	TestSetRunStoragePath(testDir)
-	defer func() {
-		os.RemoveAll(testDir)
-	}()
 
 	ss := persistapi.SandboxState{}
 	cs := make(map[string]persistapi.ContainerState)

--- a/virtcontainers/persist_test.go
+++ b/virtcontainers/persist_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -18,47 +17,6 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/persist"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 )
-
-func testCreateExpSandbox() (*Sandbox, error) {
-	sconfig := SandboxConfig{
-		ID:               "test-exp",
-		HypervisorType:   MockHypervisor,
-		HypervisorConfig: newHypervisorConfig(nil, nil),
-		AgentType:        NoopAgentType,
-		NetworkConfig:    NetworkConfig{},
-		Volumes:          nil,
-		Containers:       nil,
-		Experimental:     []exp.Feature{persist.NewStoreFeature},
-	}
-
-	// support experimental
-	sandbox, err := createSandbox(context.Background(), sconfig, nil)
-	if err != nil {
-		return nil, fmt.Errorf("Could not create sandbox: %s", err)
-	}
-
-	if err := sandbox.agent.startSandbox(sandbox); err != nil {
-		return nil, err
-	}
-
-	return sandbox, nil
-}
-
-func TestSupportNewStore(t *testing.T) {
-	assert := assert.New(t)
-	hConfig := newHypervisorConfig(nil, nil)
-	sandbox, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NetworkConfig{}, nil, nil)
-	assert.NoError(err)
-	defer cleanUp()
-
-	// not support experimental
-	assert.False(sandbox.supportNewStore())
-
-	// support experimental
-	sandbox, err = testCreateExpSandbox()
-	assert.NoError(err)
-	assert.True(sandbox.supportNewStore())
-}
 
 func TestSandboxRestore(t *testing.T) {
 	var err error

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -29,11 +29,15 @@ import (
 )
 
 const (
-	tempBundlePath = "/tmp/virtc/ocibundle/"
-	containerID    = "virtc-oci-test"
-	consolePath    = "/tmp/virtc/console"
-	fileMode       = os.FileMode(0640)
-	dirMode        = os.FileMode(0750)
+	containerID = "virtc-oci-test"
+	fileMode    = os.FileMode(0640)
+	dirMode     = os.FileMode(0750)
+)
+
+var (
+	tempRoot       = ""
+	tempBundlePath = ""
+	consolePath    = ""
 )
 
 func createConfig(fileName string, fileData string) (string, error) {
@@ -633,16 +637,27 @@ func TestGetShmSizeBindMounted(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	var err error
+	tempRoot, err = ioutil.TempDir("", "virtc-")
+	if err != nil {
+		panic(err)
+	}
+
+	tempBundlePath = filepath.Join(tempRoot, "ocibundle")
+	consolePath = filepath.Join(tempRoot, "console")
+
 	/* Create temp bundle directory if necessary */
-	err := os.MkdirAll(tempBundlePath, dirMode)
+	err = os.MkdirAll(tempBundlePath, dirMode)
 	if err != nil {
 		fmt.Printf("Unable to create %s %v\n", tempBundlePath, err)
 		os.Exit(1)
 	}
 
-	defer os.RemoveAll(tempBundlePath)
+	ret := m.Run()
 
-	os.Exit(m.Run())
+	os.RemoveAll(tempRoot)
+
+	os.Exit(ret)
 }
 
 func TestAddAssetAnnotations(t *testing.T) {

--- a/virtcontainers/proxy.go
+++ b/virtcontainers/proxy.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	kataclient "github.com/kata-containers/agent/protocols/client"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -146,7 +146,7 @@ func validateProxyConfig(proxyConfig ProxyConfig) error {
 func defaultProxyURL(id, socketType string) (string, error) {
 	switch socketType {
 	case SocketTypeUNIX:
-		socketPath := filepath.Join(store.SandboxRuntimeRootPath(id), "proxy.sock")
+		socketPath := filepath.Join(filepath.Join(fs.RunStoragePath(), id), "proxy.sock")
 		return fmt.Sprintf("unix://%s", socketPath), nil
 	case SocketTypeVSOCK:
 		// TODO Build the VSOCK default URL

--- a/virtcontainers/proxy_test.go
+++ b/virtcontainers/proxy_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -173,7 +173,7 @@ func testDefaultProxyURL(expectedURL string, socketType string, sandboxID string
 }
 
 func TestDefaultProxyURLUnix(t *testing.T) {
-	path := filepath.Join(store.SandboxRuntimeRootPath(sandboxID), "proxy.sock")
+	path := filepath.Join(filepath.Join(fs.RunStoragePath(), sandboxID), "proxy.sock")
 	socketPath := fmt.Sprintf("unix://%s", path)
 	assert.NoError(t, testDefaultProxyURL(socketPath, SocketTypeUNIX, sandboxID))
 }
@@ -183,7 +183,7 @@ func TestDefaultProxyURLVSock(t *testing.T) {
 }
 
 func TestDefaultProxyURLUnknown(t *testing.T) {
-	path := filepath.Join(store.SandboxRuntimeRootPath(sandboxID), "proxy.sock")
+	path := filepath.Join(filepath.Join(fs.RunStoragePath(), sandboxID), "proxy.sock")
 	socketPath := fmt.Sprintf("unix://%s", path)
 	assert.Error(t, testDefaultProxyURL(socketPath, "foobar", sandboxID))
 }
@@ -204,7 +204,7 @@ func testProxyStart(t *testing.T, agent agent, proxy proxy) {
 	}
 
 	invalidPath := filepath.Join(tmpdir, "enoent")
-	expectedSocketPath := filepath.Join(store.SandboxRuntimeRootPath(testSandboxID), "proxy.sock")
+	expectedSocketPath := filepath.Join(filepath.Join(fs.RunStoragePath(), testSandboxID), "proxy.sock")
 	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
 
 	data := []testData{

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -77,8 +77,6 @@ type QemuState struct {
 type qemu struct {
 	id string
 
-	store *store.VCStore
-
 	config HypervisorConfig
 
 	qmpMonitorCh qmpChannel
@@ -226,7 +224,7 @@ func (q *qemu) trace(name string) (opentracing.Span, context.Context) {
 }
 
 // setup sets the Qemu structure up.
-func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore) error {
+func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig) error {
 	span, _ := q.trace("setup")
 	defer span.Finish()
 
@@ -236,7 +234,6 @@ func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *sto
 	}
 
 	q.id = id
-	q.store = vcStore
 	q.config = *hypervisorConfig
 	q.arch = newQemuArch(q.config)
 
@@ -255,12 +252,7 @@ func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *sto
 	}
 
 	var create bool
-	if q.store != nil { //use old store
-		if err := q.store.Load(store.Hypervisor, &q.state); err != nil {
-			// hypervisor doesn't exist, create new one
-			create = true
-		}
-	} else if q.state.UUID == "" { // new store
+	if q.state.UUID == "" {
 		create = true
 	}
 
@@ -278,10 +270,6 @@ func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig, vcStore *sto
 		// The path might already exist, but in case of VM templating,
 		// we have to create it since the sandbox has not created it yet.
 		if err = os.MkdirAll(store.SandboxRuntimeRootPath(id), store.DirMode); err != nil {
-			return err
-		}
-
-		if err = q.storeState(); err != nil {
 			return err
 		}
 	}
@@ -463,14 +451,14 @@ func (q *qemu) setupFileBackedMem(knobs *govmmQemu.Knobs, memory *govmmQemu.Memo
 }
 
 // createSandbox is the Hypervisor sandbox creation implementation for govmmQemu.
-func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore, stateful bool) error {
+func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, stateful bool) error {
 	// Save the tracing context
 	q.ctx = ctx
 
 	span, _ := q.trace("createSandbox")
 	defer span.Finish()
 
-	if err := q.setup(id, hypervisorConfig, vcStore); err != nil {
+	if err := q.setup(id, hypervisorConfig); err != nil {
 		return err
 	}
 
@@ -727,9 +715,6 @@ func (q *qemu) startSandbox(timeout int) error {
 	if q.config.SharedFS == config.VirtioFS {
 		err = q.setupVirtiofsd()
 		if err != nil {
-			return err
-		}
-		if err = q.storeState(); err != nil {
 			return err
 		}
 	}
@@ -1289,7 +1274,7 @@ func (q *qemu) hotplugAddDevice(devInfo interface{}, devType deviceType) (interf
 		return data, err
 	}
 
-	return data, q.storeState()
+	return data, nil
 }
 
 func (q *qemu) hotplugRemoveDevice(devInfo interface{}, devType deviceType) (interface{}, error) {
@@ -1301,7 +1286,7 @@ func (q *qemu) hotplugRemoveDevice(devInfo interface{}, devType deviceType) (int
 		return data, err
 	}
 
-	return data, q.storeState()
+	return data, nil
 }
 
 func (q *qemu) hotplugCPUs(vcpus uint32, op operation) (uint32, error) {
@@ -1383,13 +1368,8 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		hotpluggedVCPUs++
 		if hotpluggedVCPUs == amount {
 			// All vCPUs were hotplugged
-			return amount, q.storeState()
+			return amount, nil
 		}
-	}
-
-	// All vCPUs were NOT hotplugged
-	if err := q.storeState(); err != nil {
-		q.Logger().Errorf("failed to save hypervisor state after hotplug %d vCPUs: %v", hotpluggedVCPUs, err)
 	}
 
 	return hotpluggedVCPUs, fmt.Errorf("failed to hot add vCPUs: only %d vCPUs of %d were added", hotpluggedVCPUs, amount)
@@ -1408,7 +1388,6 @@ func (q *qemu) hotplugRemoveCPUs(amount uint32) (uint32, error) {
 		// get the last vCPUs and try to remove it
 		cpu := q.state.HotpluggedVCPUs[len(q.state.HotpluggedVCPUs)-1]
 		if err := q.qmpMonitorCh.qmp.ExecuteDeviceDel(q.qmpMonitorCh.ctx, cpu.ID); err != nil {
-			q.storeState()
 			return i, fmt.Errorf("failed to hotunplug CPUs, only %d CPUs were hotunplugged: %v", i, err)
 		}
 
@@ -1416,7 +1395,7 @@ func (q *qemu) hotplugRemoveCPUs(amount uint32) (uint32, error) {
 		q.state.HotpluggedVCPUs = q.state.HotpluggedVCPUs[:len(q.state.HotpluggedVCPUs)-1]
 	}
 
-	return amount, q.storeState()
+	return amount, nil
 }
 
 func (q *qemu) hotplugMemory(memDev *memoryDevice, op operation) (int, error) {
@@ -1522,7 +1501,7 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 		}
 	}
 	q.state.HotpluggedMemory += memDev.sizeMB
-	return memDev.sizeMB, q.storeState()
+	return memDev.sizeMB, nil
 }
 
 func (q *qemu) pauseSandbox() error {
@@ -1938,7 +1917,7 @@ type qemuGrpc struct {
 	QemuSMP govmmQemu.SMP
 }
 
-func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, store *store.VCStore, j []byte) error {
+func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {
 	var qp qemuGrpc
 	err := json.Unmarshal(j, &qp)
 	if err != nil {
@@ -1946,7 +1925,6 @@ func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig,
 	}
 
 	q.id = qp.ID
-	q.store = store
 	q.config = *hypervisorConfig
 	q.qmpMonitorCh.ctx = ctx
 	q.qmpMonitorCh.path = qp.QmpChannelpath
@@ -1976,16 +1954,6 @@ func (q *qemu) toGrpc() ([]byte, error) {
 	}
 
 	return json.Marshal(&qp)
-}
-
-func (q *qemu) storeState() error {
-	if q.store != nil {
-		q.state.Bridges = q.arch.getBridges()
-		if err := q.store.Store(store.Hypervisor, q.state); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (q *qemu) save() (s persistapi.HypervisorState) {

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/pkg/errors"
 )
@@ -259,7 +259,7 @@ func TestQemuArchBaseAppendConsoles(t *testing.T) {
 	assert := assert.New(t)
 	qemuArchBase := newQemuArchBase()
 
-	path := filepath.Join(store.SandboxRuntimeRootPath(sandboxID), consoleSocket)
+	path := filepath.Join(filepath.Join(fs.RunStoragePath(), sandboxID), consoleSocket)
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.SerialDevice{

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -99,7 +99,7 @@ func TestQemuCreateSandbox(t *testing.T) {
 	parentDir := store.SandboxConfigurationRootPath(sandbox.id)
 	assert.NoError(os.MkdirAll(parentDir, store.DirMode))
 
-	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 	assert.NoError(os.RemoveAll(parentDir))
 	assert.Exactly(qemuConfig, q.config)
@@ -131,7 +131,7 @@ func TestQemuCreateSandboxMissingParentDirFail(t *testing.T) {
 	parentDir := store.SandboxConfigurationRootPath(sandbox.id)
 	assert.NoError(os.RemoveAll(parentDir))
 
-	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 }
 
@@ -364,11 +364,7 @@ func TestHotplugUnsupportedDeviceType(t *testing.T) {
 		config: qemuConfig,
 	}
 
-	vcStore, err := store.NewVCSandboxStore(q.ctx, q.id)
-	assert.NoError(err)
-	q.store = vcStore
-
-	_, err = q.hotplugAddDevice(&memoryDevice{0, 128, uint64(0), false}, fsDev)
+	_, err := q.hotplugAddDevice(&memoryDevice{0, 128, uint64(0), false}, fsDev)
 	assert.Error(err)
 	_, err = q.hotplugRemoveDevice(&memoryDevice{0, 128, uint64(0), false}, fsDev)
 	assert.Error(err)
@@ -414,7 +410,7 @@ func TestQemuGrpc(t *testing.T) {
 	assert.Nil(err)
 
 	var q2 qemu
-	err = q2.fromGrpc(context.Background(), &config, nil, json)
+	err = q2.fromGrpc(context.Background(), &config, json)
 	assert.Nil(err)
 
 	assert.True(q.id == q2.id)
@@ -429,7 +425,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 
 	q := &qemu{}
 	sandbox.config.HypervisorConfig.SharedFS = config.VirtioFS
-	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 
 	assert.Equal(q.qemuConfig.Knobs.FileBackedMem, true)
@@ -445,7 +441,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	sandbox.config.HypervisorConfig.SharedFS = config.VirtioFS
 	sandbox.config.HypervisorConfig.MemoryPath = fallbackFileBackedMemDir
 
-	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 
 	expectErr := errors.New("VM templating has been enabled with either virtio-fs or file backed memory and this configuration will not work")
 	assert.Equal(expectErr.Error(), err.Error())
@@ -456,7 +452,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 
 	q = &qemu{}
 	sandbox.config.HypervisorConfig.FileBackedMemRootDir = "/tmp/xyzabc"
-	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, sandbox.store, false)
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
 	assert.Equal(q.qemuConfig.Knobs.FileBackedMem, false)
 	assert.Equal(q.qemuConfig.Knobs.MemShared, false)

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -17,7 +17,7 @@ import (
 	govmmQemu "github.com/intel/govmm/qemu"
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/persist"
-	"github.com/kata-containers/runtime/virtcontainers/store"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -92,8 +92,8 @@ func TestQemuCreateSandbox(t *testing.T) {
 	assert.NoError(err)
 
 	// Create parent dir path for hypervisor.json
-	parentDir := store.SandboxRuntimeRootPath(sandbox.id)
-	assert.NoError(os.MkdirAll(parentDir, store.DirMode))
+	parentDir := filepath.Join(fs.RunStoragePath(), sandbox.id)
+	assert.NoError(os.MkdirAll(parentDir, DirMode))
 
 	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
 	assert.NoError(err)
@@ -120,7 +120,7 @@ func TestQemuCreateSandboxMissingParentDirFail(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure parent dir path for hypervisor.json does not exist.
-	parentDir := store.SandboxRuntimeRootPath(sandbox.id)
+	parentDir := filepath.Join(fs.RunStoragePath(), sandbox.id)
 	assert.NoError(os.RemoveAll(parentDir))
 
 	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
@@ -280,7 +280,7 @@ func TestQemuGetSandboxConsole(t *testing.T) {
 		ctx: context.Background(),
 	}
 	sandboxID := "testSandboxID"
-	expected := filepath.Join(store.RunVMStoragePath(), sandboxID, consoleSocket)
+	expected := filepath.Join(fs.RunVMStoragePath(), sandboxID, consoleSocket)
 
 	result, err := q.getSandboxConsole(sandboxID)
 	assert.NoError(err)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -677,19 +677,7 @@ func unlockSandbox(ctx context.Context, sandboxID, token string) error {
 }
 
 func supportNewStore(ctx context.Context) bool {
-	if exp.Get("newstore") == nil {
-		return false
-	}
-
-	// check if client context enabled "newstore" feature
-	exps := exp.ExpFromContext(ctx)
-	for _, v := range exps {
-		if v == "newstore" {
-			return true
-		}
-	}
-
-	return false
+	return true
 }
 
 // fetchSandbox fetches a sandbox config from a sandbox ID and returns a sandbox.
@@ -811,6 +799,12 @@ func (s *Sandbox) Delete() error {
 	}
 
 	s.agent.cleanup(s)
+
+	if s.supportNewStore() {
+		if err := s.newStore.Destroy(); err != nil {
+			return err
+		}
+	}
 
 	return s.store.Delete()
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -566,38 +566,14 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		}
 	}()
 
-	if s.supportNewStore() {
-		s.devManager = deviceManager.NewDeviceManager(sandboxConfig.HypervisorConfig.BlockDeviceDriver, nil)
+	s.devManager = deviceManager.NewDeviceManager(sandboxConfig.HypervisorConfig.BlockDeviceDriver, nil)
 
-		// Ignore the error. Restore can fail for a new sandbox
-		s.Restore()
+	// Ignore the error. Restore can fail for a new sandbox
+	s.Restore()
 
-		// new store doesn't require hypervisor to be stored immediately
-		if err = s.hypervisor.createSandbox(ctx, s.id, s.networkNS, &sandboxConfig.HypervisorConfig, nil, s.stateful); err != nil {
-			return nil, err
-		}
-	} else {
-		// Fetch sandbox network to be able to access it from the sandbox structure.
-		var networkNS NetworkNamespace
-		if err = s.store.Load(store.Network, &networkNS); err == nil {
-			s.networkNS = networkNS
-		}
-
-		devices, err := s.store.LoadDevices()
-		if err != nil {
-			s.Logger().WithError(err).WithField("sandboxid", s.id).Warning("load sandbox devices failed")
-		}
-		s.devManager = deviceManager.NewDeviceManager(sandboxConfig.HypervisorConfig.BlockDeviceDriver, devices)
-
-		// Load sandbox state. The hypervisor.createSandbox call, may need to access statei.
-		state, err := s.store.LoadState()
-		if err == nil {
-			s.state = state
-		}
-
-		if err = s.hypervisor.createSandbox(ctx, s.id, s.networkNS, &sandboxConfig.HypervisorConfig, s.store, s.stateful); err != nil {
-			return nil, err
-		}
+	// new store doesn't require hypervisor to be stored immediately
+	if err = s.hypervisor.createSandbox(ctx, s.id, s.networkNS, &sandboxConfig.HypervisorConfig, s.stateful); err != nil {
+		return nil, err
 	}
 
 	agentConfig, err := newAgentConfig(sandboxConfig.AgentType, sandboxConfig.AgentConfig)

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 )
@@ -46,6 +45,9 @@ const (
 	// vmStartTimeout represents the time in seconds a sandbox can wait before
 	// to consider the VM starting operation failed.
 	vmStartTimeout = 10
+
+	// DirMode is the permission bits used for creating a directory
+	DirMode = os.FileMode(0750) | os.ModeDir
 )
 
 // SandboxStatus describes a sandbox status.
@@ -187,9 +189,6 @@ type Sandbox struct {
 	volumes []types.Volume
 
 	containers map[string]*Container
-
-	runPath    string
-	configPath string
 
 	state types.SandboxState
 
@@ -519,8 +518,6 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		config:          &sandboxConfig,
 		volumes:         sandboxConfig.Volumes,
 		containers:      map[string]*Container{},
-		runPath:         store.SandboxRuntimeRootPath(sandboxConfig.ID),
-		configPath:      store.SandboxConfigurationRootPath(sandboxConfig.ID),
 		state:           types.SandboxState{},
 		annotationsLock: &sync.RWMutex{},
 		wg:              &sync.WaitGroup{},

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -547,7 +547,9 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	s.devManager = deviceManager.NewDeviceManager(sandboxConfig.HypervisorConfig.BlockDeviceDriver, nil)
 
 	// Ignore the error. Restore can fail for a new sandbox
-	s.Restore()
+	if err := s.Restore(); err != nil {
+		s.Logger().WithError(err).Debug("restore sandbox failed")
+	}
 
 	// new store doesn't require hypervisor to be stored immediately
 	if err = s.hypervisor.createSandbox(ctx, s.id, s.networkNS, &sandboxConfig.HypervisorConfig, s.stateful); err != nil {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -604,38 +604,22 @@ func (s *Sandbox) storeSandbox() error {
 	return nil
 }
 
-func rLockSandbox(ctx context.Context, sandboxID string) (string, error) {
-	store, err := store.NewVCSandboxStore(ctx, sandboxID)
+func rLockSandbox(sandboxID string) (func() error, error) {
+	store, err := persist.GetDriver("fs")
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to get fs persist driver: %v", err)
 	}
 
-	return store.RLock()
+	return store.Lock(sandboxID, false)
 }
 
-func rwLockSandbox(ctx context.Context, sandboxID string) (string, error) {
-	store, err := store.NewVCSandboxStore(ctx, sandboxID)
+func rwLockSandbox(sandboxID string) (func() error, error) {
+	store, err := persist.GetDriver("fs")
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to get fs persist driver: %v", err)
 	}
 
-	return store.Lock()
-}
-
-func unlockSandbox(ctx context.Context, sandboxID, token string) error {
-	// If the store no longer exists, we won't be able to unlock.
-	// Creating a new store for locking an item that does not even exist
-	// does not make sense.
-	if !store.VCSandboxStoreExists(ctx, sandboxID) {
-		return nil
-	}
-
-	store, err := store.NewVCSandboxStore(ctx, sandboxID)
-	if err != nil {
-		return err
-	}
-
-	return store.Unlock(token)
+	return store.Lock(sandboxID, true)
 }
 
 func supportNewStore(ctx context.Context) bool {

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	"github.com/kata-containers/runtime/virtcontainers/device/manager"
 	exp "github.com/kata-containers/runtime/virtcontainers/experimental"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -682,7 +682,7 @@ func TestSandboxAttachDevicesVFIO(t *testing.T) {
 	testDeviceBDFPath := "0000:00:1c.0"
 
 	devicesDir := filepath.Join(tmpDir, testFDIOGroup, "devices")
-	err = os.MkdirAll(devicesDir, store.DirMode)
+	err = os.MkdirAll(devicesDir, DirMode)
 	assert.Nil(t, err)
 
 	deviceFile := filepath.Join(devicesDir, testDeviceBDFPath)
@@ -990,7 +990,7 @@ func TestDeleteStoreWhenNewContainerFail(t *testing.T) {
 	}
 	_, err = newContainer(p, &contConfig)
 	assert.NotNil(t, err, "New container with invalid device info should fail")
-	storePath := store.ContainerRuntimeRootPath(testSandboxID, contID)
+	storePath := filepath.Join(fs.RunStoragePath(), testSandboxID, contID)
 	_, err = os.Stat(storePath)
 	assert.NotNil(t, err, "Should delete configuration root after failed to create a container")
 }
@@ -1160,8 +1160,8 @@ func TestAttachBlockDevice(t *testing.T) {
 	}
 
 	// create state file
-	path := store.ContainerRuntimeRootPath(testSandboxID, container.ID())
-	err := os.MkdirAll(path, store.DirMode)
+	path := filepath.Join(fs.RunStoragePath(), testSandboxID, container.ID())
+	err := os.MkdirAll(path, DirMode)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(path)
@@ -1238,8 +1238,8 @@ func TestPreAddDevice(t *testing.T) {
 	container.state.State = types.StateReady
 
 	// create state file
-	path := store.ContainerRuntimeRootPath(testSandboxID, container.ID())
-	err := os.MkdirAll(path, store.DirMode)
+	path := filepath.Join(fs.RunStoragePath(), testSandboxID, container.ID())
+	err := os.MkdirAll(path, DirMode)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(path)
@@ -1336,9 +1336,6 @@ func checkDirNotExist(path string) error {
 
 func checkSandboxRemains() error {
 	var err error
-	if err = checkDirNotExist(sandboxDirConfig); err != nil {
-		return fmt.Errorf("%s still exists", sandboxDirConfig)
-	}
 	if err = checkDirNotExist(sandboxDirState); err != nil {
 		return fmt.Errorf("%s still exists", sandboxDirState)
 	}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -574,11 +574,6 @@ func TestSetAnnotations(t *testing.T) {
 		},
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.NoError(err)
-
-	sandbox.store = vcStore
-
 	keyAnnotation := "annotation2"
 	valueAnnotation := "xyz"
 	newAnnotations := map[string]string{
@@ -657,10 +652,6 @@ func TestContainerStateSetFstype(t *testing.T) {
 	assert.Nil(err)
 	defer cleanUp()
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(err)
-	sandbox.store = vcStore
-
 	c := sandbox.GetContainer("100")
 	assert.NotNil(c)
 
@@ -737,14 +728,8 @@ func TestSandboxAttachDevicesVFIO(t *testing.T) {
 		config:     &SandboxConfig{},
 	}
 
-	store, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(t, err)
-	sandbox.store = store
-
 	containers[c.id].sandbox = &sandbox
 
-	err = sandbox.storeSandboxDevices()
-	assert.Nil(t, err, "Error while store sandbox devices %s", err)
 	err = containers[c.id].attachDevices()
 	assert.Nil(t, err, "Error while attaching devices %s", err)
 
@@ -1005,7 +990,7 @@ func TestDeleteStoreWhenNewContainerFail(t *testing.T) {
 	}
 	_, err = newContainer(p, &contConfig)
 	assert.NotNil(t, err, "New container with invalid device info should fail")
-	storePath := store.ContainerConfigurationRootPath(testSandboxID, contID)
+	storePath := store.ContainerRuntimeRootPath(testSandboxID, contID)
 	_, err = os.Stat(storePath)
 	assert.NotNil(t, err, "Should delete configuration root after failed to create a container")
 }
@@ -1168,10 +1153,6 @@ func TestAttachBlockDevice(t *testing.T) {
 		ctx:        context.Background(),
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(t, err)
-	sandbox.store = vcStore
-
 	contID := "100"
 	container := Container{
 		sandbox: sandbox,
@@ -1180,17 +1161,10 @@ func TestAttachBlockDevice(t *testing.T) {
 
 	// create state file
 	path := store.ContainerRuntimeRootPath(testSandboxID, container.ID())
-	err = os.MkdirAll(path, store.DirMode)
+	err := os.MkdirAll(path, store.DirMode)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(path)
-
-	stateFilePath := filepath.Join(path, store.StateFile)
-	os.Remove(stateFilePath)
-
-	_, err = os.Create(stateFilePath)
-	assert.NoError(t, err)
-	defer os.Remove(stateFilePath)
 
 	path = "/dev/hda"
 	deviceInfo := config.DeviceInfo{
@@ -1255,10 +1229,6 @@ func TestPreAddDevice(t *testing.T) {
 		ctx:        context.Background(),
 	}
 
-	vcStore, err := store.NewVCSandboxStore(sandbox.ctx, sandbox.id)
-	assert.Nil(t, err)
-	sandbox.store = vcStore
-
 	contID := "100"
 	container := Container{
 		sandbox:   sandbox,
@@ -1269,17 +1239,10 @@ func TestPreAddDevice(t *testing.T) {
 
 	// create state file
 	path := store.ContainerRuntimeRootPath(testSandboxID, container.ID())
-	err = os.MkdirAll(path, store.DirMode)
+	err := os.MkdirAll(path, store.DirMode)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(path)
-
-	stateFilePath := filepath.Join(path, store.StateFile)
-	os.Remove(stateFilePath)
-
-	_, err = os.Create(stateFilePath)
-	assert.NoError(t, err)
-	defer os.Remove(stateFilePath)
 
 	path = "/dev/hda"
 	deviceInfo := config.DeviceInfo{

--- a/virtcontainers/store/vc.go
+++ b/virtcontainers/store/vc.go
@@ -334,9 +334,3 @@ func VCSandboxStoreExists(ctx context.Context, sandboxID string) bool {
 	s := stores.findStore(SandboxConfigurationRoot(sandboxID))
 	return s != nil
 }
-
-// VCContainerStoreExists returns true if a container store already exists.
-func VCContainerStoreExists(ctx context.Context, sandboxID string, containerID string) bool {
-	s := stores.findStore(ContainerConfigurationRoot(sandboxID, containerID))
-	return s != nil
-}

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -175,7 +175,7 @@ func TestMain(m *testing.M) {
 	// allow the tests to run without affecting the host system.
 	store.ConfigStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "config") }
 	store.RunStoragePath = func() string { return filepath.Join(testDir, store.StoragePathSuffix, "run") }
-	fs.TestSetRunStoragePath(filepath.Join(testDir, "vc", "sbs"))
+	fs.TestSetRunStoragePath(filepath.Join(testDir, "vc", "run"))
 
 	defer func() {
 		store.ConfigStoragePath = ConfigStoragePathSaved

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -60,10 +61,14 @@ func cleanUp() {
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, DirMode)
 
+	store.DeleteAll()
+	store.VCStorePrefix = ""
+
 	setup()
 }
 
 func setup() {
+	store.VCStorePrefix = testDir
 	os.Mkdir(filepath.Join(testDir, testBundle), DirMode)
 
 	for _, filename := range []string{testQemuKernelPath, testQemuInitrdPath, testQemuImagePath, testQemuPath} {

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -51,8 +51,6 @@ var testVirtiofsdPath = ""
 var testHyperstartCtlSocket = ""
 var testHyperstartTtySocket = ""
 
-var savedRunVMStoragePathFunc func() string
-
 // cleanUp Removes any stale sandbox/container state that can affect
 // the next test to run.
 func cleanUp() {
@@ -160,10 +158,13 @@ func TestMain(m *testing.M) {
 
 	// allow the tests to run without affecting the host system.
 	runPathSave := fs.RunStoragePath()
+	rootPathSave := fs.StorageRootPath()
 	fs.TestSetRunStoragePath(filepath.Join(testDir, "vc", "run"))
+	fs.TestSetStorageRootPath(filepath.Join(testDir, "vc"))
 
 	defer func() {
 		fs.TestSetRunStoragePath(runPathSave)
+		fs.TestSetStorageRootPath(rootPathSave)
 	}()
 
 	// set now that configStoragePath has been overridden.

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -16,8 +16,8 @@ import (
 	pb "github.com/kata-containers/runtime/protocols/cache"
 	"github.com/kata-containers/runtime/virtcontainers/persist"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
+	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
-	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/sirupsen/logrus"
 )
 
@@ -285,7 +285,7 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 }
 
 func buildVMSharePath(id string) string {
-	return filepath.Join(store.RunVMStoragePath(), id, "shared")
+	return filepath.Join(fs.RunVMStoragePath(), id, "shared")
 }
 
 func (v *VM) logger() logrus.FieldLogger {


### PR DESCRIPTION
Fixes #803 

The "newstore" feature has had been a "experimental" feature for long time, it aims to re-organize the persistent data on disk and merging separate files into one "persist.json", and also better guarantee the compatibility.

I have been working on this for a long time and preparing its landing before Kata 2.0, and now I think it's the time. Let's land it as a formal feature!

I'm not sure when is the exact date of release 2.0, but since I can't put enough energy on this work, I hope to merge it ASAP in case nobody else would like to pick up.

You can see I removed lots of code, the "newstore" will make code clearer and easier to read, I hope everyone likes it. :-)

Signed-off-by: Wei Zhang <weizhang555.zw@gmail.com>