### PR TITLE
logging: reduce default log level to Warn from Info

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -57,8 +57,8 @@ var kataLog *logrus.Entry
 
 // originalLoggerLevel is the default log level. It is used to revert the
 // current log level back to its original value if debug output is not
-// required.
-var originalLoggerLevel logrus.Level
+// required. We set the default to 'Warn' for the runtime.
+var originalLoggerLevel = logrus.WarnLevel
 
 var debug = false
 

--- a/pkg/katautils/logger.go
+++ b/pkg/katautils/logger.go
@@ -15,7 +15,9 @@ import (
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
-var originalLoggerLevel = logrus.InfoLevel
+// Default our log level to 'Warn', rather than the logrus default
+// of 'Info', which is rather noisy.
+var originalLoggerLevel = logrus.WarnLevel
 var kataUtilsLogger = logrus.NewEntry(logrus.New())
 
 // SetLogger sets the logger for the factory.


### PR DESCRIPTION
Our default logging level was Info, which is rather noisy. Reduce it to Warn, so we still see any critical
items, but don't get swamped with Info messages.