### PR TITLE
compatoci: Add a SetLogger call

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -14,6 +14,7 @@ import (
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
@@ -50,6 +51,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 
 	deviceApi.SetLogger(virtLog)
 	store.SetLogger(virtLog)
+	compatoci.SetLogger(virtLog)
 }
 
 // CreateSandbox is the virtcontainers sandbox creation entry point.

--- a/virtcontainers/pkg/compatoci/utils.go
+++ b/virtcontainers/pkg/compatoci/utils.go
@@ -100,6 +100,13 @@ func containerCapabilities(s compatOCISpec) (specs.LinuxCapabilities, error) {
 	return c, nil
 }
 
+// SetLogger sets up a logger for this pkg
+func SetLogger(logger *logrus.Entry) {
+	fields := ociLog.Data
+
+	ociLog = logger.WithFields(fields)
+}
+
 // ContainerCapabilities return a LinuxCapabilities for virtcontainer
 func ContainerCapabilities(s compatOCISpec) (specs.LinuxCapabilities, error) {
 	if s.Process == nil {


### PR DESCRIPTION
Add a standard `SetLogger()` call to allow the `compatoci` package to be provided a base logger which it can then customise.

Fixes: #2305.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>