### PR TITLE
qemu_ppc64le: EXpose fs support explicitly

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -95,6 +95,7 @@ func (q *qemuPPC64le) capabilities() types.Capabilities {
 	}
 
 	caps.SetMultiQueueSupport()
+	caps.SetFsSharingSupport()
 
 	return caps
 }


### PR DESCRIPTION
Since fs sharing is not assumed as supported by default, expose
explicitly that the qemu_ppc64le supports it.

Fixes: #2584

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>