### PR TITLE
katautils: Use config paths set during the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /data/kata-collect-data.sh
 /kata-netmon
 /kata-runtime
+/pkg/katautils/config-settings.go
 /virtcontainers/hack/virtc/virtc
 /virtcontainers/hook/mock/hook
 /virtcontainers/profile.cov

--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,7 @@ endef
 
 
 GENERATED_FILES += $(CLI_DIR)/config-generated.go
+GENERATED_FILES += pkg/katautils/config-settings.go
 
 $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 	$(QUIET_BUILD)(cd $(CLI_DIR) && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)

--- a/pkg/katautils/config-settings.go.in
+++ b/pkg/katautils/config-settings.go.in
@@ -55,11 +55,11 @@ const defaultTemplatePath string = "/run/vc/vm/template"
 const defaultVMCacheEndpoint string = "/var/run/kata-containers/cache.sock"
 
 // Default config file used by stateless systems.
-var defaultRuntimeConfiguration = "/usr/share/defaults/kata-containers/configuration.toml"
+var defaultRuntimeConfiguration = "@CONFIG_PATH@"
 
 // Alternate config file that takes precedence over
 // defaultRuntimeConfiguration.
-var defaultSysConfRuntimeConfiguration = "/etc/kata-containers/configuration.toml"
+var defaultSysConfRuntimeConfiguration = "@SYSCONFIG@"
 
 var name = "kata"
 var defaultProxyPath = "/usr/libexec/kata-containers/kata-proxy"


### PR DESCRIPTION
When building kata runtime packagers can simply do something like
`make CONFDIR=/usr/share/kata-containers/defaults` and it'll make
runtime understand that `/usr/share/defaults/kata-containers/` shouldn't
be used as `defaultRuntimeConfiguration` and, instead, runtime will use
whatever as passed to `make` during build time.

This is a quite common approach, mainly for distros, as there's no
perfect agreement on directory layout and whatnot.

Kwowing that, let's also make `containerd-shim-kata-v2`, which reads the
configurations from `pkg/katautils/config-settings.go`, to have a
similar behaviour as `runtime` and respect a "build-time" configured
`defaultRuntimeConfiguration` and `defaultSysConfRuntimeConfiguration`
paths.

Fixes: #2610

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>