### PR TITLE
vc: Remove container share dir when stopping

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1108,6 +1108,11 @@ func (c *Container) stop(force bool) error {
 		return err
 	}
 
+	shareDir := filepath.Join(kataHostSharedDir(), c.sandbox.id, c.id)
+	if err := syscall.Rmdir(shareDir); err != nil {
+		c.Logger().WithError(err).WithField("share-dir", shareDir).Warn("Could not remove container share dir")
+	}
+
 	// container was killed by force, container MUST change its state
 	// as soon as possible just in case one of below operations fail leaving
 	// the containers in a bad state.

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -354,6 +354,10 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID s
 		logrus.Warnf("%s: %s", err, rootfsDest)
 		return nil
 	}
+	if err := syscall.Rmdir(rootfsDest); err != nil {
+		logrus.WithError(err).WithField("rootfs-dir", rootfsDest).Warn("Could not remove container rootfs dir")
+	}
+
 	return err
 }
 

--- a/virtcontainers/mount_test.go
+++ b/virtcontainers/mount_test.go
@@ -304,3 +304,29 @@ func TestBindUnmountContainerRootfsENOENTNotError(t *testing.T) {
 	err := bindUnmountContainerRootfs(context.Background(), testMnt, sID, cID)
 	assert.NoError(err)
 }
+
+func TestBindUnmountContainerRootfsRemoveRootfsDest(t *testing.T) {
+	assert := assert.New(t)
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+
+	sID := "sandIDTestRemoveRootfsDest"
+	cID := "contIDTestRemoveRootfsDest"
+
+	testPath := filepath.Join(testDir, sID, cID, rootfsDir)
+	syscall.Unmount(testPath, 0)
+	os.Remove(testPath)
+
+	err := os.MkdirAll(testPath, mountPerm)
+	assert.NoError(err)
+	defer os.RemoveAll(filepath.Join(testDir, sID))
+
+	bindUnmountContainerRootfs(context.Background(), testDir, sID, cID)
+
+	if _, err := os.Stat(testPath); err == nil {
+		t.Fatal("empty rootfs dest should be removed")
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Remove the rootfs bind dest and finally remove the created share directory when stopping the container.

Fixes #2516
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>