### PR TITLE
versions: bump conmon version to v2.0.5

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -183,7 +183,7 @@ externals:
   conmon:
     description: "An OCI container runtime monitor"
     url: "https://github.com/containers/conmon"
-    version: "v2.0.1"
+    version: "v2.0.5"
 
   crio:
     description: |


### PR DESCRIPTION
in hopes the old failures were fixed, and to investigate them if not
if passes, this will fix: https://github.com/kata-containers/tests/issues/2271

Signed-off-by: Peter Hunt <pehunt@redhat.com>