### PR TITLE
clh: virtiofs: Add no_posix_lock option

### DIFF
--- a/virtcontainers/virtiofsd.go
+++ b/virtcontainers/virtiofsd.go
@@ -126,9 +126,11 @@ func (v *virtiofsd) args() ([]string, error) {
 
 	args := []string{
 		"-f",
-		"-o", "vhost_user_socket=" + v.socketPath,
+		"-o", "cache=" + v.cache,
+		"-o", "no_posix_lock",
 		"-o", "source=" + v.sourcePath,
-		"-o", "cache=" + v.cache}
+		"-o", "vhost_user_socket=" + v.socketPath,
+	}
 
 	if len(v.extraArgs) != 0 {
 		args = append(args, v.extraArgs...)


### PR DESCRIPTION
Add option in qemu driver , this will allow lock operations.

Fixes: #2594

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>