### PR TITLE
shimv2: clean up properly if vmm quits unexpectedly

### DIFF
--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -17,11 +17,11 @@ import (
 )
 
 func deleteContainer(ctx context.Context, s *service, c *container) error {
-	if !c.cType.IsSandbox() {
-		status, err := s.sandbox.StatusContainer(c.id)
-		if err != nil {
-			return err
-		}
+	status, err := s.sandbox.StatusContainer(c.id)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	if !c.cType.IsSandbox() && err == nil {
 		if status.State.State != types.StateStopped {
 			_, err = s.sandbox.StopContainer(c.id, false)
 			if err != nil {

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1096,13 +1096,6 @@ func (c *Container) stop(force bool) error {
 	// get failed if the process hasn't exited.
 	c.sandbox.agent.waitProcess(c, c.id)
 
-	// container was killed by force, container MUST change its state
-	// as soon as possible just in case one of below operations fail leaving
-	// the containers in a bad state.
-	if err := c.setContainerState(types.StateStopped); err != nil {
-		return err
-	}
-
 	defer func() {
 		// Save device and drive data.
 		// TODO: can we merge this saving with setContainerState()?
@@ -1130,6 +1123,13 @@ func (c *Container) stop(force bool) error {
 	}
 
 	if err := c.removeDrive(); err != nil && !force {
+		return err
+	}
+
+	// container was killed by force, container MUST change its state
+	// as soon as possible just in case one of below operations fail leaving
+	// the containers in a bad state.
+	if err := c.setContainerState(types.StateStopped); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When we kill vmm with SIGKILL after creating a new sandbox, there are two issues:
1. shimv2 process does not exit
2. data in container volume is removed unexpectedly

The PR fixes both of them.