### PR TITLE
qemu: remove cache attribute VhostUserDeviceAttrs

### DIFF
--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -204,7 +204,6 @@ type VhostUserDeviceAttrs struct {
 	// These are only meaningful for vhost user fs devices
 	Tag       string
 	CacheSize uint32
-	Cache     string
 }
 
 // GetHostPathFunc is function pointer used to mock GetHostPath in tests.

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1551,7 +1551,6 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 				Tag:       v.MountTag,
 				Type:      config.VhostUserFS,
 				CacheSize: q.config.VirtioFSCacheSize,
-				Cache:     q.config.VirtioFSCache,
 			}
 			vhostDev.SocketPath = sockPath
 			vhostDev.DevID = id


### PR DESCRIPTION
The cache attribute is not needed to append a VhostUserDevice.

Fixes: #2329