### PR TITLE
clh: Remove dead-code on maxClhVcpus

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -62,7 +62,6 @@ const (
 	supportedMinorVersion = 5
 	defaultClhPath        = "/usr/local/bin/cloud-hypervisor"
 	virtioFsCacheAlways   = "always"
-	maxClhVcpus           = uint32(64)
 )
 
 // Interface that hides the implementation of openAPI client
@@ -793,11 +792,6 @@ func (clh *cloudHypervisor) LaunchClh() (string, int, error) {
 	}
 
 	return errStr, cmd.Process.Pid, nil
-}
-
-// MaxClhVCPUs returns the maximum number of vCPUs supported
-func MaxClhVCPUs() uint32 {
-	return maxClhVcpus
 }
 
 //###########################################################################

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -47,7 +47,7 @@ func newClhConfig() (HypervisorConfig, error) {
 		BlockDeviceDriver: config.VirtioBlock,
 		MemorySize:        defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
-		DefaultMaxVCPUs:   MaxClhVCPUs(),
+		DefaultMaxVCPUs:   uint32(64),
 		SharedFS:          config.VirtioFS,
 		VirtioFSCache:     virtioFsCacheAlways,
 		VirtioFSDaemon:    testVirtiofsdPath,


### PR DESCRIPTION
Our CLH driver in kata defines its own constant variable 'maxClhVcpus'
which can conflict with the maximum number of vCPUs specified from the
kata configuration file 'clh.config.DefaultMaxVCPUs'. As the value from
kata configuration file is preferred anyway and the code on 'maxClhVcpus'
is not being used. We'd better remove it for better readability and
avoiding further confusions.

Fixes: #2528

Signed-off-by: Bo Chen <chen.bo@intel.com>