### PR TITLE
Jailer: checking whether chrootBasedir is mounted `noexec` 

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -481,7 +481,7 @@ func (c *Container) shareFiles(m Mount, idx int, hostSharedDir, guestSharedDir s
 	} else {
 		// These mounts are created in the shared dir
 		mountDest := filepath.Join(hostSharedDir, c.sandbox.id, filename)
-		if err := bindMount(c.ctx, m.Source, mountDest, false); err != nil {
+		if err := bindMount(c.ctx, m.Source, mountDest, false, "private"); err != nil {
 			return "", false, err
 		}
 		// Save HostPath mount value into the mount list of the container.

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -174,15 +174,15 @@ func TestUnmountHostMountsRemoveBindHostPath(t *testing.T) {
 			ctx:    context.Background(),
 		}
 
-		if err := bindMount(c.ctx, src, hostPath, false); err != nil {
+		if err := bindMount(c.ctx, src, hostPath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(hostPath, 0)
-		if err := bindMount(c.ctx, src, nonEmptyHostpath, false); err != nil {
+		if err := bindMount(c.ctx, src, nonEmptyHostpath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(nonEmptyHostpath, 0)
-		if err := bindMount(c.ctx, src, devPath, false); err != nil {
+		if err := bindMount(c.ctx, src, devPath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(devPath, 0)

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -309,6 +309,24 @@ func bindMount(ctx context.Context, source, destination string, readonly bool, p
 	return nil
 }
 
+// An existing mount may be remounted by specifying `MS_REMOUNT` in
+// mountflags.
+// This allows you to change the mountflags of an existing mount.
+// The mountflags should match the values used in the original mount() call,
+// except for those parameters that you are trying to change.
+func remount(ctx context.Context, mountflags uintptr, src string) error {
+	absSrc, err := filepath.EvalSymlinks(src)
+	if err != nil {
+		return fmt.Errorf("Could not resolve symlink for %s", src)
+	}
+
+	if err := syscall.Mount(absSrc, absSrc, "", syscall.MS_REMOUNT|mountflags, ""); err != nil {
+		return fmt.Errorf("remount %s failed: %v", absSrc, err)
+	}
+
+	return nil
+}
+
 // bindMountContainerRootfs bind mounts a container rootfs into a 9pfs shared
 // directory between the guest and the host.
 func bindMountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID, cRootFs string, readonly bool) error {

--- a/virtcontainers/syscall_test.go
+++ b/virtcontainers/syscall_test.go
@@ -7,93 +7,12 @@
 package virtcontainers
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
-	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestBindMountInvalidSourceSymlink(t *testing.T) {
-	source := filepath.Join(testDir, "fooFile")
-	os.Remove(source)
-
-	err := bindMount(context.Background(), source, "", false)
-	assert.Error(t, err)
-}
-
-func TestBindMountFailingMount(t *testing.T) {
-	source := filepath.Join(testDir, "fooLink")
-	fakeSource := filepath.Join(testDir, "fooFile")
-	os.Remove(source)
-	os.Remove(fakeSource)
-	assert := assert.New(t)
-
-	_, err := os.OpenFile(fakeSource, os.O_CREATE, mountPerm)
-	assert.NoError(err)
-
-	err = os.Symlink(fakeSource, source)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, "", false)
-	assert.Error(err)
-}
-
-func TestBindMountSuccessful(t *testing.T) {
-	assert := assert.New(t)
-	if tc.NotValid(ktu.NeedRoot()) {
-		t.Skip(testDisabledAsNonRoot)
-	}
-
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
-
-	err := os.MkdirAll(source, mountPerm)
-	assert.NoError(err)
-
-	err = os.MkdirAll(dest, mountPerm)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, dest, false)
-	assert.NoError(err)
-
-	syscall.Unmount(dest, 0)
-}
-
-func TestBindMountReadonlySuccessful(t *testing.T) {
-	assert := assert.New(t)
-	if tc.NotValid(ktu.NeedRoot()) {
-		t.Skip(testDisabledAsNonRoot)
-	}
-
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
-
-	err := os.MkdirAll(source, mountPerm)
-	assert.NoError(err)
-
-	err = os.MkdirAll(dest, mountPerm)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, dest, true)
-	assert.NoError(err)
-
-	defer syscall.Unmount(dest, 0)
-
-	// should not be able to create file in read-only mount
-	destFile := filepath.Join(dest, "foo")
-	_, err = os.OpenFile(destFile, os.O_CREATE, mountPerm)
-	assert.Error(err)
-}
 
 func TestEnsureDestinationExistsNonExistingSource(t *testing.T) {
 	err := ensureDestinationExists("", "")
@@ -107,8 +26,9 @@ func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
 	os.Remove(dest)
 	assert := assert.New(t)
 
-	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	file, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	assert.NoError(err)
+	defer file.Close()
 
 	err = ensureDestinationExists(source, dest)
 	assert.Error(err)
@@ -123,20 +43,22 @@ func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
 
 	err := os.MkdirAll(source, mountPerm)
 	assert.NoError(err)
+	defer os.Remove(source)
 
 	err = ensureDestinationExists(source, dest)
 	assert.NoError(err)
 }
 
 func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
+	source := filepath.Join(testDir, "fooFileSrc")
+	dest := filepath.Join(testDir, "fooFileDest")
 	os.Remove(source)
 	os.Remove(dest)
 	assert := assert.New(t)
 
-	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	file, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	assert.NoError(err)
+	defer file.Close()
 
 	err = ensureDestinationExists(source, dest)
 	assert.NoError(err)


### PR DESCRIPTION
Hi~ guys
When running kata-containers with jailer in Ubuntu 18.04, I've encountered the following error, after
jailer chrooting `$jailerChrootBaseDir/firecracker/<sandbox_id>/root` and trying to execute `firecracker`:
```
$ /run/vc/firecracker/..../root/firecracker
-bash: /run/vc/firecracker/.../root/firecracker: Permission denied
```
That's because that in some distributions(`Ubuntu 18.04`/ `Ubuntu 16.04`), now, `/run` is mounted with `noexec` flag.
```
$ mount | grep "/run"
tmpfs on /run type tmpfs (rw,nosuid,noexec,relatime,size=6582528k,mode=755)
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"

```
BTW, we could use `mount -o remount,exec /run` to temporarily fix the error. 
But IMO, above method is too risky and shouldn't been carried out by `kata-runtime`.  We just need to do one pre-run checking to ensure `jailerChrootBaseDir` is not mounted with `noexec`

And also we can relax the restriction of `jailerChrootBaseDir`. The default value of `jailerChrootBaseDir` is still `/run/vc`, but now we let user define their own customized value.
