### PR TITLE
versions: update qemu to 4.2.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "4.1.1"
-      tag: "v4.1.1"
+      version: "4.2.0"
+      tag: "v4.2.0"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -131,9 +131,9 @@ func (q *qemuAmd64) cpuModel() string {
 		cpuModel += ",pmu=off"
 	}
 
-	// VMX is not migratable yet.
-	// issue: https://github.com/kata-containers/runtime/issues/1750
-	if q.vmFactory {
+	if q.nestedRun {
+		// VMX is not migratable yet.
+		// issue: https://github.com/kata-containers/runtime/issues/1750
 		virtLog.WithField("subsystem", "qemuAmd64").Warn("VMX is not migratable yet: turning it off")
 		cpuModel += ",vmx=off"
 	}


### PR DESCRIPTION
New features that can improve/impact in kata containers:

x86
* VMX features can be enabled/disabled via the "-cpu" flag.
* When nested virtualization is enabled with an option like
  "-cpu Haswell,+vmx", the set of VMX features will also be constrained to
  what was available on the corresponding CPU model.
* New "microvm" machine type that has virtio-mmio instead of PCI, and no ACPI
  support (so no hotplug too). The new machine type is meant as a baseline
  for performance optimizations of QEMU, firmware and guests. While inspired
  by Firecracker it is not entirely compatible with it (for example it does
  not have Firecracker's userspace IP stack and MicroVM Metadata Service).

ARM:
* We now correctly support more than 256 CPUs when using KVM
* The virt board now supports memory hotplugging, when used with a UEFI
  guest BIOS and ACPI.

s390:
* Using KVM now explicitly requires a host kernel version of at least 3.15
  (which includes the 'flic' KVM device). This had been broken since QEMU
  2.10 already.

# Metrics

![s1](https://user-images.githubusercontent.com/13009432/70814527-472fcd80-1d91-11ea-9019-344125723afd.png)

![s2](https://user-images.githubusercontent.com/13009432/70814534-4c8d1800-1d91-11ea-9fc5-faba1614af36.png)


fixes #2354

Signed-off-by: Julio Montes <julio.montes@intel.com>