### PR TITLE
AArch64: fix golint error on ARM CI.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -795,6 +795,7 @@
     "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
     "github.com/opencontainers/runc/libcontainer/configs",
     "github.com/opencontainers/runc/libcontainer/specconv",
+    "github.com/opencontainers/runc/libcontainer/system",
     "github.com/opencontainers/runc/libcontainer/utils",
     "github.com/opencontainers/runtime-spec/specs-go",
     "github.com/opentracing/opentracing-go",

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -54,7 +54,7 @@ var (
 		"source": "rootless",
 	})
 
-	//The function is declared this way for mocking in unit tests
+	// IsRootless is declared this way for mocking in unit tests
 	IsRootless = isRootlessFunc
 )
 


### PR DESCRIPTION
# Description of problem
Recently, ARM CI frequently failed on the following golint error:
http://jenkins.katacontainers.io/job/kata-containers-runtime-ARM-18.04-PR/1451/console
```
11:24:18 pkg/rootless/rootless.go:57:2: comment on exported var `IsRootless` should be of the form `IsRootless ...` (golint)
11:24:18 	//The function is declared this way for mocking in unit tests
11:24:18 	^
11:24:23 Build step 'Execute shell' marked build as failure
```

**Updates:**
New error output:
```
12:13:45 # Gopkg.lock is out of sync:
12:13:45 github.com/opencontainers/runc/libcontainer/system: imported or required, but missing from Gopkg.lock's input-imports
```
It looks like that in PR #2418, we imported `github.com/opencontainers/runc/libcontainer/system`, but forgot to `dep ensure` ?