### PR TITLE
kata-check: Add version consistency check

### DIFF
--- a/cli/kata-check.go
+++ b/cli/kata-check.go
@@ -63,6 +63,7 @@ const (
 	moduleParamDir        = "parameters"
 	successMessageCapable = "System is capable of running " + project
 	successMessageCreate  = "System can currently create " + project
+	successMessageVersion = "Version consistency of " + project + " is verified"
 	failMessage           = "System is not capable of running " + project
 	kernelPropertyCorrect = "Kernel property value correct"
 
@@ -309,6 +310,10 @@ var kataCheckCLICommand = cli.Command{
 			Name:  "verbose, v",
 			Usage: "display the list of checks performed",
 		},
+		cli.BoolFlag{
+			Name:  "strict, s",
+			Usage: "perform strict checking",
+		},
 	},
 
 	Action: func(context *cli.Context) error {
@@ -355,6 +360,16 @@ var kataCheckCLICommand = cli.Command{
 			}
 
 			fmt.Println(successMessageCreate)
+		}
+
+		strict := context.Bool("strict")
+		if strict {
+			err = checkVersionConsistencyInComponents(runtimeConfig)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(successMessageVersion)
 		}
 
 		return nil
@@ -453,4 +468,36 @@ func genericCheckKVMExtensions(extensions map[string]kvmExtension) (map[string]i
 	}
 
 	return results, nil
+}
+
+// checkVersionConsistencyInComponents checks version consistency in Kata Components.
+func checkVersionConsistencyInComponents(config oci.RuntimeConfig) error {
+	proxyInfo := getProxyInfo(config)
+
+	shimInfo, err := getShimInfo(config)
+	if err != nil {
+		return err
+	}
+	shimVersionInfo := shimInfo.Version
+
+	runtimeVersionInfo := constructVersionInfo(version)
+
+	// kata-proxy exists
+	if proxyInfo.Type != string(vc.NoProxyType) {
+		proxyVersionInfo := proxyInfo.Version
+		if !versionEqual(proxyVersionInfo, runtimeVersionInfo) || !versionEqual(shimVersionInfo, runtimeVersionInfo) {
+			return fmt.Errorf("there exists version inconsistency in kata components. kata-proxy: v%d.%d.%d, kata-shim: v%d.%d.%d, kata-runtime: v%d.%d.%d",
+				proxyVersionInfo.Major, proxyVersionInfo.Minor, proxyVersionInfo.Patch,
+				shimVersionInfo.Major, shimVersionInfo.Minor, shimVersionInfo.Patch,
+				runtimeVersionInfo.Major, runtimeVersionInfo.Minor, runtimeVersionInfo.Patch)
+		}
+	} else {
+		if !versionEqual(shimVersionInfo, runtimeVersionInfo) {
+			return fmt.Errorf("there exists version inconsistency in kata components. kata-shim: v%d.%d.%d, kata-runtime: v%d.%d.%d",
+				shimVersionInfo.Major, shimVersionInfo.Minor, shimVersionInfo.Patch,
+				runtimeVersionInfo.Major, runtimeVersionInfo.Minor, runtimeVersionInfo.Patch)
+		}
+	}
+
+	return nil
 }

--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -19,6 +19,7 @@ import (
 
 	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/kata-containers/runtime/pkg/katautils"
+	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -904,4 +905,88 @@ func TestArchRequiredKernelModules(t *testing.T) {
 	}
 
 	assert.EqualValues(count, expectedCount)
+}
+
+func TestCheckVersionConsistencyInComponents(t *testing.T) {
+	type testData struct {
+		proxyExist     bool
+		expectError    bool
+		shimVersion    string
+		proxyVersion   string
+		runtimeVersion string
+	}
+
+	data := []testData{
+		{
+			true,
+			true,
+			"kata-shim version 0.2.0-rc0-xxxxxxxxxxxxx",
+			"kata-proxy version 0.1.0-rc0-xxxxxxxxxxxxx",
+			"0.2.0-rc0",
+		},
+		{
+			true,
+			true,
+			"kata-shim version 0.1.0-rc0-xxxxxxxxxxxxx",
+			"kata-proxy version 0.2.0-rc0-xxxxxxxxxxxxx",
+			"0.2.0-rc0",
+		},
+		{
+			true,
+			true,
+			"kata-shim version 0.1.0-rc0-xxxxxxxxxxxxx",
+			"kata-proxy version 0.1.0-rc0-xxxxxxxxxxxxx",
+			"0.2.0-rc0",
+		},
+		{
+			true,
+			false,
+			"kata-shim version 0.2.0-rc0-xxxxxxxxxxxxx",
+			"kata-proxy version 0.2.0-rc0-xxxxxxxxxxxxx",
+			"0.2.0-rc0",
+		},
+		{
+			false,
+			true,
+			"kata-shim version 0.1.0-rc0-xxxxxxxxxxxxx",
+			"",
+			"0.2.0-rc0",
+		},
+		{
+			false,
+			false,
+			"kata-shim version 0.2.0-rc0-xxxxxxxxxxxxx",
+			"",
+			"0.2.0-rc0",
+		},
+	}
+
+	origVersion := version
+	for _, d := range data {
+		tmpdir, err := ioutil.TempDir("", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(tmpdir)
+
+		testShimVersion = d.shimVersion
+		if d.proxyExist {
+			testProxyVersion = d.proxyVersion
+		}
+		_, config, err := makeRuntimeConfig(tmpdir)
+		assert.NoError(t, err)
+		if !d.proxyExist {
+			config.ProxyType = vc.NoProxyType
+		}
+		version = d.runtimeVersion
+		defer func() {
+			version = origVersion
+		}()
+
+		err = checkVersionConsistencyInComponents(config)
+		if d.expectError {
+			assert.Error(t, err, fmt.Sprintf("%+v", d))
+			continue
+		} else {
+			assert.NoError(t, err, fmt.Sprintf("%+v", d))
+		}
+	}
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -183,3 +183,21 @@ func constructVersionInfo(version string) VersionInfo {
 	}
 
 }
+
+func versionEqual(a VersionInfo, b VersionInfo) bool {
+	av, err := semver.Make(a.Semver)
+	if err != nil {
+		return false
+	}
+
+	bv, err := semver.Make(b.Semver)
+	if err != nil {
+		return false
+	}
+
+	if av.Major == bv.Major && av.Minor == bv.Minor && av.Patch == bv.Patch {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
**Which feature do you think can be improved?**
We may need multiple kata components to launch one kata container. The longest legacy one could have `kata-shim`, `kata-proxy`, `kata-runtime`, and `kata-agent.`
For users, especially for developers, we often encounter confused runtime error due to each kata component at different version.
E.g. Laterly, I've encountered following error in launching kata container with firecracker, and it's because of stale version of `kata-shim`, which is lower than `v1.9.0`.
```
$ docker run --runtime kata-runtime busybox
docker: Error response from daemon: cannot start a stopped process: unknown.
ERRO[0002] error waiting for container: context canceled
```
**How can it be improved?**
So, here, I want to introduce version consistency check in `kata-runtime kata-check`.
If we have kata components at different version, it should issue a warning, like this:
```
$ kata-runtime kata-check
System is capable of running Kata Containers
System can currently create Kata Containers
Warning: there exists version inconsistency in kata components. kata-proxy: v1.10, kata-shim: v1.7, kata-runtime: v1.10
```
Otherwise, it should output like this:
```
$ kata-runtime kata-check
INFO[0000] VSOCK supported, configure to not use proxy
System is capable of running Kata Containers
System can currently create Kata Containers
Version consistency of Kata Containers is verified
```

**Updates:**
Following upstream comments to use `--strict/-s` option to perform version consistency check:
```
$ kata-runtime kata-check --strict
INFO[0000] VSOCK supported, configure to not use proxy
System is capable of running Kata Containers
System can currently create Kata Containers
Version consistency of Kata Containers is verified
```
```
$ kata-runtime kata-check --strict         
INFO[0000] VSOCK supported, configure to not use proxy
System is capable of running Kata Containers
System can currently create Kata Containers
ERRO[0000] there exists version inconsistency in Kata Components. kata-shim: v1.8.1, kata-runtime: v1.10.0
  arch=arm64 name=kata-runtime pid=35284 source=runtime
there exists version inconsistency in Kata Components. kata-shim: v1.8.1, kata-runtime: v1.10.0
```