### PR TITLE
agent: Use "virtiofs" instead of "virtio_fs"

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -61,7 +61,7 @@ var (
 	mountGuestTag               = "kataShared"
 	defaultKataGuestSandboxDir  = "/run/kata-containers/sandbox/"
 	type9pFs                    = "9p"
-	typeVirtioFS                = "virtio_fs"
+	typeVirtioFS                = "virtiofs"
 	typeVirtioFSNoCache         = "none"
 	kata9pDevType               = "9p"
 	kataMmioBlkDevType          = "mmioblk"


### PR DESCRIPTION
virtio_fs was the name used for the module in the very early stages of
its development.

Resolves: #2462

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>