### PR TITLE
dax: enable dax on arm64

### DIFF
--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -140,6 +140,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,
 			disableNvdimm:         config.DisableImageNvdimm,
+			dax:                   true,
 		},
 	}
 


### PR DESCRIPTION
Hi guys

In PR https://github.com/kata-containers/packaging/pull/1006, I've backported Anshuman Khandual's patch series of Enabling memory hot remove on aarch64(https://patchwork.kernel.org/cover/11419305/) to `v5.4.x`.
This patch series has already been merged, and queued for 5.7.
And after backporting this series, we could finally enable nvdimm/dax on arm64.

See kernel dump info:
```
[    0.154853] EXT4-fs (pmem0p1): DAX enabled. Warning: EXPERIMENTAL, use at your own risk
[    0.155487] EXT4-fs (pmem0p1): mounted filesystem with ordered data mode. Opts: dax,data=ordered,errors=remount-ro
[    0.155714] VFS: Mounted root (ext4 filesystem) readonly on device 259:1
```
NVDIMM/DAX is truly working here~~