### PR TITLE
Fix typo in 'sandbox'

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1844,7 +1844,7 @@ func (s *Sandbox) cgroupsUpdate() error {
 func (s *Sandbox) cgroupsDelete() error {
 	s.Logger().Debug("Deleting sandbox cgroup")
 	if s.state.CgroupPath == "" {
-		s.Logger().Warnf("sandox cgroups path is empty")
+		s.Logger().Warnf("sandbox cgroups path is empty")
 		return nil
 	}
 


### PR DESCRIPTION
There was a small typo, "sandox"

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>