### PR TITLE
yq: failed traversing anchors in version.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -125,11 +125,11 @@ assets:
       s390x:
         name: "ubuntu"
         version: "latest"
-      x86_64:
-        name: &default-image-name "clearlinux"
+      x86_64: &default-image
+        name: "clearlinux"
         version: "latest"
     meta:
-      image-type: *default-image-name
+      image-type: *default-image
 
   initrd:
     description: |
@@ -137,18 +137,12 @@ assets:
       machine.
     url: "https://github.com/kata-containers/osbuilder"
     architecture:
-      aarch64:
-        name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.7"
-      ppc64le:
-        name: *default-initrd-name
-        version: *default-initrd-version
-      s390x:
-        name: *default-initrd-name
-        version: *default-initrd-version
-      x86_64:
-        name: *default-initrd-name
-        version: *default-initrd-version
+      aarch64: &default-initrd
+        name: "alpine"
+        version: "3.7"
+      ppc64le: *default-initrd
+      s390x: *default-initrd
+      x86_64: *default-initrd
 
   kernel:
     description: "Linux kernel optimised for virtual machines"


### PR DESCRIPTION
# Description of problem
Recently, initrd-related CI are failing frequently. 
http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-PR-initrd/2843/
```
INFO: Image to generate: kata-containers-*default-initrd-name-*default-initrd-version-osbuilder-7526f49-agent-36b37f6.initrd
......
./rootfs-builder/rootfs.sh: line 280: /tmp/jenkins/workspace/kata-containers-runtime-ubuntu-18-04-PR-initrd/go/src/github.com/kata-containers/osbuilder/rootfs-builder/*default-initrd-name/config.sh: No such file or directory
Failed at 120: sudo -E AGENT_INIT="${AGENT_INIT}" AGENT_VERSION="${agent_commit}" GOPATH="$GOPATH" USE_DOCKER=true OS_VERSION=${os_version} ./rootfs-builder/rootfs.sh "${distro}"
Failed at 26: "${cidir}/install_kata_image.sh" "${tag}"
```
Debugging on the above output, the cause may come from that yq failed reading values from `assets.initrd.architecture.$arch.name`
Based on [the latest yq spec](https://mikefarah.gitbook.io/yq/commands/read#anchors-and-aliases), the read command could print out the anchors of a document and can also traverse them.
But when anchor refers to an scalar (string, integer etc), the latest yq could not traverse it.
e.g.
```
$ yq read versions.yaml "assets.initrd.architecture.ppc64le.name"
*default-initrd-name
```
