### PR TITLE
selinux: Disable selinux

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1007,7 +1007,7 @@ func (k *kataAgent) replaceOCIMountsForStorages(spec *specs.Spec, volumeStorages
 	return nil
 }
 
-func constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
+func (k *kataAgent) constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
 	// Disable Hooks since they have been handled on the host and there is
 	// no reason to send them to the agent. It would make no sense to try
 	// to apply them on the guest.
@@ -1017,6 +1017,12 @@ func constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
 	// configuration.toml and guest image is seccomp capable.
 	if !passSeccomp {
 		grpcSpec.Linux.Seccomp = nil
+	}
+
+	// Disable selinux
+	if grpcSpec.Process.SelinuxLabel != "" {
+		k.Logger().Warn("Selinux label specified in config, but not supported in Kata yet, running container without selinux")
+		grpcSpec.Process.SelinuxLabel = ""
 	}
 
 	// By now only CPU constraints are supported
@@ -1312,7 +1318,7 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 
 	// We need to constraint the spec to make sure we're not passing
 	// irrelevant information to the agent.
-	constraintGRPCSpec(grpcSpec, passSeccomp)
+	k.constraintGRPCSpec(grpcSpec, passSeccomp)
 
 	k.handleShm(grpcSpec, sandbox)
 

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -487,9 +487,13 @@ func TestConstraintGRPCSpec(t *testing.T) {
 			},
 			CgroupsPath: "system.slice:foo:bar",
 		},
+		Process: &pb.Process{
+			SelinuxLabel: "foo",
+		},
 	}
 
-	constraintGRPCSpec(g, true)
+	k := kataAgent{}
+	k.constraintGRPCSpec(g, true)
 
 	// check nil fields
 	assert.Nil(g.Hooks)
@@ -501,6 +505,7 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	assert.Nil(g.Linux.Resources.HugepageLimits)
 	assert.Nil(g.Linux.Resources.Network)
 	assert.NotNil(g.Linux.Resources.CPU)
+	assert.Equal(g.Process.SelinuxLabel, "")
 
 	// check namespaces
 	assert.Len(g.Linux.Namespaces, 1)


### PR DESCRIPTION
Till we implement support for selinux, disable selinux
by not passing selinux labels in the container spec.

Fixes #2442

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>