### PR TITLE
kernel: update kernel to the new LTS version, v5.4.x

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -152,10 +152,10 @@ assets:
 
   kernel:
     description: "Linux kernel optimised for virtual machines"
-    url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
+    url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"
     uscan-url: >-
-      https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-(4\.19\..+)\.tar\.gz
-    version: "v4.19.86"
+      https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-(5\.4\..+)\.tar\.gz
+    version: "v5.4.4"
 
   kernel-experimental:
     description: "Linux kernel with virtiofs 3.0"


### PR DESCRIPTION
For ARM64, we back-ported some huge, annoyed patches on top of `v4.19.x`.
Most of this has already landed upstream, and would be available in the new LTS version, `5.4.x`.
The latest version for now will be `v5.4.4`.

Fixes: #2349
Depends-on: github.com/kata-containers/packaging#883

Signed-off-by: Penny Zheng <penny.zheng@arm.com>