### PR TITLE
pmem: Add a SetLogger call

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -52,6 +52,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 	deviceApi.SetLogger(virtLog)
 	compatoci.SetLogger(virtLog)
 	store.SetLogger(virtLog)
+	deviceConfig.SetLogger(virtLog)
 }
 
 // CreateSandbox is the virtcontainers sandbox creation entry point.

--- a/virtcontainers/device/config/pmem.go
+++ b/virtcontainers/device/config/pmem.go
@@ -29,6 +29,13 @@ var (
 	pmemLog = logrus.WithField("source", "virtcontainers/device/config")
 )
 
+// SetLogger sets up a logger for this pkg
+func SetLogger(logger *logrus.Entry) {
+	fields := pmemLog.Data
+
+	pmemLog = logger.WithFields(fields)
+}
+
 // PmemDeviceInfo returns a DeviceInfo if a loop device
 // is mounted on source, and the backing file of the loop device
 // has the PFN signature.


### PR DESCRIPTION
Call the `device/config` package `SetLogger()` function to ensure all its log
records contain all required structured logging fields.

Fixes: #2643

Signed-off-by: Julio Montes <julio.montes@intel.com>