### PR TITLE
versions: update qemu to 4.1.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "4.1.0"
-      tag: "v4.1.0"
+      version: "4.1.1"
+      tag: "v4.1.1"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
Fixes CVE-2019-12068

shortlog:
99c5874a9b Update version for 4.1.1 release
e092a17d38 mirror: Keep mirror_top_bs drained after dropping permissions
088f1e8fd9 block/create: Do not abort if a block driver is not available
145b562990 vhost: Fix memory region section comparison
42b6571357 memory: Provide an equality function for MemoryRegionSections
c0aca9352d memory: Align MemoryRegionSections fields
54c130493c tests: make filemonitor test more robust to event ordering
3d018ff3bd block: posix: Always allocate the first block
f0d3fa265d file-posix: Handle undetectable alignment
7db05c8a73 block/file-posix: Let post-EOF fallocate serialize
d9b88f7e0d block: Add bdrv_co_get_self_request()
590cff8230 block: Make wait/mark serialising requests public
2e2ad02f2c block/io: refactor padding
b3b76fc643 util/iov: improve qemu_iovec_is_zero
cff024fe85 util/iov: introduce qemu_iovec_init_extended
40df4a1bf7 qcow2-bitmap: Fix uint64_t left-shift overflow
b156178553 iotests: Add peek_file* functions
15f5e8c367 iotests: Add test for 4G+ compressed qcow2 write
405deba14f qcow2: Fix QCOW2_COMPRESSED_SECTOR_MASK
01be50603b virtio-blk: Cancel the pending BH when the dataplane is reset
051c9b3cbc scsi: lsi: exit infinite loop while executing script
           (CVE-2019-12068)
b387531323 target/xtensa: regenerate and re-import test_mmuhifi_c3 core
cdc6896659 target/arm: Allow reading flags from FPSCR for M-profile
c0b35d87de hbitmap: handle set/reset with zero length
fcd7cba6ac util/hbitmap: strict hbitmap_reset
aea18ef938 COLO-compare: Fix incorrect `if` logic
4887acf574 virtio-net: prevent offloads reset on migration
8010d3fce0 virtio: new post_load hook
6705b9344f ui: Fix hanging up Cocoa display on macOS 10.15 (Catalina)
c0e2fbf124 mirror: Do not dereference invalid pointers
b077ac637d iotests: Test large write request to qcow2 file
9e51c5306c qcow2: Limit total allocation range to INT_MAX
aae0faa5d3 hw/core/loader: Fix possible crash in rom_copy()
7b404cae7f vhost-user: save features if the char dev is closed
d868d30db6 iotests: Test internal snapshots with -blockdev
7a8aa6c734 block/snapshot: Restrict set of snapshot nodes
331c08d300 s390: PCI: fix IOMMU region init
fc5afb1a92 roms/Makefile.edk2: don't pull in submodules when building from
           tarball
c5c9b1362d make-release: pull in edk2 submodules so we can build it from
           tarballs
220816989c hw/arm/boot.c: Set NSACR.{CP11,CP10} for NS kernel boots
783e7eb52c block/backup: fix backup_cow_with_offload for last cluster
e01ed1a1ae block/backup: fix max_transfer handling for copy_range
416a692e51 qcow2: Fix corruption bug in qcow2_detect_metadata_preallocation()
e9bb3d942e coroutine: Add qemu_co_mutex_assert_locked()
84f22c7285 block/qcow2: Fix corruption introduced by commit 8ac0f15f335
86b0f4022b blockjob: update nodes head while removing all bdrv
2d86df1f78 curl: Handle success in multi_check_completion
18e1b71937 curl: Report only ready sockets
0888ddac8e curl: Pass CURLSocket to curl_multi_do()
4be97ef966 curl: Check completion in curl_multi_do()
78ea94e389 curl: Keep *socket until the end of curl_sock_cb()
3648493495 curl: Keep pointer to the CURLState in CURLSocket
0694c489cd block/nfs: tear down aio before nfs_close
c9ffb12754 qcow2: Fix the calculation of the maximum L2 cache size
28a9a3558a libvhost-user: fix SLAVE_SEND_FD handling
9027d3fba6 target/arm: Don't abort on M-profile exception return in linux-user
           mode
38fb634853 target/arm: Free TCG temps in trans_VMOV_64_sp()
ad95e0573e iotests: Test blockdev-create for vpc
593beeaf81 iotests: Restrict nbd Python tests to nbd
eee776fbc0 iotests: Restrict file Python tests to file
819ba23575 iotests: Add supported protocols to execute_test()
4d9bdd3149 iotests: add testing shim for script-style python tests
97c478c355 vpc: Return 0 from vpc_co_create() on success
725dfa851f x86: do not advertise die-id in query-hotpluggbale-cpus if
           '-smp dies' is not set
57fdf4a13f pr-manager: Fix invalid g_free() crash bug
3361d03ff0 iotests: Test reverse sub-cluster qcow2 writes
6f1a94035b block/file-posix: Reduce xfsctl() use
c12adfd8f6 xen-bus: check whether the frontend is active during device reset...
b6cedc911e xen-bus: Fix backend state transition on device reset
7ebcd375ad pc: Don't make die-id mandatory unless necessary
4bfd496be3 target/alpha: fix tlb_fill trap_arg2 value for instruction fetch
499a5d6bb4 s390x/tcg: Fix VERIM with 32/64 bit elements
73a5bf4729 Revert "ide/ahci: Check for -ECANCELED in aio callbacks"
fbde196c30 dma-helpers: ensure AIO callback is invoked after cancellation

Signed-off-by: Julio Montes <julio.montes@intel.com>