### PR TITLE
ci: Do not setup virtcontainers while using podman

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -7,5 +7,8 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+export CI_JOB="${CI_JOB:-default}"
 
-run_go_test
+if [ "${CI_JOB}" != "PODMAN" ]; then
+	run_go_test
+fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -8,6 +8,7 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+export CI_JOB="${CI_JOB:-default}"
 
 clone_tests_repo
 
@@ -15,8 +16,10 @@ pushd "${tests_repo_dir}"
 .ci/setup.sh
 popd
 
-echo "Setup virtcontainers environment"
-chronic sudo -E PATH=$PATH bash -c "${cidir}/../virtcontainers/utils/virtcontainers-setup.sh"
+if [ "${CI_JOB}" != "PODMAN" ]; then
+	echo "Setup virtcontainers environment"
+	chronic sudo -E PATH=$PATH bash -c "${cidir}/../virtcontainers/utils/virtcontainers-setup.sh"
 
-echo "Install virtcontainers"
-make -C "${cidir}/../virtcontainers" && chronic sudo make -C "${cidir}/../virtcontainers" install
+	echo "Install virtcontainers"
+	make -C "${cidir}/../virtcontainers" && chronic sudo make -C "${cidir}/../virtcontainers" install
+fi


### PR DESCRIPTION
Skip the setup and installation of virtcontainers as it is using docker,
when we try to setup podman CI.

Depends-on: github.com/kata-containers/tests#2299

Fixes #2451

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>