### PR TITLE
virtcontainers: clh: Set the serial to NULL instead of OFF

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -265,7 +265,7 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 
 	} else {
 		clh.vmconfig.Serial = chclient.ConsoleConfig{
-			Mode: cctOFF,
+			Mode: cctNULL,
 		}
 	}
 
@@ -761,6 +761,7 @@ func MaxClhVCPUs() uint32 {
 const (
 	cctOFF  string = "Off"
 	cctFILE string = "File"
+	cctNULL string = "Null"
 )
 
 const (


### PR DESCRIPTION
The guest Linux kernel might try to access the serial port, and in case
the serial is "off", this might cause some slowness because the port is
not emulated at all. Problem is, when the port is not emulated, the
default value when reading the I/O port will be 0, which has a special
meaning in case of the serial port. It means there is some data ready
to be read, which the kernel might try to read for some time, causing
global system slowness.

That's why it's safer to use "null" by default as this means the serial
port will be emulated but anything written to it will be redirected to
/dev/null.

Fixes #2437 

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>