### PR TITLE
vc: Version support check is ineffective in createSandbox

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -137,6 +137,18 @@ var clhDebugKernelParams = []Param{
 //
 //###########################################################
 
+func (clh *cloudHypervisor) checkVersion() error {
+	if clh.version.Major < supportedMajorVersion || (clh.version.Major == supportedMajorVersion && clh.version.Minor < supportedMinorVersion) {
+		errorMessage := fmt.Sprintf("Unsupported version: cloud-hypervisor %d.%d not supported by this driver version (%d.%d)",
+			clh.version.Major,
+			clh.version.Minor,
+			supportedMajorVersion,
+			supportedMinorVersion)
+		return errors.New(errorMessage)
+	}
+	return nil
+}
+
 // For cloudHypervisor this call only sets the internal structure up.
 // The VM will be created and started through startSandbox().
 func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore, stateful bool) error {
@@ -168,13 +180,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 
 		}
 
-		if clh.version.Major < supportedMajorVersion && clh.version.Minor < supportedMinorVersion {
-			errorMessage := fmt.Sprintf("Unsupported version: cloud-hypervisor %d.%d not supported by this driver version (%d.%d)",
-				clh.version.Major,
-				clh.version.Minor,
-				supportedMajorVersion,
-				supportedMinorVersion)
-			return errors.New(errorMessage)
+		if err := clh.checkVersion(); err != nil {
+			return err
 		}
 
 	}

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -7,6 +7,7 @@ package virtcontainers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -264,4 +265,48 @@ func TestClooudHypervisorStartSandbox(t *testing.T) {
 
 	err = clh.startSandbox(10)
 	assert.NoError(err)
+}
+
+func TestCheckVersion(t *testing.T) {
+	clh := &cloudHypervisor{}
+	assert := assert.New(t)
+	testcases := []struct {
+		name  string
+		major int
+		minor int
+		pass  bool
+	}{
+		{
+			name:  "minor lower than supported version",
+			major: supportedMajorVersion,
+			minor: 2,
+			pass:  false,
+		},
+		{
+			name:  "minor equal to supported version",
+			major: supportedMajorVersion,
+			minor: supportedMinorVersion,
+			pass:  true,
+		},
+		{
+			name:  "major exceeding supported version",
+			major: 1,
+			minor: supportedMinorVersion,
+			pass:  true,
+		},
+	}
+	for _, tc := range testcases {
+		clh.version = CloudHypervisorVersion{
+			Major:    tc.major,
+			Minor:    tc.minor,
+			Revision: 0,
+		}
+		err := clh.checkVersion()
+		msg := fmt.Sprintf("test: %+v, clh.version: %v, result: %v", tc, clh.version, err)
+		if tc.pass {
+			assert.NoError(err, msg)
+		} else {
+			assert.Error(err, msg)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #2311

If major version matches max supported major, we continue comparing the minor version.

Signed-off-by: Ted Yu <yuzhihong@gmail.com>

The error along with the original check was actually negated.
Since supportedMajorVersion is 0, the condition was never hit. But the new test exposes the bug.
