### PR TITLE
versions: Update containerd commit

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -199,7 +199,9 @@ externals:
       Containerd Plugin for Kubernetes Container Runtime Interface.
     url: "github.com/containerd/cri"
     tarball_url: "https://storage.googleapis.com/cri-containerd-release"
-    version: "1.3.0"
+    # Next commit from 1.3 branch contains fix to be able to run
+    # tests using go 1.13
+    version: "3a4acfbc99aa976849f51a8edd4af20ead51d8d7"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
We currently use containerd v1.3.0, but this version has an
issue when running the containerd/cri tests with go 1.13.
This commit: 3a4acfbc99aa976849f51a8edd4af20ead51d8d7 from
branch release/1.3 contains the fix to be able to run the
tests with go 1.13.

Fixes: #2562.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>