### PR TITLE
versions: Remove golangci-lint and gometalinter entries

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -216,19 +216,6 @@ externals:
     meta:
       swarm-version: "1.12.1"
 
-  gometalinter:
-    description: "Utility to run various golang linters"
-    url: "https://github.com/alecthomas/gometalinter"
-    uscan-url: >-
-      https://github.com/alecthomas/gometalinter/tags
-      .*/v?([\d\.]+)\.tar\.gz
-    version: "v2.0.5"
-
-  golangci-lint:
-    description: "Utility to run various golang linters"
-    url: "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
-    version: "v1.15.0"
-
   kubernetes:
     description: "Kubernetes project container manager"
     url: "https://github.com/kubernetes/kubernetes"


### PR DESCRIPTION
Removed the `golangci-lint` and `gometalinter` entries from the versions database:

- The `golangci-lint` package is now tracked in the `tests` versions database:

  https://github.com/kata-containers/tests/blob/master/versions.yaml

- The `gometalinter` package is no longer used.

See:

- https://github.com/kata-containers/tests/issues/1323
- https://github.com/kata-containers/tests/commit/d676140510f11dd795e3606341f512a75d8f0d75

Fixes: #2636.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>