### PR TITLE
logging: Fix structured logging in store package

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/persist"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -50,6 +51,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 
 	deviceApi.SetLogger(virtLog)
 	compatoci.SetLogger(virtLog)
+	store.SetLogger(virtLog)
 }
 
 // CreateSandbox is the virtcontainers sandbox creation entry point.


### PR DESCRIPTION
Call the `store` packages `SetLogger()` function to ensure all its log records contain all required structured logging fields.

Fixes: #2644.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>