### PR TITLE
config: Add scsi_mod.scan=none for virtio-scsi

### DIFF
--- a/pkg/katautils/create_test.go
+++ b/pkg/katautils/create_test.go
@@ -208,6 +208,10 @@ func TestSetKernelParams(t *testing.T) {
 	err := SetKernelParams(&config)
 	assert.NoError(err)
 
+	config.HypervisorConfig.BlockDeviceDriver = "virtio-scsi"
+	err = SetKernelParams(&config)
+	assert.NoError(err)
+
 	if needSystemd(config.HypervisorConfig) {
 		assert.NotEmpty(config.HypervisorConfig.KernelParams)
 	}


### PR DESCRIPTION
As per [1], the default scan mode of scsi is sync. Change it to none
can reduce the guest boot time:
=Before this patch=
[    0.090796]  vda: vda1
[    0.092119] scsi host0: Virtio SCSI HBA
[    0.148851] tun: Universal TUN/TAP device driver, 1.6
[    0.149023] rtc-pl031 9010000.pl031: rtc core: registered pl031 as rtc0

=After this patch=
[    0.077012]  vda: vda1
[    0.078353] scsi host0: Virtio SCSI HBA
[    0.080755] tun: Universal TUN/TAP device driver, 1.6
[    0.081884] rtc-pl031 9010000.pl031: rtc core: registered pl031 as rtc0
It reduces about 54ms on arm64 for virtio-scsi.

This patch changes the default kernel parameter:
1. If user specifies the scan mode, use that
2. If user doesn't specify it, and the block device is virtio-scsi, use
   "async" by default

[1] https://lwn.net/Articles/201898/

Fixes: #2560
Signed-off-by: Jia He <justin.he@arm.com