### PR TITLE
versions: Update go to 1.13.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ sudo: required
 dist: xenial
 
 language: go
+go:
+  - 1.13.9
 
 os:
   - linux
@@ -30,7 +32,6 @@ before_install:
   - ".ci/versions_checker.sh"
 
 before_script:
-  - ".ci/install_go.sh"
   - ".ci/static-checks.sh"
   - ".ci/versions_checker.sh"
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -302,7 +302,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.13.8"
+      newest-version: "1.13.9"
 
   rust:
     description: "rust language"


### PR DESCRIPTION
Update golang to fix `golangci-lint` errors on travis.

Depends-on: github.com/kata-containers/tests#2435

Fixes: #2592.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>