### PR TITLE
gitignore: include cloud hypervisor configuration toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .git-commit
 .git-commit.tmp
 /cli/config/configuration-acrn.toml
+/cli/config/configuration-clh.toml
 /cli/config/configuration-fc.toml
 /cli/config/configuration-nemu.toml
 /cli/config/configuration-qemu.toml


### PR DESCRIPTION
update .gitignore to include configuration-clh.toml to the list of
untracked files

fixes #2249

Signed-off-by: Julio Montes <julio.montes@intel.com>