### PR TITLE
versions: bump firecracker version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.19.0"
+      version: "v0.19.1"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
To include the latest fix for CVE-2019-18960.

Fixes: #2334
