### PR TITLE
virtcontainers: honour ContainerConfig struct comment and don't save OCI spec

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -252,7 +252,7 @@ type ContainerConfig struct {
 	Resources specs.LinuxResources
 
 	// Raw OCI specification, it won't be saved to disk.
-	Spec *specs.Spec `json:"_"`
+	Spec *specs.Spec `json:"-"`
 }
 
 // valid checks that the container configuration is valid.


### PR DESCRIPTION
Currently kata-runtime saves the Container OCI Spec even when it's not needed
and a comment in `ContainerConfig struct` specifically indicates that
it won't be saved to disk.
Use '-' as json tag instead of '_' to indicates that `Spec` field shouldn't
be saved to disk.

fixes #2256

Signed-off-by: Julio Montes <julio.montes@intel.com>