### PR TITLE
clh: enable CPU hotplug

### DIFF
--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -81,6 +81,11 @@ func (c *clhClientMock) BootVM(ctx context.Context) (*http.Response, error) {
 	return nil, nil
 }
 
+//nolint:golint
+func (c *clhClientMock) VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error) {
+	return nil, nil
+}
+
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}


### PR DESCRIPTION
With the HTTP API 'vm.resize()', the CPU hotplug with CLH is much simpler
comparing with QEMU. This is because we don't need to distinguish adding from
removing CPUs.

Fixes: #2495

Signed-off-by: Bo Chen <chen.bo@intel.com>

Note: hotplug with CLH requires a patch to the guest kernel (as noted from [CLH's docs](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/hotplug.md#kernel-support)), which is missing in kata's guest kernel for now. We will need to introduce [this patch](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/drivers/acpi/Makefile?id=ac36d37e943635fc072e9d4f47e40a48fbcdb3f0) to our kata packaging first, before we can merge this PR.