### PR TITLE
rootless: Disable vhost-net for rootless(backport)

### DIFF
--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
+	"github.com/kata-containers/runtime/pkg/rootless"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/uuid"
 	"github.com/kata-containers/runtime/virtcontainers/utils"
@@ -440,7 +441,12 @@ func xConnectVMNetwork(endpoint Endpoint, h hypervisor) error {
 		queues = int(h.hypervisorConfig().NumVCPUs)
 	}
 
-	disableVhostNet := h.hypervisorConfig().DisableVhostNet
+	var disableVhostNet bool
+	if rootless.IsRootless() {
+		disableVhostNet = true
+	} else {
+		disableVhostNet = h.hypervisorConfig().DisableVhostNet
+	}
 
 	if netPair.NetInterworkingModel == NetXConnectDefaultModel {
 		netPair.NetInterworkingModel = DefaultNetInterworkingModel


### PR DESCRIPTION
Since the /dev/vhost-net device is owned by root, we cannot used
vhost-net networking in rootless mode. Instead of having to
do this manually in the toml, disable vhost-net when the runtime
detects it is running rootless.

Fixes #2321

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>