### PR TITLE
vendor: update agent client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -419,7 +419,7 @@
   revision = "ee21903287393441c7bb53a0b0d39b8fa4075221"
 
 [[projects]]
-  digest = "1:6da9487ef0cc0cca3eeb1a24e3bb018ce2e07b7c2fc4d50975b54efdcc942118"
+  digest = "1:903bfb87f41dc18a533d327b5b03fd2f562f34deafcbd0db93d4be3fa8d6099c"
   name = "github.com/kata-containers/agent"
   packages = [
     "pkg/types",
@@ -427,7 +427,7 @@
     "protocols/grpc",
   ]
   pruneopts = "NUT"
-  revision = "1b3628c43660cb198ec055d78e5c7b03809cba60"
+  revision = "686708d9a8be625f9350c925ae3f038c1530a423"
 
 [[projects]]
   digest = "1:58999a98719fddbac6303cb17e8d85b945f60b72f48e3a2df6b950b97fa926f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/kata-containers/agent"
-  revision = "1b3628c43660cb198ec055d78e5c7b03809cba60"
+  revision = "686708d9a8be625f9350c925ae3f038c1530a423"
 
 [[constraint]]
   name = "github.com/containerd/cri-containerd"


### PR DESCRIPTION
Update agent client to improve CI stability.

Changes:

660e61f Revert: client.go: HybridVSockDialer: Change Read EOT to recv peek
6cfb75d Revert: client.go: HybridVSockDialer: Check return size n of unix.Recvfrom
54eb918 Revert: client.go: HybridVSockDialer: Close dup fd after receive packet
2f49115 agent: Fix mem-hotplug on x86 when ARCH_MEMORY_PROBE is set

Fixes: #2397

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>