### PR TITLE
AArch64: officially enable firecracker v0.21.0 on AArch64

### DIFF
--- a/arch/arm64-options.mk
+++ b/arch/arm64-options.mk
@@ -10,3 +10,8 @@ KERNELPARAMS :=
 MACHINEACCELERATORS :=
 
 QEMUCMD := qemu-system-aarch64
+
+# Firecracker binary name
+FCCMD := firecracker
+# Firecracker's jailer binary name
+FCJAILERCMD := jailer

--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.20.0"
+      version: "v0.21.1"
 
     qemu:
       description: "VMM that uses KVM"

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -934,20 +934,6 @@ func (fc *firecracker) fcUpdateBlockDrive(path, id string) error {
 		return err
 	}
 
-	// Rescan needs to used only if the VM is running
-	if fc.vmRunning() {
-		actionParams := ops.NewCreateSyncActionParams()
-		actionType := "BlockDeviceRescan"
-		actionInfo := &models.InstanceActionInfo{
-			ActionType: &actionType,
-			Payload:    id,
-		}
-		actionParams.SetInfo(actionInfo)
-		if _, err := fc.client().Operations.CreateSyncAction(actionParams); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -361,7 +361,6 @@ func (fc *firecracker) fcInit(timeout int) error {
 		jailedArgs := []string{
 			"--id", fc.id,
 			"--node", "0", //FIXME: Comprehend NUMA topology or explicit ignore
-			"--seccomp-level", "2",
 			"--exec-file", fc.config.HypervisorPath,
 			"--uid", "0", //https://github.com/kata-containers/runtime/issues/1869
 			"--gid", "0",

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -80,7 +80,7 @@ const (
 )
 
 // Specify the minimum version of firecracker supported
-var fcMinSupportedVersion = semver.MustParse("0.19.0")
+var fcMinSupportedVersion = semver.MustParse("0.21.1")
 
 var fcKernelParams = append(commonVirtioblkKernelRootParams, []Param{
 	// The boot source is the first partition of the first block device added
@@ -300,7 +300,9 @@ func (fc *firecracker) getVersionNumber() (string, error) {
 	var version string
 	fields := strings.Split(string(data), " ")
 	if len(fields) > 1 {
-		version = strings.TrimSpace(fields[1])
+		// The output format of `Firecracker --verion` is as follows
+		// Firecracker v0.21.1
+		version = strings.TrimPrefix(strings.TrimSpace(fields[1]), "v")
 		return version, nil
 	}
 

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -612,7 +612,6 @@ func (fc *firecracker) fcSetLogger() error {
 		Level:       &fcLogLevel,
 		LogFifo:     &jailedLogFifo,
 		MetricsFifo: &jailedMetricsFifo,
-		Options:     []string{},
 	}
 
 	return err

--- a/virtcontainers/fc_test.go
+++ b/virtcontainers/fc_test.go
@@ -29,3 +29,19 @@ func TestFCGenerateSocket(t *testing.T) {
 	assert.NotEmpty(hvsock.UdsPath)
 	assert.NotZero(hvsock.Port)
 }
+
+func TestFCTruncateID(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+
+	testLongID := "3ef98eb7c6416be11e0accfed2f4e6560e07f8e33fa8d31922fd4d61747d7ead"
+	expectedID := "3ef98eb7c6416be11e0accfed2f4e656"
+	id := fc.truncateID(testLongID)
+	assert.Equal(expectedID, id)
+
+	testShortID := "3ef98eb7c6416be11"
+	expectedID = "3ef98eb7c6416be11"
+	id = fc.truncateID(testShortID)
+	assert.Equal(expectedID, id)
+}

--- a/virtcontainers/pkg/firecracker/client/models/instance_action_info.go
+++ b/virtcontainers/pkg/firecracker/client/models/instance_action_info.go
@@ -21,11 +21,8 @@ type InstanceActionInfo struct {
 
 	// Enumeration indicating what type of action is contained in the payload
 	// Required: true
-	// Enum: [BlockDeviceRescan FlushMetrics InstanceStart SendCtrlAltDel]
+	// Enum: [FlushMetrics InstanceStart SendCtrlAltDel]
 	ActionType *string `json:"action_type"`
-
-	// payload
-	Payload string `json:"payload,omitempty"`
 }
 
 // Validate validates this instance action info
@@ -46,7 +43,7 @@ var instanceActionInfoTypeActionTypePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["BlockDeviceRescan","FlushMetrics","InstanceStart","SendCtrlAltDel"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["FlushMetrics","InstanceStart","SendCtrlAltDel"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -55,9 +52,6 @@ func init() {
 }
 
 const (
-
-	// InstanceActionInfoActionTypeBlockDeviceRescan captures enum value "BlockDeviceRescan"
-	InstanceActionInfoActionTypeBlockDeviceRescan string = "BlockDeviceRescan"
 
 	// InstanceActionInfoActionTypeFlushMetrics captures enum value "FlushMetrics"
 	InstanceActionInfoActionTypeFlushMetrics string = "FlushMetrics"

--- a/virtcontainers/pkg/firecracker/client/models/logger.go
+++ b/virtcontainers/pkg/firecracker/client/models/logger.go
@@ -31,9 +31,6 @@ type Logger struct {
 	// Required: true
 	MetricsFifo *string `json:"metrics_fifo"`
 
-	// Additional logging options. Only "LogDirtyPages" is supported.
-	Options []string `json:"options"`
-
 	// Whether or not to output the level in the logs.
 	ShowLevel *bool `json:"show_level,omitempty"`
 

--- a/virtcontainers/pkg/firecracker/firecracker.yaml
+++ b/virtcontainers/pkg/firecracker/firecracker.yaml
@@ -449,12 +449,9 @@ definitions:
         description: Enumeration indicating what type of action is contained in the payload
         type: string
         enum:
-        - BlockDeviceRescan
         - FlushMetrics
         - InstanceStart
         - SendCtrlAltDel
-      payload:
-        type: string
 
   InstanceInfo:
     type: object

--- a/virtcontainers/pkg/firecracker/firecracker.yaml
+++ b/virtcontainers/pkg/firecracker/firecracker.yaml
@@ -5,7 +5,7 @@ info:
                The API is accessible through HTTP calls on specific URLs
                carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.19.0
+  version: 0.21.1
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"
@@ -508,12 +508,6 @@ definitions:
         type: boolean
         description: Whether or not to include the file path and line number of the log's origin.
         default: false
-      options:
-        type: array
-        items:
-          type: string
-        description: Additional logging options. Only "LogDirtyPages" is supported.
-        default: []
 
   MachineConfiguration:
     type: object


### PR DESCRIPTION
Hi~~guys
Firecracker has released the new version, `v0.21.0`. 
In this new release, Firecracker deprecated KVM dirty page tracking, and removed `options` field from the logger configuration. This feature previously was only supported on `amd64`.
So, finally, `AArch64` could support all general feature defined in [firecracker.yaml](https://github.com/firecracker-microvm/firecracker/blob/master/src/api_server/swagger/firecracker.yaml).
**So I want to officially enable firecracker in kata-containers on AArch64**.🎊

### Block:
In v0.21.0, Firecracker imported one new small `args_parser` scheme to do the command line arguments parsing. 
But it forgets to support `--version` flag. 
```
$ ./firecracker-v0.21.0-x86_64 --version
2020-02-26T03:15:13.135125190 [anonymous-instance:ERROR:src/firecracker/src/main.rs:132] Arguments parsing error: Found argument 'version' which wasn't expected, or isn't valid in this context.
```
I've raised one PR https://github.com/firecracker-microvm/firecracker/pull/1633 to fix it.
now, the upstream agrees to move it to `v0.21.1`.