### PR TITLE
clh:  Implment capabilities 

### DIFF
--- a/virtcontainers/acrn_arch_base.go
+++ b/virtcontainers/acrn_arch_base.go
@@ -360,8 +360,6 @@ func (a *acrnArchBase) memoryTopology(memoryMb uint64) Memory {
 func (a *acrnArchBase) capabilities() types.Capabilities {
 	var caps types.Capabilities
 
-	// For devicemapper disable support for filesystem sharing
-	caps.SetFsSharingUnsupported()
 	caps.SetBlockDeviceSupport()
 	caps.SetBlockDeviceHotplugSupport()
 

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -579,8 +579,8 @@ func (clh *cloudHypervisor) capabilities() types.Capabilities {
 
 	clh.Logger().WithField("function", "capabilities").Info("get Capabilities")
 	var caps types.Capabilities
+	caps.SetFsSharingSupport()
 	return caps
-
 }
 
 func (clh *cloudHypervisor) trace(name string) (opentracing.Span, context.Context) {

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -1065,7 +1065,6 @@ func (fc *firecracker) capabilities() types.Capabilities {
 	span, _ := fc.trace("capabilities")
 	defer span.Finish()
 	var caps types.Capabilities
-	caps.SetFsSharingUnsupported()
 	caps.SetBlockDeviceHotplugSupport()
 
 	return caps

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -119,6 +119,7 @@ func (q *qemuAmd64) capabilities() types.Capabilities {
 	}
 
 	caps.SetMultiQueueSupport()
+	caps.SetFsSharingSupport()
 
 	return caps
 }

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -271,6 +271,7 @@ func (q *qemuArchBase) capabilities() types.Capabilities {
 	var caps types.Capabilities
 	caps.SetBlockDeviceHotplugSupport()
 	caps.SetMultiQueueSupport()
+	caps.SetFsSharingSupport()
 	return caps
 }
 

--- a/virtcontainers/types/capabilities.go
+++ b/virtcontainers/types/capabilities.go
@@ -9,7 +9,7 @@ const (
 	blockDeviceSupport = 1 << iota
 	blockDeviceHotplugSupport
 	multiQueueSupport
-	fsSharingUnsupported
+	fsSharingSupported
 )
 
 // Capabilities describe a virtcontainers hypervisor capabilities
@@ -50,10 +50,10 @@ func (caps *Capabilities) SetMultiQueueSupport() {
 
 // IsFsSharingSupported tells if an hypervisor supports host filesystem sharing.
 func (caps *Capabilities) IsFsSharingSupported() bool {
-	return caps.flags&fsSharingUnsupported == 0
+	return caps.flags&fsSharingSupported != 0
 }
 
 // SetFsSharingUnsupported sets the host filesystem sharing capability to true.
-func (caps *Capabilities) SetFsSharingUnsupported() {
-	caps.flags |= fsSharingUnsupported
+func (caps *Capabilities) SetFsSharingSupport() {
+	caps.flags |= fsSharingSupported
 }

--- a/virtcontainers/types/capabilities_test.go
+++ b/virtcontainers/types/capabilities_test.go
@@ -30,7 +30,7 @@ func TestBlockDeviceHotplugCapability(t *testing.T) {
 func TestFsSharingCapability(t *testing.T) {
 	var caps Capabilities
 
-	assert.True(t, caps.IsFsSharingSupported())
-	caps.SetFsSharingUnsupported()
 	assert.False(t, caps.IsFsSharingSupported())
+	caps.SetFsSharingSupport()
+	assert.True(t, caps.IsFsSharingSupported())
 }


### PR DESCRIPTION
- Change capabilities to change `SetFsSharingUnsupported()`  to `SetFsSharingSupport()` it make more natural with the rest of methods that enable features. 

- Implement `capabilities()` for clh by setting  `FsSharingSupport` to true, other capabilities are not supported today.