### PR TITLE
dnm: vendor: add max_ports option to virtio-serial-pci devices

### DIFF
--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -891,6 +891,7 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", dev.ID))
 	if dev.Transport.isVirtioPCI(config) {
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", dev.ROMFile))
+		deviceParams = append(deviceParams, fmt.Sprintf(",max_ports=2"))
 	}
 
 	if dev.Transport.isVirtioCCW(config) {


### PR DESCRIPTION
add max_ports option to virtio-serial-pci devices

fixes #99999

Signed-off-by: Julio Montes <julio.montes@intel.com>