### PR TITLE
Support persistent memory volumes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,11 +412,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:0044fb81f517f480ca3c33675a3af6b4ada77a6faf699a302bc2388c98cacba9"
+  digest = "1:fafdb4aa5b6207f51ec7557818d5f7a534ed44ea4fb31c6f2e8abb01d1627b74"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "3700c55dd766d37e17af354fb9975dc801619d62"
+  revision = "e969afbec52cf687bbe97b76654c664128cdb04b"
 
 [[projects]]
   digest = "1:d6e9b99fe0150d4c26d81612676e8d59ad045642e4cbc8646e494b50d4f245ef"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "3700c55dd766d37e17af354fb9975dc801619d62"
+  revision = "e969afbec52cf687bbe97b76654c664128cdb04b"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1323,7 +1323,7 @@ func (c *Container) hotplugDrive() error {
 			c.rootfsSuffix = ""
 		}
 		// If device mapper device, then fetch the full path of the device
-		devicePath, fsType, err = GetDevicePathAndFsType(dev.mountPoint)
+		devicePath, fsType, err = utils.GetDevicePathAndFsType(dev.mountPoint)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -643,6 +643,11 @@ func filterDevices(c *Container, devices []ContainerDevice) (ret []ContainerDevi
 }
 
 func (c *Container) createBlockDevices() error {
+	if !c.checkBlockDeviceSupport() {
+		c.Logger().Warn("Block device not supported")
+		return nil
+	}
+
 	// iterate all mounts and create block device if it's block based.
 	for i, m := range c.mounts {
 		if len(m.BlockDeviceID) > 0 || m.Type != "bind" {
@@ -657,18 +662,36 @@ func (c *Container) createBlockDevices() error {
 			return fmt.Errorf("stat %q failed: %v", m.Source, err)
 		}
 
+		var di *config.DeviceInfo
+		var err error
+
 		// Check if mount is a block device file. If it is, the block device will be attached to the host
 		// instead of passing this as a shared mount.
-		if c.checkBlockDeviceSupport() && stat.Mode&unix.S_IFBLK == unix.S_IFBLK {
-			b, err := c.sandbox.devManager.NewDevice(config.DeviceInfo{
+		if stat.Mode&unix.S_IFBLK == unix.S_IFBLK {
+			di = &config.DeviceInfo{
 				HostPath:      m.Source,
 				ContainerPath: m.Destination,
 				DevType:       "b",
 				Major:         int64(unix.Major(stat.Rdev)),
 				Minor:         int64(unix.Minor(stat.Rdev)),
-			})
+			}
+			// check whether source can be used as a pmem device
+		} else if di, err = config.PmemDeviceInfo(m.Source, m.Destination); err != nil {
+			c.Logger().WithError(err).
+				WithField("mount-source", m.Source).
+				Debug("no loop device")
+		}
+
+		if err == nil && di != nil {
+			b, err := c.sandbox.devManager.NewDevice(*di)
+
 			if err != nil {
-				return fmt.Errorf("device manager failed to create new device for %q: %v", m.Source, err)
+				// Do not return an error, try to create
+				// devices for other mounts
+				c.Logger().WithError(err).WithField("mount-source", m.Source).
+					Error("device manager failed to create new device")
+				continue
+
 			}
 
 			c.mounts[i].BlockDeviceID = b.DeviceID()

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -113,6 +113,10 @@ type DeviceInfo struct {
 	Major int64
 	Minor int64
 
+	// Pmem enabled persistent memory. Use HostPath as backing file
+	// for a nvdimm device in the guest.
+	Pmem bool
+
 	// FileMode permission bits for the device.
 	FileMode os.FileMode
 
@@ -169,6 +173,10 @@ type BlockDrive struct {
 
 	// ReadOnly sets the device file readonly
 	ReadOnly bool
+
+	// Pmem enables persistent memory. Use File as backing file
+	// for a nvdimm device in the guest
+	Pmem bool
 }
 
 // VFIODeviceType indicates VFIO device type

--- a/virtcontainers/device/config/config_test.go
+++ b/virtcontainers/device/config/config_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBackingFile(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir("", "backing")
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	orgGetSysDevPath := getSysDevPath
+	getSysDevPath = func(info DeviceInfo) string {
+		return dir
+	}
+	defer func() { getSysDevPath = orgGetSysDevPath }()
+
+	info := DeviceInfo{}
+	path, err := getBackingFile(info)
+	assert.Error(err)
+	assert.Empty(path)
+
+	loopDir := filepath.Join(dir, "loop")
+	err = os.Mkdir(loopDir, os.FileMode(0755))
+	assert.NoError(err)
+
+	backingFile := "/fake-img"
+
+	err = ioutil.WriteFile(filepath.Join(loopDir, "backing_file"), []byte(backingFile), os.FileMode(0755))
+	assert.NoError(err)
+
+	path, err = getBackingFile(info)
+	assert.NoError(err)
+	assert.Equal(backingFile, path)
+}
+
+func TestGetSysDevPathImpl(t *testing.T) {
+	assert := assert.New(t)
+
+	info := DeviceInfo{
+		DevType: "",
+		Major:   127,
+		Minor:   0,
+	}
+
+	path := getSysDevPathImpl(info)
+	assert.Empty(path)
+
+	expectedFormat := fmt.Sprintf("%d:%d", info.Major, info.Minor)
+
+	info.DevType = "c"
+	path = getSysDevPathImpl(info)
+	assert.Contains(path, expectedFormat)
+	assert.Contains(path, "char")
+
+	info.DevType = "b"
+	path = getSysDevPathImpl(info)
+	assert.Contains(path, expectedFormat)
+	assert.Contains(path, "block")
+}

--- a/virtcontainers/device/config/pmem.go
+++ b/virtcontainers/device/config/pmem.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/kata-containers/runtime/virtcontainers/utils"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// This signature is defined in the linux NVDIMM driver.
+	// devices or backing files with this signature can be used
+	// as pmem (persistent memory) devices in the guest.
+	pfnSignature = "NVDIMM_PFN_INFO"
+
+	// offset in the backing file where the signature should be
+	pfnSignatureOffset = int64(4 * 1024)
+)
+
+var (
+	pmemLog = logrus.WithField("source", "virtcontainers/device/config")
+)
+
+// PmemDeviceInfo returns a DeviceInfo if a loop device
+// is mounted on source, and the backing file of the loop device
+// has the PFN signature.
+func PmemDeviceInfo(source, destination string) (*DeviceInfo, error) {
+	stat := syscall.Stat_t{}
+	err := syscall.Stat(source, &stat)
+	if err != nil {
+		return nil, err
+	}
+
+	// device object is still incomplete,
+	// but it can be used to fetch the backing file
+	device := &DeviceInfo{
+		ContainerPath: destination,
+		DevType:       "b",
+		Major:         int64(unix.Major(stat.Dev)),
+		Minor:         int64(unix.Minor(stat.Dev)),
+		Pmem:          true,
+		DriverOptions: make(map[string]string),
+	}
+
+	pmemLog.WithFields(
+		logrus.Fields{
+			"major": device.Major,
+			"minor": device.Minor,
+		}).Debug("looking for backing file")
+
+	device.HostPath, err = getBackingFile(*device)
+	if err != nil {
+		return nil, err
+	}
+
+	pmemLog.WithField("backing-file", device.HostPath).
+		Debug("backing file found: looking for PFN signature")
+
+	if !hasPFNSignature(device.HostPath) {
+		return nil, fmt.Errorf("backing file %v has not PFN signature", device.HostPath)
+	}
+
+	_, fstype, err := utils.GetDevicePathAndFsType(source)
+	if err != nil {
+		pmemLog.WithError(err).WithField("mount-point", source).Warn("failed to get fstype: using ext4")
+		fstype = "ext4"
+	}
+
+	pmemLog.WithField("fstype", fstype).Debug("filesystem for mount point")
+	device.DriverOptions["fstype"] = fstype
+
+	return device, nil
+}
+
+// returns true if the file/device path has the PFN signature
+// required to use it as PMEM device and enable DAX.
+// See [1] to know more about the PFN signature.
+//
+// [1] - https://github.com/kata-containers/osbuilder/blob/master/image-builder/nsdax.gpl.c
+func hasPFNSignature(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		pmemLog.WithError(err).Error("Could not get PFN signature")
+		return false
+	}
+	defer f.Close()
+
+	signatureLen := len(pfnSignature)
+	signature := make([]byte, signatureLen)
+
+	l, err := f.ReadAt(signature, pfnSignatureOffset)
+	if err != nil {
+		pmemLog.WithError(err).Debug("Could not read pfn signature")
+		return false
+	}
+
+	pmemLog.WithFields(logrus.Fields{
+		"path":      path,
+		"signature": string(signature),
+	}).Debug("got signature")
+
+	if l != signatureLen {
+		pmemLog.WithField("read-bytes", l).Debug("Incomplete signature")
+		return false
+	}
+
+	return pfnSignature == string(signature)
+}

--- a/virtcontainers/device/config/pmem_test.go
+++ b/virtcontainers/device/config/pmem_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createPFNFile(assert *assert.Assertions, dir string) string {
+	pfnPath := filepath.Join(dir, "pfn")
+	file, err := os.Create(pfnPath)
+	assert.NoError(err)
+	defer file.Close()
+
+	l, err := file.WriteAt([]byte(pfnSignature), pfnSignatureOffset)
+	assert.NoError(err)
+	assert.Equal(len(pfnSignature), l)
+
+	return pfnPath
+}
+
+func TestHasPFNSignature(t *testing.T) {
+	assert := assert.New(t)
+
+	b := hasPFNSignature("/abc/xyz/123/sw")
+	assert.False(b)
+
+	f, err := ioutil.TempFile("", "pfn")
+	assert.NoError(err)
+	f.Close()
+	defer os.Remove(f.Name())
+
+	b = hasPFNSignature(f.Name())
+	assert.False(b)
+
+	pfnFile := createPFNFile(assert, os.TempDir())
+	defer os.Remove(pfnFile)
+
+	b = hasPFNSignature(pfnFile)
+	assert.True(b)
+}

--- a/virtcontainers/device/drivers/block.go
+++ b/virtcontainers/device/drivers/block.go
@@ -65,6 +65,11 @@ func (device *BlockDevice) Attach(devReceiver api.DeviceReceiver) (err error) {
 		Format: "raw",
 		ID:     utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
 		Index:  index,
+		Pmem:   device.DeviceInfo.Pmem,
+	}
+
+	if fs, ok := device.DeviceInfo.DriverOptions["fstype"]; ok {
+		drive.Format = fs
 	}
 
 	customOptions := device.DeviceInfo.DriverOptions
@@ -169,6 +174,7 @@ func (device *BlockDevice) Save() persistapi.DeviceState {
 			NvdimmID: drive.NvdimmID,
 			VirtPath: drive.VirtPath,
 			DevNo:    drive.DevNo,
+			Pmem:     drive.Pmem,
 		}
 	}
 	return ds
@@ -194,6 +200,7 @@ func (device *BlockDevice) Load(ds persistapi.DeviceState) {
 		NvdimmID: bd.NvdimmID,
 		VirtPath: bd.VirtPath,
 		DevNo:    bd.DevNo,
+		Pmem:     bd.Pmem,
 	}
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1099,6 +1099,13 @@ func (k *kataAgent) appendBlockDevice(dev ContainerDevice, c *Container) *grpc.D
 		return nil
 	}
 
+	if d.Pmem {
+		// block drive is a persistent memory device that
+		// was passed as volume (-v) not as device (--device).
+		// It shouldn't be visible in the container
+		return nil
+	}
+
 	kataDevice := &grpc.Device{
 		ContainerPath: dev.ContainerPath,
 	}
@@ -1461,6 +1468,12 @@ func (k *kataAgent) handleDeviceBlockVolume(c *Container, device api.Device) (*g
 		return nil, fmt.Errorf("malformed block drive")
 	}
 	switch {
+	// pmem volumes case
+	case blockDrive.Pmem:
+		vol.Driver = kataNvdimmDevType
+		vol.Source = fmt.Sprintf("/dev/pmem%s", blockDrive.NvdimmID)
+		vol.Fstype = blockDrive.Format
+		vol.Options = []string{"dax"}
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioBlockCCW:
 		vol.Driver = kataBlkCCWDevType
 		vol.Source = blockDrive.DevNo
@@ -1538,8 +1551,12 @@ func (k *kataAgent) handleBlockVolumes(c *Container) ([]*grpc.Storage, error) {
 		}
 
 		vol.MountPoint = m.Destination
-		vol.Fstype = "bind"
-		vol.Options = []string{"bind"}
+		if vol.Fstype == "" {
+			vol.Fstype = "bind"
+		}
+		if len(vol.Options) == 0 {
+			vol.Options = []string{"bind"}
+		}
 
 		volumeStorages = append(volumeStorages, vol)
 	}

--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -206,22 +206,6 @@ func TestGetDeviceForPathBindMount(t *testing.T) {
 	assert.Equal(sourceDev, destDev)
 }
 
-func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
-	assert := assert.New(t)
-	_, _, err := GetDevicePathAndFsType("")
-	assert.Error(err)
-}
-
-func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
-	assert := assert.New(t)
-
-	path, fstype, err := GetDevicePathAndFsType("/proc")
-	assert.NoError(err)
-
-	assert.Equal(path, "proc")
-	assert.Equal(fstype, "proc")
-}
-
 func TestIsDeviceMapper(t *testing.T) {
 	assert := assert.New(t)
 

--- a/virtcontainers/persist/api/device.go
+++ b/virtcontainers/persist/api/device.go
@@ -41,6 +41,10 @@ type BlockDrive struct {
 
 	// DevNo
 	DevNo string
+
+	// Pmem enabled persistent memory. Use File as backing file
+	// for a nvdimm device in the guest.
+	Pmem bool
 }
 
 // VFIODev represents a VFIO drive used for hotplugging

--- a/virtcontainers/utils/utils_linux_test.go
+++ b/virtcontainers/utils/utils_linux_test.go
@@ -33,3 +33,19 @@ func TestFindContextID(t *testing.T) {
 	assert.Zero(cid)
 	assert.Error(err)
 }
+
+func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
+	assert := assert.New(t)
+	_, _, err := GetDevicePathAndFsType("")
+	assert.Error(err)
+}
+
+func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
+	assert := assert.New(t)
+
+	path, fstype, err := GetDevicePathAndFsType("/proc")
+	assert.NoError(err)
+
+	assert.Equal(path, "proc")
+	assert.Equal(fstype, "proc")
+}


### PR DESCRIPTION
A persistent memory volume MUST meet the following conditions:
* A loop device must be mounted in the directory passed as volume
* The loop device must have a backing file
* The backing file must have the PFN signature at offset 4k [1][2]

The backing file is used as backend file for a NVDIMM device in the guest

fixes #2262

[1] - https://github.com/kata-containers/osbuilder/blob/master/image-builder
/nsdax.gpl.c
[2] - https://github.com/torvalds/linux/blob/master/drivers/nvdimm/pfn.h

cc @pohly

Signed-off-by: Julio Montes <julio.montes@intel.com>
