### PR TITLE
virtcontainers: Don't create vfio devices in the guest

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -51,6 +51,9 @@ const (
 	// KataLocalDevType creates a local directory inside the VM for sharing files between
 	// containers.
 	KataLocalDevType = "local"
+
+	// path to vfio devices
+	vfioPath = "/dev/vfio/"
 )
 
 var (
@@ -1067,6 +1070,18 @@ func (k *kataAgent) constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
 		}
 	}
 	grpcSpec.Linux.Namespaces = tmpNamespaces
+
+	// VFIO char device shouldn't not appear in the guest,
+	// the device driver should handle it and determinate its group.
+	var linuxDevices []grpc.LinuxDevice
+	for _, dev := range grpcSpec.Linux.Devices {
+		if dev.Type == "c" && strings.HasPrefix(dev.Path, vfioPath) {
+			k.Logger().WithField("vfio-dev", dev.Path).Debug("removing vfio device from grpcSpec")
+			continue
+		}
+		linuxDevices = append(linuxDevices, dev)
+	}
+	grpcSpec.Linux.Devices = linuxDevices
 }
 
 func (k *kataAgent) handleShm(grpcSpec *grpc.Spec, sandbox *Sandbox) {

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"io/ioutil"
 	"net"
 	"os"
@@ -19,6 +18,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	vcAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 
 	gpb "github.com/gogo/protobuf/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -611,6 +612,16 @@ func TestConstraintGRPCSpec(t *testing.T) {
 				Network:        &pb.LinuxNetwork{},
 			},
 			CgroupsPath: "system.slice:foo:bar",
+			Devices: []pb.LinuxDevice{
+				{
+					Path: "/dev/vfio/1",
+					Type: "c",
+				},
+				{
+					Path: "/dev/vfio/2",
+					Type: "c",
+				},
+			},
 		},
 		Process: &pb.Process{
 			SelinuxLabel: "foo",
@@ -641,6 +652,9 @@ func TestConstraintGRPCSpec(t *testing.T) {
 
 	// check cgroup path
 	assert.Equal(expectedCgroupPath, g.Linux.CgroupsPath)
+
+	// check Linux devices
+	assert.Empty(g.Linux.Devices)
 }
 
 func TestHandleShm(t *testing.T) {

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -675,8 +675,6 @@ func TestContainerStateSetFstype(t *testing.T) {
 	assert.Equal(cImpl.state.Fstype, newFstype)
 }
 
-const vfioPath = "/dev/vfio/"
-
 func TestSandboxAttachDevicesVFIO(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	assert.Nil(t, err)


### PR DESCRIPTION
vfio devices hotplugged in the VM are expected to be handled by the kernel
driver in the guest, hence the char vfio devices shouldn't appear in the
container under /dev/vfio/.

fixes #2539

Signed-off-by: Julio Montes <julio.montes@intel.com>