### PR TITLE
qemu: virtifsd: remove no_posix_lock option

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -622,7 +622,7 @@ func (q *qemu) virtiofsdArgs(fd uintptr) []string {
 		fmt.Sprintf("--fd=%v", fd),
 		"-o", "source=" + sourcePath,
 		"-o", "cache=" + q.config.VirtioFSCache,
-		"--syslog", "-o", "no_posix_lock"}
+		"--syslog"}
 	if q.config.Debug {
 		args = append(args, "-d")
 	} else {

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -555,12 +555,12 @@ func TestQemuVirtiofsdArgs(t *testing.T) {
 		kataHostSharedDir = savedKataHostSharedDir
 	}()
 
-	result := "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -o no_posix_lock -d"
+	result := "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -d"
 	args := q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 
 	q.config.Debug = false
-	result = "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -o no_posix_lock -f"
+	result = "--fd=123 -o source=test-share-dir/foo -o cache=none --syslog -f"
 	args = q.virtiofsdArgs(123)
 	assert.Equal(strings.Join(args, " "), result)
 }


### PR DESCRIPTION
Remove no_posix_lock until find a solution on how to
expose this and other capabilities.

Related to: https://github.com/kata-containers/runtime/pull/2595

Fixes: #2444

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>