### PR TITLE
versions: Update cloud hypervisor url

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -72,9 +72,9 @@ assets:
 
     cloud_hypervisor:
       description: "Cloud Hypervisor is an open source Virtual Machine Monitor"
-      url: "https://github.com/intel/cloud-hypervisor"
+      url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
-        https://github.com/intel/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
+        https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
       version: "v0.4.0"
 
     firecracker:


### PR DESCRIPTION
This updates the cloud hypervisor url.

Fixes #2365

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>