### PR TITLE
vc: Use map to represent ignoredMounts

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -542,9 +542,9 @@ func (c *Container) shareFiles(m Mount, idx int, hostSharedDir, guestSharedDir s
 // It also updates the container mount list with the HostPath info, and store
 // container mounts to the storage. This way, we will have the HostPath info
 // available when we will need to unmount those mounts.
-func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (map[string]Mount, []Mount, error) {
+func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (map[string]Mount, map[string]Mount, error) {
 	sharedDirMounts := make(map[string]Mount)
-	var ignoredMounts []Mount
+	ignoredMounts := make(map[string]Mount)
 	for idx, m := range c.mounts {
 		// Skip mounting certain system paths from the source on the host side
 		// into the container as it does not make sense to do so.
@@ -595,7 +595,7 @@ func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (
 
 		// Expand the list of mounts to ignore.
 		if ignore {
-			ignoredMounts = append(ignoredMounts, Mount{Source: m.Source})
+			ignoredMounts[m.Source] = Mount{Source: m.Source}
 			continue
 		}
 
@@ -605,6 +605,7 @@ func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (
 		for _, flag := range m.Options {
 			if flag == "ro" {
 				readonly = true
+				break
 			}
 		}
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -975,20 +975,13 @@ func (k *kataAgent) replaceOCIMountSource(spec *specs.Spec, guestMounts map[stri
 	return nil
 }
 
-func (k *kataAgent) removeIgnoredOCIMount(spec *specs.Spec, ignoredMounts []Mount) error {
+func (k *kataAgent) removeIgnoredOCIMount(spec *specs.Spec, ignoredMounts map[string]Mount) error {
 	var mounts []specs.Mount
 
 	for _, m := range spec.Mounts {
-		found := false
-		for _, ignoredMount := range ignoredMounts {
-			if ignoredMount.Source == m.Source {
-				k.Logger().WithField("removed-mount", m.Source).Debug("Removing OCI mount")
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if _, found := ignoredMounts[m.Source]; found {
+			k.Logger().WithField("removed-mount", m.Source).Debug("Removing OCI mount")
+		} else {
 			mounts = append(mounts, m)
 		}
 	}


### PR DESCRIPTION
We can use map from Source to Mount as ignoredMounts representation.
Inner loop in kataAgent#removeIgnoredOCIMount is removed.

Fixes #2299

Signed-off-by: Ted Yu yuzhihong@gmail.com