### PR TITLE
runtime: Change kata-runtime version output format to fit dockerd

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -452,21 +452,21 @@ func makeVersionString() string {
 		versionStr = unknown
 	}
 
-	v = append(v, name+"  : "+versionStr)
+	v = append(v, name+" version "+versionStr)
 
 	commitStr := commit
 	if commitStr == "" {
 		commitStr = unknown
 	}
 
-	v = append(v, "   commit   : "+commitStr)
+	v = append(v, "commit: "+commitStr)
 
 	specVersionStr := specs.Version
 	if specVersionStr == "" {
 		specVersionStr = unknown
 	}
 
-	v = append(v, "   OCI specs: "+specVersionStr)
+	v = append(v, "OCI specs: "+specVersionStr)
 
 	return strings.Join(v, "\n")
 }


### PR DESCRIPTION
I see this error in dockerd,
 `dockerd[962]: time="2020-01-10T14:56:03.481652400+08:00" level=warning msg="failed to parse /usr/bin/kata-runtime version: unknown output format: kata-runtime  : 1.10.0-rc0\n   commit   : 97d32c60e554306acb60d380242e4bedba600072\n   OCI specs: 1.0.1-dev\n"`

Then I changed kata-runtime version command output format to fit dockerd.