### PR TITLE
enable timestamp for dmesg log on arm64.

### DIFF
--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -40,6 +40,7 @@ var kernelParams = []Param{
 	{"console", "hvc0"},
 	{"console", "hvc1"},
 	{"iommu.passthrough", "0"},
+	{"printk.time", "1"},
 }
 
 // For now, AArch64 doesn't support DAX, so we couldn't use


### PR DESCRIPTION
Currently, no timestamp offered by dmesg in container for arm64.
This patch set "printk.time" to 1 in kernel parameters to enable it.

Fixes: #2347
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @grahamwhaley  @Pennyzct  @devimc 