### PR TITLE
ut: fix make test failures

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -160,7 +160,9 @@ func TestMain(m *testing.M) {
 
 	// Make sure we have the opportunity to flush the coverage report to disk when
 	// terminating the process.
-	atexit(cover.FlushProfiles)
+	defer func() {
+		cover.FlushProfiles()
+	}()
 
 	// If the test binary name is kata-runtime.coverage, we've are being asked to
 	// run the coverage-instrumented kata-runtime.

--- a/virtcontainers/factory/direct/direct_test.go
+++ b/virtcontainers/factory/direct/direct_test.go
@@ -8,17 +8,26 @@ package direct
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/runtime/virtcontainers"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 )
 
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
+	assert.Nil(err)
+	store.VCStorePrefix = testDir
+	defer func() {
+		os.RemoveAll(testDir)
+		store.VCStorePrefix = ""
+	}()
+
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,
 		ImagePath:  testDir,

--- a/virtcontainers/persist/fs/fs_test.go
+++ b/virtcontainers/persist/fs/fs_test.go
@@ -7,6 +7,7 @@ package fs
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,6 +33,13 @@ func TestFsLock(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 
+	testDir, err := ioutil.TempDir("", "fs-tmp-")
+	assert.Nil(t, err)
+	TestSetRunStoragePath(testDir)
+	defer func() {
+		os.RemoveAll(testDir)
+	}()
+
 	fs.sandboxState.SandboxContainer = "test-fs-driver"
 	sandboxDir, err := fs.sandboxDir()
 	assert.Nil(t, err)
@@ -50,6 +58,13 @@ func TestFsDriver(t *testing.T) {
 	fs, err := getFsDriver()
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
+
+	testDir, err := ioutil.TempDir("", "fs-tmp-")
+	assert.Nil(t, err)
+	TestSetRunStoragePath(testDir)
+	defer func() {
+		os.RemoveAll(testDir)
+	}()
 
 	ss := persistapi.SandboxState{}
 	cs := make(map[string]persistapi.ContainerState)

--- a/virtcontainers/pkg/nsenter/nsenter_test.go
+++ b/virtcontainers/pkg/nsenter/nsenter_test.go
@@ -18,9 +18,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
+
+	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 )
 
 const testPID = 12345
+
+var tu = ktu.NewTestConstraint(true)
 
 func TestGetNSPathFromPID(t *testing.T) {
 	for nsType := range CloneFlagsTable {
@@ -165,6 +169,9 @@ func TestNsEnterEmptyNamespaceListSuccess(t *testing.T) {
 }
 
 func TestNsEnterSuccessful(t *testing.T) {
+	if tu.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
 	nsList := supportedNamespaces()
 	sleepDuration := 60
 

--- a/virtcontainers/store/filesystem_backend_test.go
+++ b/virtcontainers/store/filesystem_backend_test.go
@@ -20,7 +20,11 @@ type TestNoopStructure struct {
 	Field2 string
 }
 
-var rootPath = "/tmp/root1/"
+var rootPath = func() string {
+	dir, _ := ioutil.TempDir("", "")
+	return dir
+}()
+
 var expectedFilesystemData = "{\"Field1\":\"value1\",\"Field2\":\"value2\"}"
 
 func TestStoreFilesystemStore(t *testing.T) {

--- a/virtcontainers/store/manager_test.go
+++ b/virtcontainers/store/manager_test.go
@@ -23,14 +23,17 @@ var sandboxDirState = ""
 var sandboxDirLock = ""
 var sandboxFileState = ""
 var sandboxFileLock = ""
-var storeRoot = "file:///tmp/root1/"
+var storeRoot, storeRootDir = func() (string, string) {
+	dir, _ := ioutil.TempDir("", "")
+	return "file://" + dir, dir
+}()
 
 func TestNewStore(t *testing.T) {
 	s, err := New(context.Background(), storeRoot)
 	assert.Nil(t, err)
 	assert.Equal(t, s.scheme, "file")
 	assert.Equal(t, s.host, "")
-	assert.Equal(t, s.path, "/tmp/root1/")
+	assert.Equal(t, s.path, storeRootDir)
 }
 
 func TestDeleteStore(t *testing.T) {

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -64,12 +64,14 @@ func cleanUp() {
 	store.DeleteAll()
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, store.DirMode)
+	store.VCStorePrefix = ""
 
 	setup()
 }
 
 func setup() {
 	os.Mkdir(filepath.Join(testDir, testBundle), store.DirMode)
+	store.VCStorePrefix = testDir
 
 	for _, filename := range []string{testQemuKernelPath, testQemuInitrdPath, testQemuImagePath, testQemuPath} {
 		_, err := os.Create(filename)

--- a/virtcontainers/virtcontainers_test.go
+++ b/virtcontainers/virtcontainers_test.go
@@ -57,21 +57,28 @@ var testVirtiofsdPath = ""
 var testHyperstartCtlSocket = ""
 var testHyperstartTtySocket = ""
 
+var savedRunVMStoragePathFunc func() string
+
 // cleanUp Removes any stale sandbox/container state that can affect
 // the next test to run.
 func cleanUp() {
 	globalSandboxList.removeSandbox(testSandboxID)
 	store.DeleteAll()
 	os.RemoveAll(testDir)
-	os.MkdirAll(testDir, store.DirMode)
 	store.VCStorePrefix = ""
+	store.RunVMStoragePath = savedRunVMStoragePathFunc
 
 	setup()
 }
 
 func setup() {
-	os.Mkdir(filepath.Join(testDir, testBundle), store.DirMode)
 	store.VCStorePrefix = testDir
+	savedRunVMStoragePathFunc = store.RunVMStoragePath
+	store.RunVMStoragePath = func() string {
+		return filepath.Join("testDir", "vm")
+	}
+	os.MkdirAll(store.RunVMStoragePath(), store.DirMode)
+	os.MkdirAll(filepath.Join(testDir, testBundle), store.DirMode)
 
 	for _, filename := range []string{testQemuKernelPath, testQemuInitrdPath, testQemuImagePath, testQemuPath} {
 		_, err := os.Create(filename)


### PR DESCRIPTION
The PR fixes several `make test` failures:
- `testing: can't write /tmp/go-build146132196/b001/testlog.txt: close /tmp/go-build146132196/b001/testlog.txt: file already closed`

- `mkdir /var/lib/vc/uuid: permission denied`

- `clh_test.go:191: cloudHypervisor.cleanupVM() expected error != open /run/vc/vm: permission denied`

- several other permission errors in different packages