### PR TITLE
AArch64: change image rootfs from fedora to ubuntu

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -117,7 +117,7 @@ assets:
     url: "https://github.com/kata-containers/osbuilder"
     architecture:
       aarch64:
-        name: "fedora"
+        name: "ubuntu"
         version: "latest"
       ppc64le:
         name: "centos"


### PR DESCRIPTION
Hi guys
I try to choose which distribution is the most suitable one for AArch64. And maybe the size of rootfs is the key point we should consider most and first. 
Comparing on the three common distribution: 

- Fedora
```
$ ~/go/src/github.com/kata-containers/osbuilder# du -sh fedora_rootfs/
283M    fedora_rootfs/
```

Also The late Fedora(`fedora 30`) has the following issue on AArch64: https://github.com/kata-containers/ci/issues/205, So we have to stick to the old version `fedora 29`.

- Centos
```
$ ~/go/src/github.com/kata-containers/osbuilder# du -sh centos_rootfs/                
394M    centos_rootfs/
```

- Ubuntu
```
$ ~/go/src/github.com/kata-containers/osbuilder# du -sh ubuntu_rootfs/                
118M    ubuntu_rootfs/
```
In conclusion, ubuntu is the best option on AArch64. ;)