### PR TITLE
qemu-ppc64le: Switch off large decrementer capability

### DIFF
--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -22,7 +22,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken"
+const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off"
 
 const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
 


### PR DESCRIPTION
Large decrementer was introduced in Power 9 cpus.
Switch it off "cap-large-decr=off" as not all KVM hosts
support it

Fixes: #2599

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>