### PR TITLE
virtcontainers: rename GetOCISpec to GetPatchedOCISpec

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -620,7 +620,7 @@ func statusContainer(sandbox *Sandbox, containerID string) (ContainerStatus, err
 			PID:         container.process.Pid,
 			StartTime:   container.process.StartTime,
 			RootFs:      container.config.RootFs.Target,
-			Spec:        container.GetOCISpec(),
+			Spec:        container.GetPatchedOCISpec(),
 			Annotations: container.config.Annotations,
 		}, nil
 	}

--- a/virtcontainers/api_test.go
+++ b/virtcontainers/api_test.go
@@ -81,7 +81,7 @@ func newTestSandboxConfigNoop() SandboxConfig {
 		RootFs:      RootFs{Target: bundlePath, Mounted: true},
 		Cmd:         newBasicTestCmd(),
 		Annotations: containerAnnotations,
-		Spec:        emptySpec,
+		CustomSpec:  emptySpec,
 	}
 
 	// Sets the hypervisor configuration.
@@ -717,7 +717,7 @@ func newTestContainerConfigNoop(contID string) ContainerConfig {
 		RootFs:      RootFs{Target: filepath.Join(testDir, testBundle), Mounted: true},
 		Cmd:         newBasicTestCmd(),
 		Annotations: containerAnnotations,
-		Spec:        newEmptySpec(),
+		CustomSpec:  newEmptySpec(),
 	}
 
 	return container

--- a/virtcontainers/cgroups_test.go
+++ b/virtcontainers/cgroups_test.go
@@ -175,7 +175,7 @@ func TestUpdateCgroups(t *testing.T) {
 			},
 			config: &ContainerConfig{
 				Annotations: containerAnnotations,
-				Spec:        newEmptySpec(),
+				CustomSpec:  newEmptySpec(),
 			},
 		},
 		"xyz": {
@@ -184,7 +184,7 @@ func TestUpdateCgroups(t *testing.T) {
 			},
 			config: &ContainerConfig{
 				Annotations: containerAnnotations,
-				Spec:        newEmptySpec(),
+				CustomSpec:  newEmptySpec(),
 			},
 		},
 	}

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -746,7 +746,7 @@ func (k *kataAgent) setProxyFromGrpc(proxy proxy, pid int, url string) {
 }
 
 func (k *kataAgent) getDNS(sandbox *Sandbox) ([]string, error) {
-	ociSpec := sandbox.GetOCISpec()
+	ociSpec := sandbox.GetPatchedOCISpec()
 	if ociSpec == nil {
 		k.Logger().Debug("Sandbox OCI spec not found. Sandbox DNS will not be set.")
 		return nil, nil
@@ -1283,7 +1283,7 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 		ctrStorages = append(ctrStorages, rootfs)
 	}
 
-	ociSpec := c.GetOCISpec()
+	ociSpec := c.GetPatchedOCISpec()
 	if ociSpec == nil {
 		return nil, errorMissingOCISpec
 	}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -728,7 +728,7 @@ func TestAgentCreateContainer(t *testing.T) {
 			Fstype: "xfs",
 		},
 		config: &ContainerConfig{
-			Spec:        &specs.Spec{},
+			CustomSpec:  &specs.Spec{},
 			Annotations: map[string]string{},
 		},
 	}

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -861,7 +861,10 @@ func ContainerConfig(ocispec specs.Spec, bundlePath, cid, console string, detach
 		Mounts:      containerMounts(ocispec),
 		DeviceInfos: deviceInfos,
 		Resources:   *ocispec.Linux.Resources,
-		Spec:        &ocispec,
+
+		// This is a custom OCI spec modified at SetEphemeralStorageType()
+		// to support ephemeral storage and k8s empty dir.
+		CustomSpec: &ocispec,
 	}
 
 	cType, err := ContainerType(ocispec)

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -156,7 +156,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 		Resources: specs.LinuxResources{Devices: []specs.LinuxDeviceCgroup{
 			{Allow: false, Type: "", Major: (*int64)(nil), Minor: (*int64)(nil), Access: "rwm"},
 		}},
-		Spec: &spec,
+		CustomSpec: &spec,
 	}
 
 	expectedNetworkConfig := vc.NetworkConfig{}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -649,7 +649,7 @@ func TestContainerStateSetFstype(t *testing.T) {
 		{
 			ID:          "100",
 			Annotations: containerAnnotations,
-			Spec:        newEmptySpec(),
+			CustomSpec:  newEmptySpec(),
 		},
 	}
 
@@ -1524,7 +1524,7 @@ func TestSandbox_SetupSandboxCgroup(t *testing.T) {
 	sandboxContainer.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)
 
 	emptyJSONLinux := ContainerConfig{
-		Spec: newEmptySpec(),
+		CustomSpec: newEmptySpec(),
 	}
 	emptyJSONLinux.Annotations = make(map[string]string)
 	emptyJSONLinux.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)
@@ -1532,7 +1532,7 @@ func TestSandbox_SetupSandboxCgroup(t *testing.T) {
 	cloneSpec1 := newEmptySpec()
 	cloneSpec1.Linux.CgroupsPath = "/myRuntime/myContainer"
 	successfulContainer := ContainerConfig{
-		Spec: cloneSpec1,
+		CustomSpec: cloneSpec1,
 	}
 	successfulContainer.Annotations = make(map[string]string)
 	successfulContainer.Annotations[annotations.ContainerTypeKey] = string(PodSandbox)


### PR DESCRIPTION
GetOCISpec returns a patched version of the original OCI spec, it was modified
to support:
* capabilities
* Ephemeral storage
* k8s empty dir

In order to avoid consusions and make api clear, rename GetOCISpec
to GetPatchedOCISpec.

fixes #2252

Signed-off-by: Julio Montes <julio.montes@intel.com>