### PR TITLE
clh: set rootfstype

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -122,6 +122,7 @@ var clhKernelParams = []Param{
 	{"noreplace-smp", ""},  // do not replace SMP instructions
 	{"agent.log_vport", fmt.Sprintf("%d", vSockLogsPort)}, // tell the agent where to send the logs
 	{"rootflags", "data=ordered,errors=remount-ro ro"},    // mount the root filesystem as readonly
+	{"rootfstype", "ext4"},
 }
 
 var clhDebugKernelParams = []Param{


### PR DESCRIPTION
set rootfstype=ext4 to make kernel not do print errros like:

```
Mount option "data=ordered" incompatible with ext2
```

Fixes: #2524

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>