### PR TITLE
clh: add 'APIsocket' to persist HypervisorState

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -435,12 +435,14 @@ func (clh *cloudHypervisor) save() (s persistapi.HypervisorState) {
 	s.Pid = clh.state.PID
 	s.Type = string(ClhHypervisor)
 	s.VirtiofsdPid = clh.state.VirtiofsdPID
+	s.APISocket = clh.state.apiSocket
 	return
 }
 
 func (clh *cloudHypervisor) load(s persistapi.HypervisorState) {
 	clh.state.PID = s.Pid
 	clh.state.VirtiofsdPID = s.VirtiofsdPid
+	clh.state.apiSocket = s.APISocket
 }
 
 func (clh *cloudHypervisor) check() error {

--- a/virtcontainers/persist/api/hypervisor.go
+++ b/virtcontainers/persist/api/hypervisor.go
@@ -42,4 +42,7 @@ type HypervisorState struct {
 	VirtiofsdPid         int
 	HotplugVFIOOnRootBus bool
 	PCIeRootPort         int
+
+	// clh sepcific: refer to 'virtcontainers/clh.go:CloudHypervisorState'
+	APISocket string
 }


### PR DESCRIPTION
The 'apiSocket' member in the CloudHypervisorState struct needs to be kept
across different executions of kata-runtime with persist HypervisorState, so
that kata-runtime can talk with the same running cloud-hypervisor through
HTTP/REST API calls.

Fixes: kata-containers#2506

Signed-off-by: Bo Chen <chen.bo@intel.com>