### PR TITLE
virtcontainers: constrain docker container when sandbox_cgroup_only=true

### DIFF
--- a/cli/config/configuration-acrn.toml.in
+++ b/cli/config/configuration-acrn.toml.in
@@ -223,9 +223,9 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 
 # if enabled, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
-# The sandbox cgroup is not constrained by the runtime
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+# The sandbox cgroup is constrained if there is no container type annotation.
 # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 

--- a/cli/config/configuration-clh.toml.in
+++ b/cli/config/configuration-clh.toml.in
@@ -199,9 +199,9 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 
 # if enabled, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
-# The sandbox cgroup is not constrained by the runtime
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+# The sandbox cgroup is constrained if there is no container type annotation.
 # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 

--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -325,9 +325,9 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 
 # if enable, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
-# The sandbox cgroup is not constrained by the runtime
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+# The sandbox cgroup is constrained if there is no container type annotation.
 # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 

--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -427,9 +427,9 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 
 # if enabled, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
-# The sandbox cgroup is not constrained by the runtime
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+# The sandbox cgroup is constrained if there is no container type annotation.
 # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -422,9 +422,9 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 
 # if enabled, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
-# The sandbox cgroup is not constrained by the runtime
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+# The sandbox cgroup is constrained if there is no container type annotation.
 # See: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -818,6 +818,8 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid, c
 		// Spec: &ocispec,
 
 		Experimental: runtime.Experimental,
+
+		HasCRIContainerType: HasCRIContainerType(ocispec.Annotations),
 	}
 
 	if err := addAnnotations(ocispec, &sandboxConfig); err != nil {
@@ -985,4 +987,15 @@ func GetOCIConfig(status vc.ContainerStatus) (specs.Spec, error) {
 	}
 
 	return *status.Spec, nil
+}
+
+// HasCRIContainerType returns true if annottations contain
+// a CRI container type annotation
+func HasCRIContainerType(annotations map[string]string) bool {
+	for _, key := range CRIContainerTypeKeyList {
+		if _, ok := annotations[key]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -127,7 +127,7 @@ type SandboxConfig struct {
 
 	// Cgroups specifies specific cgroup settings for the various subsystems that the container is
 	// placed into to limit the resources the container has available
-	Cgroups *configs.Cgroup `json:"cgroups"`
+	Cgroups *configs.Cgroup
 }
 
 func (s *Sandbox) trace(name string) (opentracing.Span, context.Context) {


### PR DESCRIPTION
The sandbox cgroup will be constrained if there is no container
 type annotation, otherwise kata will rely on container engine's cgroup
configuration

fixes #2408