### PR TITLE
unit-test: cleaning up stale files under /tmp

### DIFF
--- a/virtcontainers/acrn_arch_base_test.go
+++ b/virtcontainers/acrn_arch_base_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -128,6 +129,7 @@ func TestAcrnArchBaseAppendImage(t *testing.T) {
 
 	image, err := ioutil.TempFile("", "img")
 	assert.NoError(err)
+	defer os.Remove(image.Name())
 	err = image.Close()
 	assert.NoError(err)
 

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -636,6 +636,7 @@ func TestAgentConfigure(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "kata-agent-test")
 	assert.Nil(err)
+	defer os.RemoveAll(dir)
 
 	k := &kataAgent{}
 	h := &mockHypervisor{}
@@ -758,6 +759,7 @@ func TestAgentCreateContainer(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "kata-agent-test")
 	assert.Nil(err)
+	defer os.RemoveAll(dir)
 
 	err = k.configure(&mockHypervisor{}, sandbox.id, dir, true, KataAgentConfig{})
 	assert.Nil(err)
@@ -904,8 +906,10 @@ func TestKataCleanupSandbox(t *testing.T) {
 	s := Sandbox{
 		id: "testFoo",
 	}
-	dir := path.Join(kataHostSharedDir(), s.id)
-	err := os.MkdirAll(dir, 0777)
+
+	dir := kataHostSharedDir()
+	defer os.RemoveAll(dir)
+	err := os.MkdirAll(path.Join(dir, s.id), 0777)
 	assert.Nil(err)
 
 	k := &kataAgent{ctx: context.Background()}

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -287,6 +288,7 @@ func TestQemuArchBaseAppendImage(t *testing.T) {
 
 	image, err := ioutil.TempFile("", "img")
 	assert.NoError(err)
+	defer os.Remove(image.Name())
 	err = image.Close()
 	assert.NoError(err)
 

--- a/virtcontainers/vm_test.go
+++ b/virtcontainers/vm_test.go
@@ -8,6 +8,7 @@ package virtcontainers
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/kata-containers/runtime/virtcontainers/utils"
@@ -17,7 +18,10 @@ import (
 func TestNewVM(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
+	assert.Nil(err)
+	defer os.RemoveAll(testDir)
+
 	config := VMConfig{
 		HypervisorType: MockHypervisor,
 		AgentType:      NoopAgentType,
@@ -31,7 +35,7 @@ func TestNewVM(t *testing.T) {
 	ctx := context.Background()
 
 	var vm *VM
-	_, err := NewVM(ctx, config)
+	_, err = NewVM(ctx, config)
 	assert.Error(err)
 
 	config.HypervisorConfig = hyperConfig
@@ -82,7 +86,10 @@ func TestVMConfigValid(t *testing.T) {
 	err := config.Valid()
 	assert.Error(err)
 
-	testDir, _ := ioutil.TempDir("", "vmfactory-tmp-")
+	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
+	assert.Nil(err)
+	defer os.RemoveAll(testDir)
+
 	config.HypervisorConfig = HypervisorConfig{
 		KernelPath: testDir,
 		InitrdPath: testDir,


### PR DESCRIPTION
I've found a few unit tests which were generating stale files under `/tmp`

**- Using `defer` in TestMain.**
os.Exit will skip all deferred instructions.
So we should reconstruct TestMain to leave all setup-related code in setup(), and all cleanup-related code in shutdown().

**- Missing deleting what `ioutil.TempDir()` creates**
Normally, ` ioutil.TempDir` will create a new temporary dir under `/tmp`.

**- Missing deleting what `ioutil.TempFile()` creates**
`ioutil.TempFile` creates a new temporary file in the directory `/tmp`.
It is the caller's responsibility to remove the file when no longer needed.
