### PR TITLE
vc: add agent.container_pipe_size annotation

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -162,13 +162,14 @@ func ephemeralPath() string {
 // KataAgentConfig is a structure storing information needed
 // to reach the Kata Containers agent.
 type KataAgentConfig struct {
-	LongLiveConn  bool
-	UseVSock      bool
-	Debug         bool
-	Trace         bool
-	TraceMode     string
-	TraceType     string
-	KernelModules []string
+	LongLiveConn      bool
+	UseVSock          bool
+	Debug             bool
+	Trace             bool
+	ContainerPipeSize uint32
+	TraceMode         string
+	TraceType         string
+	KernelModules     []string
 }
 
 // KataAgentState is the structure describing the data stored from this
@@ -263,6 +264,11 @@ func KataAgentKernelParams(config KataAgentConfig) []Param {
 
 	if config.Trace && config.TraceMode == agentTraceModeStatic {
 		params = append(params, Param{Key: "agent.trace", Value: config.TraceType})
+	}
+
+	if config.ContainerPipeSize > 0 {
+		containerPipeSize := strconv.FormatUint(uint64(config.ContainerPipeSize), 10)
+		params = append(params, Param{Key: vcAnnotations.ContainerPipeSizeKernelParam, Value: containerPipeSize})
 	}
 
 	return params

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -237,6 +237,11 @@ const (
 
 	// AgentTraceMode is a sandbox annotation to specify the trace type for the agent.
 	AgentTraceType = kataAnnotAgentPrefix + "trace_type"
+
+	// AgentContainerPipeSize is an annotation to specify the size of the pipes created for containers
+	AgentContainerPipeSize       = kataAnnotAgentPrefix + ContainerPipeSizeOption
+	ContainerPipeSizeOption      = "container_pipe_size"
+	ContainerPipeSizeKernelParam = "agent." + ContainerPipeSizeOption
 )
 
 const (

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -775,6 +775,14 @@ func addAgentConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) error
 		c.TraceType = value
 	}
 
+	if value, ok := ocispec.Annotations[vcAnnotations.AgentContainerPipeSize]; ok {
+		containerPipeSize, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return fmt.Errorf("Error parsing annotation for %s: Please specify uint32 value", vcAnnotations.AgentContainerPipeSize)
+		}
+		c.ContainerPipeSize = uint32(containerPipeSize)
+	}
+
 	config.AgentConfig = c
 
 	return nil

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -701,10 +701,34 @@ func TestAddAgentAnnotations(t *testing.T) {
 			"e1000e InterruptThrottleRate=3000,3000,3000 EEE=1",
 			"i915 enable_ppgtt=0",
 		},
+		ContainerPipeSize: 1024,
 	}
 
 	ocispec.Annotations[vcAnnotations.KernelModules] = strings.Join(expectedAgentConfig.KernelModules, KernelModulesSeparator)
+	ocispec.Annotations[vcAnnotations.AgentContainerPipeSize] = "1024"
 	addAnnotations(ocispec, &config)
+	assert.Exactly(expectedAgentConfig, config.AgentConfig)
+}
+
+func TestContainerPipeSizeAnnotation(t *testing.T) {
+	assert := assert.New(t)
+
+	config := vc.SandboxConfig{
+		Annotations: make(map[string]string),
+		AgentConfig: vc.KataAgentConfig{},
+	}
+
+	ocispec := specs.Spec{
+		Annotations: make(map[string]string),
+	}
+
+	expectedAgentConfig := vc.KataAgentConfig{
+		ContainerPipeSize: 0,
+	}
+
+	ocispec.Annotations[vcAnnotations.AgentContainerPipeSize] = "foo"
+	err := addAnnotations(ocispec, &config)
+	assert.Error(err)
 	assert.Exactly(expectedAgentConfig, config.AgentConfig)
 }
 

--- a/virtcontainers/vm_test.go
+++ b/virtcontainers/vm_test.go
@@ -125,7 +125,7 @@ func TestVMConfigGrpc(t *testing.T) {
 		HypervisorType:   QemuHypervisor,
 		HypervisorConfig: newQemuConfig(),
 		AgentType:        KataContainersAgent,
-		AgentConfig:      KataAgentConfig{false, true, false, false, "", "", []string{}},
+		AgentConfig:      KataAgentConfig{false, true, false, false, 0, "", "", []string{}},
 		ProxyType:        NoopProxyType,
 	}
 


### PR DESCRIPTION
This adds the `agent.container_pipe_size` annotation which allows
configuration of the size of the pipes for stdout/stderr for containers
inside the guest.

fixes #2467

Signed-off-by: Alex Price <aprice@atlassian.com>