### PR TITLE
qemu: Don't crash if virtiofsd path is non existent

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -638,6 +638,10 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	var listener *net.UnixListener
 	var fd *os.File
 
+	if _, err = os.Stat(q.config.VirtioFSDaemon); os.IsNotExist(err) {
+		return fmt.Errorf("virtiofsd path (%s) does not exist", q.config.VirtioFSDaemon)
+	}
+
 	sockPath, err := q.vhostFSSocketPath(q.id)
 	if err != nil {
 		return err


### PR DESCRIPTION
Instead, report an error and exit gracefully, as shown below:
```
dahmer fidencio # podman run -ti --runtime=/usr/bin/kata-runtime fedora sh
Error: stat /usr/libexec/virtiofsd: no such file or directory: OCI runtime command not found error
```

Fixes: #2582

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>