### PR TITLE
cache-factory: a few bug fix

### DIFF
--- a/cli/factory.go
+++ b/cli/factory.go
@@ -88,7 +88,7 @@ func (s *cacheServer) Quit(ctx context.Context, empty *types.Empty) (*types.Empt
 		time.Sleep(time.Second)
 		s.quit()
 	}()
-	return nil, nil
+	return &types.Empty{}, nil
 }
 
 func (s *cacheServer) Status(ctx context.Context, empty *types.Empty) (*pb.GrpcStatus, error) {

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -222,7 +222,7 @@ type agent interface {
 	configure(h hypervisor, id, sharePath string, builtin bool, config interface{}) error
 
 	// configureFromGrpc will update agent settings based on provided arguments which from Grpc
-	configureFromGrpc(id string, builtin bool, config interface{}) error
+	configureFromGrpc(h hypervisor, id string, builtin bool, config interface{}) error
 
 	// getVMPath will return the agent vm socket's directory path
 	getVMPath(id string) string

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -416,8 +416,8 @@ func (k *kataAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 	return h.addDevice(sharedVolume, fsDev)
 }
 
-func (k *kataAgent) configureFromGrpc(id string, builtin bool, config interface{}) error {
-	return k.internalConfigure(nil, id, "", builtin, config)
+func (k *kataAgent) configureFromGrpc(h hypervisor, id string, builtin bool, config interface{}) error {
+	return k.internalConfigure(h, id, "", builtin, config)
 }
 
 func (k *kataAgent) createSandbox(sandbox *Sandbox) error {

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -181,7 +181,7 @@ func (n *noopAgent) configure(h hypervisor, id, sharePath string, builtin bool, 
 	return nil
 }
 
-func (n *noopAgent) configureFromGrpc(id string, builtin bool, config interface{}) error {
+func (n *noopAgent) configureFromGrpc(h hypervisor, id string, builtin bool, config interface{}) error {
 	return nil
 }
 

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1942,6 +1942,7 @@ func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig,
 
 	q.qemuConfig.SMP = qp.QemuSMP
 
+	q.arch.setBridges(q.state.Bridges)
 	return nil
 }
 

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -264,7 +264,7 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 	}
 
 	agent := newAgent(config.AgentType)
-	agent.configureFromGrpc(v.Id, isProxyBuiltIn(config.ProxyType), config.AgentConfig)
+	agent.configureFromGrpc(hypervisor, v.Id, isProxyBuiltIn(config.ProxyType), config.AgentConfig)
 
 	proxy, err := newProxy(config.ProxyType)
 	if err != nil {


### PR DESCRIPTION
# Description of problem
For now, we will encounter nil pointer runtime panic when launching kata containers from cache factory.
```
kata-runtime[133160]: time="2019-11-25T15:57:05.799620876+08:00" level=error msg="fatal
error" arch=arm64 name=kata-runtime panic="runtime error: invalid memory address or nil pointer
dereference" pid=133160 source=runtime
```
After fixing this, we will still have missing bridge address error.
```
$ docker run --runtime kata-runtime busybox
docker: Error response from daemon: OCI runtime create failed: failed to get available address from bridges: unknown.
```
That's because that although we've already passed bridges info to clients from cache factory server, we've still missed the setting part when creating vm.