### PR TITLE
Stable-1.9 backports 

### DIFF
--- a/containerd-shim-v2/stream.go
+++ b/containerd-shim-v2/stream.go
@@ -63,14 +63,14 @@ func newTtyIO(ctx context.Context, stdin, stdout, stderr string, console bool) (
 	}
 
 	if stdout != "" {
-		outw, err = fifo.OpenFifo(ctx, stdout, syscall.O_WRONLY, 0)
+		outw, err = fifo.OpenFifo(ctx, stdout, syscall.O_RDWR, 0)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if !console && stderr != "" {
-		errw, err = fifo.OpenFifo(ctx, stderr, syscall.O_WRONLY, 0)
+		errw, err = fifo.OpenFifo(ctx, stderr, syscall.O_RDWR, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/containerd-shim-v2/stream_test.go
+++ b/containerd-shim-v2/stream_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Baidu Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package containerdshim
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/fifo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTtyIOFifoReopen(t *testing.T) {
+	var outr io.ReadWriteCloser
+	var errr io.ReadWriteCloser
+	var tty *ttyIO
+	assert := assert.New(t)
+	ctx := context.TODO()
+	fifoPath, err := ioutil.TempDir(testDir, "fifo-path-")
+	assert.NoError(err)
+	stdout := filepath.Join(fifoPath, "stdout")
+	stderr := filepath.Join(fifoPath, "stderr")
+
+	createReadFifo := func(f string) io.ReadWriteCloser {
+		rf, err := fifo.OpenFifo(ctx, f, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return rf
+	}
+
+	outr = createReadFifo(stdout)
+	defer outr.Close()
+	errr = createReadFifo(stderr)
+	defer errr.Close()
+	tty, err = newTtyIO(ctx, "", stdout, stderr, false)
+	assert.NoError(err)
+	defer tty.close()
+
+	testBytes := []byte("T")
+	checkFifoWrite := func(w io.Writer) {
+		_, err = w.Write(testBytes)
+		assert.NoError(err)
+	}
+	checkFifoRead := func(r io.Reader) {
+		var err error
+		buf := make([]byte, 1)
+		done := make(chan struct{})
+		timer := time.NewTimer(2 * time.Second)
+		go func() {
+			_, err = r.Read(buf)
+			close(done)
+		}()
+		select {
+		case <-done:
+			assert.NoError(err)
+			assert.Equal(buf, testBytes)
+		case <-timer.C:
+			t.Fatal("read fifo timeout")
+		}
+	}
+
+	checkFifoWrite(tty.Stdout)
+	checkFifoRead(outr)
+	checkFifoWrite(tty.Stderr)
+	checkFifoRead(errr)
+
+	err = outr.Close()
+	assert.NoError(err)
+	err = errr.Close()
+	assert.NoError(err)
+
+	// Make sure that writing to tty fifo will not get `EPIPE`
+	// when the read side is closed
+	checkFifoWrite(tty.Stdout)
+	checkFifoWrite(tty.Stderr)
+
+	// Reopen the fifo
+	outr = createReadFifo(stdout)
+	errr = createReadFifo(stderr)
+	checkFifoRead(outr)
+	checkFifoRead(errr)
+}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -486,6 +486,16 @@ func TestConstraintGRPCSpec(t *testing.T) {
 				Network:        &pb.LinuxNetwork{},
 			},
 			CgroupsPath: "system.slice:foo:bar",
+			Devices: []pb.LinuxDevice{
+				{
+					Path: "/dev/vfio/1",
+					Type: "c",
+				},
+				{
+					Path: "/dev/vfio/2",
+					Type: "c",
+				},
+			},
 		},
 	}
 
@@ -511,6 +521,9 @@ func TestConstraintGRPCSpec(t *testing.T) {
 
 	// check cgroup path
 	assert.Equal(expectedCgroupPath, g.Linux.CgroupsPath)
+
+	// check Linux devices
+	assert.Empty(g.Linux.Devices)
 }
 
 func TestHandleShm(t *testing.T) {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -629,6 +629,10 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	var listener *net.UnixListener
 	var fd *os.File
 
+	if _, err = os.Stat(q.config.VirtioFSDaemon); os.IsNotExist(err) {
+		return fmt.Errorf("virtiofsd path (%s) does not exist", q.config.VirtioFSDaemon)
+	}
+
 	sockPath, err := q.vhostFSSocketPath(q.id)
 	if err != nil {
 		return err

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -716,8 +716,6 @@ func TestContainerStateSetFstype(t *testing.T) {
 	assert.Equal(res.State, state.State)
 }
 
-const vfioPath = "/dev/vfio/"
-
 func TestSandboxAttachDevicesVFIO(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	assert.Nil(t, err)


### PR DESCRIPTION
v2: Open log fifo with `RDWR` instead of `WRONLY` … 81d08f7
qemu: Don't crash if virtiofsd path is non existent … 24f660c
virtcontainers: Don't create vfio devices in the guest … eefccac