### PR TITLE
sharedDirVirtioFS*Options changes / cleanups

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -868,7 +868,10 @@ func setupStorages(sandbox *Sandbox) []*grpc.Storage {
 			// options should not contain 'dax' lest the virtio-fs daemon crashing
 			// with an invalid address reference.
 			if sandbox.config.HypervisorConfig.VirtioFSCache != typeVirtioFSNoCache {
-				sharedDirVirtioFSOptions = append(sharedDirVirtioFSOptions, sharedDirVirtioFSDaxOptions)
+				// If virtio_fs_cache_size = 0, dax should not be used.
+				if sandbox.config.HypervisorConfig.VirtioFSCacheSize != 0 {
+					sharedDirVirtioFSOptions = append(sharedDirVirtioFSOptions, sharedDirVirtioFSDaxOptions)
+				}
 			}
 			sharedVolume := &grpc.Storage{
 				Driver:     kataVirtioFSDevType,

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -71,7 +71,7 @@ var (
 	kataNvdimmDevType           = "nvdimm"
 	kataVirtioFSDevType         = "virtio-fs"
 	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
-	sharedDirVirtioFSOptions    = []string{"default_permissions,allow_other,rootmode=040000,user_id=0,group_id=0", "nodev"}
+	sharedDirVirtioFSOptions    = []string{}
 	sharedDirVirtioFSDaxOptions = "dax"
 	shmDir                      = "shm"
 	kataEphemeralDevType        = "ephemeral"


### PR DESCRIPTION
sharedDirVirtioFSOptions has, by default, the following values: "default_permissions,allow_other,rootmode=040000,user_id=0,group_id=0", "nodev"

Although those values made sense in the earlier stages of development, the default options got baked into virtiofs.ko when it got merged.

Keeping those options as they ar would case the following issue:
```
[root@f32 runtime]# podman run --security-opt label=disable  --runtime=/usr/local/bin/kata-runtime --rm -id fedora sh
Error: rpc error: code = Internal desc = Could not mount kataShared to /run/kata-containers/shared/containers/: invalid argument: OCI runtime error
```

sharedDirVirtioFSOptions has, by default, the following value "dax". Although dax will be re-introduced soon, right now it just causes the very same issue described above:
```
[root@f32 runtime]# podman run --security-opt label=disable  --runtime=/usr/local/bin/kata-runtime --rm -id fedora sh
Error: rpc error: code = Internal desc = Could not mount kataShared to /run/kata-containers/shared/containers/: invalid argument: OCI runtime error
```

IMHO, the best way to work this around would be to **not** set the "dax" option when `virtio_fs_cache_size = 0`.

Those two fixes are related to #2464, but don't exactly go along with the conversation I've had with @devimc on #kata-dev. There we talked about:
- deprecate virtio_fs_extra_args;
- add virtio_fs_args (documenting what's already set as default);

The reasons I didn't take the suggested path are:
- virtio_fs_extra_args still makes sense, as those would be options passed to the virtiofsd daemon;
- add virtio_fs_args still makes sense, but  avoiding setting dax whenever `virtio_fs_cache = 0` also does, which makes me want to postpone the addition of virtio_fs_args till we explicitly need it.

Does everything make sense?