### PR TITLE
versions: bump fc version to v0.18.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -76,7 +76,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.18.0"
+      version: "v0.18.1"
 
     nemu:
       description: "Reduced-emulation VMM that uses KVM"


### PR DESCRIPTION
To include latest fix for CVE-2019-18960.

Fixes: #2336
Signed-off-by: Peng Tao <bergwolf@hyper.sh>