### PR TITLE
virtcontainers: apply constrains to the sandbox cgroup

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -76,13 +76,6 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		return nil, err
 	}
 
-	// Move runtime to sandbox cgroup so all process are created there.
-	if s.config.SandboxCgroupOnly {
-		if err := s.setupSandboxCgroup(); err != nil {
-			return nil, err
-		}
-	}
-
 	// cleanup sandbox resources in case of any failure
 	defer func() {
 		if err != nil {
@@ -101,6 +94,13 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 			s.removeNetwork()
 		}
 	}()
+
+	// Move runtime to sandbox cgroup so all process are created there.
+	if s.config.SandboxCgroupOnly {
+		if err := s.setupSandboxCgroup(); err != nil {
+			return nil, err
+		}
+	}
 
 	// Start the VM
 	if err = s.startVM(); err != nil {

--- a/virtcontainers/device/api/interface.go
+++ b/virtcontainers/device/api/interface.go
@@ -56,6 +56,9 @@ type Device interface {
 	// GetMajorMinor returns major and minor numbers
 	GetMajorMinor() (int64, int64)
 
+	// GetHostPath return the device path in the host
+	GetHostPath() string
+
 	// GetDeviceInfo returns device specific data used for hotplugging by hypervisor
 	// Caller could cast the return value to device specific struct
 	// e.g. Block device returns *config.BlockDrive,

--- a/virtcontainers/device/drivers/generic.go
+++ b/virtcontainers/device/drivers/generic.go
@@ -68,6 +68,14 @@ func (device *GenericDevice) GetMajorMinor() (int64, int64) {
 	return device.DeviceInfo.Major, device.DeviceInfo.Minor
 }
 
+// GetHostPath return the device path in the host
+func (device *GenericDevice) GetHostPath() string {
+	if device.DeviceInfo != nil {
+		return device.DeviceInfo.HostPath
+	}
+	return ""
+}
+
 // Reference adds one reference to device
 func (device *GenericDevice) Reference() uint {
 	if device.RefCount != intMax {

--- a/virtcontainers/device/drivers/generic_test.go
+++ b/virtcontainers/device/drivers/generic_test.go
@@ -8,6 +8,7 @@ package drivers
 import (
 	"testing"
 
+	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,4 +42,16 @@ func TestBumpAttachCount(t *testing.T) {
 			assert.Nil(t, err)
 		}
 	}
+}
+
+func TestGetHostPath(t *testing.T) {
+	assert := assert.New(t)
+	dev := &GenericDevice{}
+	assert.Empty(dev.GetHostPath())
+
+	expectedHostPath := "/dev/null"
+	dev.DeviceInfo = &config.DeviceInfo{
+		HostPath: expectedHostPath,
+	}
+	assert.Equal(expectedHostPath, dev.GetHostPath())
 }

--- a/virtcontainers/pkg/cgroups/manager.go
+++ b/virtcontainers/pkg/cgroups/manager.go
@@ -23,7 +23,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 type Config struct {
@@ -74,21 +73,7 @@ func UseSystemdCgroup() bool {
 
 // returns the list of devices that a hypervisor may need
 func hypervisorDevices() []specs.LinuxDeviceCgroup {
-	wildcard := int64(-1)
-	devicemapperMajor := int64(253)
-
 	devices := []specs.LinuxDeviceCgroup{}
-
-	devices = append(devices,
-		// hypervisor needs access to all devicemapper devices,
-		// since they can be hotplugged in the VM.
-		specs.LinuxDeviceCgroup{
-			Allow:  true,
-			Type:   "b",
-			Major:  &devicemapperMajor,
-			Minor:  &wildcard,
-			Access: "rwm",
-		})
 
 	// Processes running in a device-cgroup are constrained, they have acccess
 	// only to the devices listed in the devices.list file.
@@ -97,33 +82,16 @@ func hypervisorDevices() []specs.LinuxDeviceCgroup {
 	hypervisorDevices := []string{
 		"/dev/kvm",       // To run virtual machines
 		"/dev/vhost-net", // To create virtqueues
+		"/dev/vfio/vfio", // To access VFIO devices
 	}
 
 	for _, device := range hypervisorDevices {
-		var st unix.Stat_t
-		linuxDevice := specs.LinuxDeviceCgroup{
-			Allow:  true,
-			Access: "rwm",
-		}
-
-		if err := unix.Stat(device, &st); err != nil {
-			cgroupsLogger.WithError(err).WithField("device", device).Warn("Could not get device information")
+		ldevice, err := DeviceToLinuxDevice(device)
+		if err != nil {
+			cgroupsLogger.WithError(err).Warnf("Could not get device information")
 			continue
 		}
-
-		switch st.Mode & unix.S_IFMT {
-		case unix.S_IFCHR:
-			linuxDevice.Type = "c"
-		case unix.S_IFBLK:
-			linuxDevice.Type = "b"
-		}
-
-		major := int64(unix.Major(st.Rdev))
-		minor := int64(unix.Minor(st.Rdev))
-		linuxDevice.Major = &major
-		linuxDevice.Minor = &minor
-
-		devices = append(devices, linuxDevice)
+		devices = append(devices, ldevice)
 	}
 
 	return devices
@@ -134,8 +102,7 @@ func New(config *Config) (*Manager, error) {
 	var err error
 	useSystemdCgroup := UseSystemdCgroup()
 
-	devices := []specs.LinuxDeviceCgroup{}
-	copy(devices, config.Resources.Devices)
+	devices := config.Resources.Devices
 	devices = append(devices, hypervisorDevices()...)
 	// Do not modify original devices
 	config.Resources.Devices = devices

--- a/virtcontainers/pkg/cgroups/utils.go
+++ b/virtcontainers/pkg/cgroups/utils.go
@@ -7,8 +7,13 @@ package cgroups
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 // prepend a kata specific string to oci cgroup path to
@@ -62,4 +67,54 @@ func IsSystemdCgroup(cgroupPath string) bool {
 	// if found string is equal to cgroupPath then
 	// it's a correct systemd cgroup path.
 	return found != nil && cgroupPath[found[0]:found[1]] == cgroupPath
+}
+
+func DeviceToCgroupDevice(device string) (*configs.Device, error) {
+	var st unix.Stat_t
+	linuxDevice := configs.Device{
+		Allow:       true,
+		Permissions: "rwm",
+		Path:        device,
+	}
+
+	if err := unix.Stat(device, &st); err != nil {
+		return nil, err
+	}
+
+	devType := st.Mode & unix.S_IFMT
+
+	switch devType {
+	case unix.S_IFCHR:
+		linuxDevice.Type = 'c'
+	case unix.S_IFBLK:
+		linuxDevice.Type = 'b'
+	default:
+		return nil, fmt.Errorf("unsupported device type: %v", devType)
+	}
+
+	major := int64(unix.Major(st.Rdev))
+	minor := int64(unix.Minor(st.Rdev))
+	linuxDevice.Major = major
+	linuxDevice.Minor = minor
+
+	linuxDevice.Gid = st.Gid
+	linuxDevice.Uid = st.Uid
+	linuxDevice.FileMode = os.FileMode(st.Mode)
+
+	return &linuxDevice, nil
+}
+
+func DeviceToLinuxDevice(device string) (specs.LinuxDeviceCgroup, error) {
+	dev, err := DeviceToCgroupDevice(device)
+	if err != nil {
+		return specs.LinuxDeviceCgroup{}, err
+	}
+
+	return specs.LinuxDeviceCgroup{
+		Allow:  dev.Allow,
+		Type:   string(dev.Type),
+		Major:  &dev.Major,
+		Minor:  &dev.Minor,
+		Access: dev.Permissions,
+	}, nil
 }

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -843,8 +843,6 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid, c
 		// Spec: &ocispec,
 
 		Experimental: runtime.Experimental,
-
-		HasCRIContainerType: HasCRIContainerType(ocispec.Annotations),
 	}
 
 	if err := addAnnotations(ocispec, &sandboxConfig); err != nil {
@@ -1012,15 +1010,4 @@ func GetOCIConfig(status vc.ContainerStatus) (specs.Spec, error) {
 	}
 
 	return *status.Spec, nil
-}
-
-// HasCRIContainerType returns true if annottations contain
-// a CRI container type annotation
-func HasCRIContainerType(annotations map[string]string) bool {
-	for _, key := range CRIContainerTypeKeyList {
-		if _, ok := annotations[key]; ok {
-			return true
-		}
-	}
-	return false
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -123,9 +123,6 @@ type SandboxConfig struct {
 
 	DisableGuestSeccomp bool
 
-	// HasCRIContainerType specifies whether container type was set explicitly through annotations or not.
-	HasCRIContainerType bool
-
 	// Experimental features enabled
 	Experimental []exp.Feature
 
@@ -2134,8 +2131,6 @@ func (s *Sandbox) setupSandboxCgroup() error {
 		s.Logger().WithField("sandboxid", s.id).Warning("no cgroup path provided for pod sandbox, not creating sandbox cgroup")
 		return nil
 	}
-
-	s.Logger().WithField("hasCRIContainerType", s.config.HasCRIContainerType).Debug("Setting sandbox cgroup")
 
 	s.state.CgroupPath, err = vccgroups.ValidCgroupPath(spec.Linux.CgroupsPath, s.config.SystemdCgroup)
 	if err != nil {


### PR DESCRIPTION
kata relies on the cgroup created and configured by container engine,
but sometimes the sandbox cgroup is not configured (podman) or the
cgroup implementation is very restrictive (cgroups v2) that the
workload may not have access to any device.
Use the initial (sandbox) cgroup configuration to have a functional
cgroup where the hypervisor can be started, the container engine (e.g k8s)
it's free to modify it later.

fixes #2605

Signed-off-by: Julio Montes <julio.montes@intel.com>