### PR TITLE
virtiofs: add default value for virtioFsCache type.

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -320,7 +320,6 @@ func beforeSubcommands(c *cli.Context) error {
 	if err != nil {
 		fatal(err)
 	}
-
 	if !subCmdIsCheckCmd {
 		debug = runtimeConfig.Debug
 		crashOnError = runtimeConfig.Debug

--- a/pkg/katautils/config-settings.go
+++ b/pkg/katautils/config-settings.go
@@ -45,6 +45,7 @@ const defaultMsize9p uint32 = 8192
 const defaultHotplugVFIOOnRootBus bool = false
 const defaultEntropySource = "/dev/urandom"
 const defaultGuestHookPath string = ""
+const defaultVirtioFSCacheMode = "none"
 
 const defaultTemplatePath string = "/run/vc/vm/template"
 const defaultVMCacheEndpoint string = "/var/run/kata-containers/cache.sock"

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -342,6 +342,14 @@ func (h hypervisor) defaultBridges() uint32 {
 	return h.DefaultBridges
 }
 
+func (h hypervisor) defaultVirtioFSCache() string {
+	if h.VirtioFSCache == "" {
+		return defaultVirtioFSCacheMode
+	}
+
+	return h.VirtioFSCache
+}
+
 func (h hypervisor) blockDeviceDriver() (string, error) {
 	supportedBlockDrivers := []string{config.VirtioSCSI, config.VirtioBlock, config.VirtioMmio, config.Nvdimm, config.VirtioBlockCCW}
 
@@ -620,7 +628,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		SharedFS:                sharedFS,
 		VirtioFSDaemon:          h.VirtioFSDaemon,
 		VirtioFSCacheSize:       h.VirtioFSCacheSize,
-		VirtioFSCache:           h.VirtioFSCache,
+		VirtioFSCache:           h.defaultVirtioFSCache(),
 		VirtioFSExtraArgs:       h.VirtioFSExtraArgs,
 		MemPrealloc:             h.MemPrealloc,
 		HugePages:               h.HugePages,
@@ -1060,6 +1068,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		Msize9p:                 defaultMsize9p,
 		HotplugVFIOOnRootBus:    defaultHotplugVFIOOnRootBus,
 		GuestHookPath:           defaultGuestHookPath,
+		VirtioFSCache:           defaultVirtioFSCacheMode,
 	}
 }
 

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -164,6 +164,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		GuestHookPath:         defaultGuestHookPath,
 		SharedFS:              sharedFS,
 		VirtioFSDaemon:        "/path/to/virtiofsd",
+		VirtioFSCache:         defaultVirtioFSCacheMode,
 	}
 
 	agentConfig := vc.KataAgentConfig{}
@@ -624,6 +625,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		BlockDeviceDriver:     defaultBlockDeviceDriver,
 		Msize9p:               defaultMsize9p,
 		GuestHookPath:         defaultGuestHookPath,
+		VirtioFSCache:         defaultVirtioFSCacheMode,
 	}
 
 	expectedAgentConfig := vc.KataAgentConfig{}
@@ -1369,6 +1371,23 @@ func TestDefaultBridges(t *testing.T) {
 	h.DefaultBridges = maxPCIBridges
 	bridges = h.defaultBridges()
 	assert.Equal(maxPCIBridges, bridges)
+}
+
+func TestDefaultVirtioFSCache(t *testing.T) {
+	assert := assert.New(t)
+
+	h := hypervisor{VirtioFSCache: ""}
+
+	cache := h.defaultVirtioFSCache()
+	assert.Equal(defaultVirtioFSCacheMode, cache)
+
+	h.VirtioFSCache = "always"
+	cache = h.defaultVirtioFSCache()
+	assert.Equal("always", cache)
+
+	h.VirtioFSCache = "none"
+	cache = h.defaultVirtioFSCache()
+	assert.Equal("none", cache)
 }
 
 func TestDefaultFirmware(t *testing.T) {


### PR DESCRIPTION
If no virtioFsCache type set in configuration file, virtiofsd will
not start well as a daemon, which make container start fail if virtio-fs
as its shared file system.

Fixed: #2279
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @grahamwhaley