### PR TITLE
shimv2: move container rootfs mounted flag to container level

### DIFF
--- a/containerd-shim-v2/container.go
+++ b/containerd-shim-v2/container.go
@@ -33,9 +33,10 @@ type container struct {
 	exit     uint32
 	status   task.Status
 	terminal bool
+	mounted  bool
 }
 
-func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.ContainerType, spec *specs.Spec) (*container, error) {
+func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.ContainerType, spec *specs.Spec, mounted bool) (*container, error) {
 	if r == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrInvalidArgument, " CreateTaskRequest points to nil")
 	}
@@ -59,6 +60,7 @@ func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.Con
 		status:   task.StatusCreated,
 		exitIOch: make(chan struct{}),
 		exitCh:   make(chan uint32, 1),
+		mounted:  mounted,
 	}
 	return c, nil
 }

--- a/containerd-shim-v2/container_test.go
+++ b/containerd-shim-v2/container_test.go
@@ -6,15 +6,16 @@
 package containerdshim
 
 import (
+	"testing"
+
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	_, err := newContainer(nil, nil, "", nil)
+	_, err := newContainer(nil, nil, "", nil, false)
 
 	assert.Error(err)
 }
@@ -24,7 +25,7 @@ func TestGetExec(t *testing.T) {
 
 	r := &taskAPI.CreateTaskRequest{}
 
-	c, err := newContainer(nil, r, "", nil)
+	c, err := newContainer(nil, r, "", nil, true)
 	assert.NoError(err)
 
 	_, err = c.getExec("")

--- a/containerd-shim-v2/delete.go
+++ b/containerd-shim-v2/delete.go
@@ -39,7 +39,7 @@ func deleteContainer(ctx context.Context, s *service, c *container) error {
 		return err
 	}
 
-	if s.mount {
+	if c.mounted {
 		rootfs := path.Join(c.bundle, "rootfs")
 		if err := mount.UnmountAll(rootfs, 0); err != nil {
 			logrus.WithError(err).Warn("failed to cleanup rootfs mount")

--- a/containerd-shim-v2/delete_test.go
+++ b/containerd-shim-v2/delete_test.go
@@ -40,7 +40,7 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testContainerID,
 	}
-	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil)
+	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil, true)
 	assert.NoError(err)
 }
 

--- a/containerd-shim-v2/exec_test.go
+++ b/containerd-shim-v2/exec_test.go
@@ -36,7 +36,7 @@ func TestExecNoSpecFail(t *testing.T) {
 	}
 
 	var err error
-	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil)
+	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil, false)
 	assert.NoError(err)
 
 	reqExec := &taskAPI.ExecProcessRequest{

--- a/containerd-shim-v2/pause_test.go
+++ b/containerd-shim-v2/pause_test.go
@@ -57,7 +57,7 @@ func TestPauseContainerSuccess(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testContainerID,
 	}
-	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil)
+	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil, true)
 	assert.NoError(err)
 
 	reqPause := &taskAPI.PauseRequest{
@@ -149,7 +149,7 @@ func TestResumeContainerSuccess(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testContainerID,
 	}
-	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil)
+	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil, true)
 	assert.NoError(err)
 
 	reqResume := &taskAPI.ResumeRequest{

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -82,7 +82,6 @@ func New(ctx context.Context, id string, publisher events.Publisher) (cdshim.Shi
 		events:     make(chan interface{}, chSize),
 		ec:         make(chan exit, bufferSize),
 		cancel:     cancel,
-		mount:      false,
 	}
 
 	go s.processExits()
@@ -109,10 +108,6 @@ type service struct {
 	// thus for the returned values needed pid, just return this shim's
 	// pid directly.
 	pid uint32
-
-	// if the container's rootfs is block device backed, kata shimv2
-	// will not do the rootfs mount.
-	mount bool
 
 	ctx        context.Context
 	sandbox    vc.VCSandbox

--- a/containerd-shim-v2/start_test.go
+++ b/containerd-shim-v2/start_test.go
@@ -50,7 +50,7 @@ func TestStartStartSandboxSuccess(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testSandboxID,
 	}
-	s.containers[testSandboxID], err = newContainer(s, reqCreate, vc.PodSandbox, nil)
+	s.containers[testSandboxID], err = newContainer(s, reqCreate, vc.PodSandbox, nil, false)
 	assert.NoError(err)
 
 	reqStart := &taskAPI.StartRequest{
@@ -98,7 +98,7 @@ func TestStartMissingAnnotation(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testSandboxID,
 	}
-	s.containers[testSandboxID], err = newContainer(s, reqCreate, "", nil)
+	s.containers[testSandboxID], err = newContainer(s, reqCreate, "", nil, false)
 	assert.NoError(err)
 
 	reqStart := &taskAPI.StartRequest{
@@ -164,7 +164,7 @@ func TestStartStartContainerSucess(t *testing.T) {
 	reqCreate := &taskAPI.CreateTaskRequest{
 		ID: testContainerID,
 	}
-	s.containers[testContainerID], err = newContainer(s, reqCreate, vc.PodContainer, nil)
+	s.containers[testContainerID], err = newContainer(s, reqCreate, vc.PodContainer, nil, false)
 	assert.NoError(err)
 
 	reqStart := &taskAPI.StartRequest{

--- a/containerd-shim-v2/wait.go
+++ b/containerd-shim-v2/wait.go
@@ -112,13 +112,14 @@ func watchSandbox(s *service) {
 		logrus.WithError(err).Warn("delete sandbox failed")
 	}
 
-	if s.mount {
-		for _, c := range s.containers {
-			rootfs := path.Join(c.bundle, "rootfs")
-			logrus.WithField("rootfs", rootfs).WithField("id", c.id).Debug("container umount rootfs")
-			if err := mount.UnmountAll(rootfs, 0); err != nil {
-				logrus.WithError(err).Warn("failed to cleanup rootfs mount")
-			}
+	for _, c := range s.containers {
+		if !c.mounted {
+			continue
+		}
+		rootfs := path.Join(c.bundle, "rootfs")
+		logrus.WithField("rootfs", rootfs).WithField("id", c.id).Debug("container umount rootfs")
+		if err := mount.UnmountAll(rootfs, 0); err != nil {
+			logrus.WithError(err).Warn("failed to cleanup rootfs mount")
 		}
 	}
 


### PR DESCRIPTION
It is in fact a container specific info not sandbox level info.
We are assuming that all containers use the same snapshotter
but we should be able to handle different snapshotters even in
the same sandbox.