### PR TITLE
fc.go: Set firecracker log level to debug if hypervisor.enable_debug …

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -622,6 +622,9 @@ func (fc *firecracker) fcSetLogger() error {
 	defer span.Finish()
 
 	fcLogLevel := "Error"
+	if fc.config.Debug {
+		fcLogLevel = "Debug"
+	}
 
 	// listen to log fifo file and transfer error info
 	jailedLogFifo, err := fc.fcListenToFifo(fcLogFifo)


### PR DESCRIPTION
…is true

Set firecracker log level to debug if hypervisor.enable_debug is true.

Fixes: #2260

Signed-off-by: Hui Zhu <teawater@antfin.com>