### PR TITLE
Update go to v1.13.8

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -300,7 +300,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.12.3"
+      newest-version: "1.13.8"
 
   rust:
     description: "rust language"


### PR DESCRIPTION
We need this update for building Kubernetes and CRI-O with the latest go 1.13
version.

/cc @chavafg 

Releates to https://github.com/cri-o/cri-o/pull/3392
Fixes https://github.com/kata-containers/runtime/issues/2537