### PR TITLE
versions: Move to latest cloud-hypervisor

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "a8ec8f3326628d34021ccae0f259a9509ff1e6da"
+      version: "f5debc4bc001fb14dad0aee28fef102e6c263565"
 
     firecracker:
       description: "Firecracker micro-VMM"

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -278,14 +278,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 		return errors.New("image path is empty")
 	}
 
-	st, err := os.Stat(imagePath)
-	if err != nil {
-		return fmt.Errorf("Failed to get information for image file '%v': %v", imagePath, err)
-	}
-
 	pmem := chclient.PmemConfig{
 		File:          imagePath,
-		Size:          st.Size(),
 		DiscardWrites: true,
 	}
 	clh.vmconfig.Pmem = append(clh.vmconfig.Pmem, pmem)

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -225,6 +225,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	// Convert to int64 openApiClient only support int64
 	clh.vmconfig.Memory.Size = int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes())
 	clh.vmconfig.Memory.File = "/dev/shm"
+	// shared memory should be enabled if using vhost-user(kata uses virtiofsd)
+	clh.vmconfig.Memory.Shared = true
 	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
 	if err != nil {
 		return nil

--- a/virtcontainers/pkg/cloud-hypervisor/client/README.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/README.md
@@ -42,6 +42,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**ShutdownVMM**](docs/DefaultApi.md#shutdownvmm) | **Put** /vmm.shutdown | Shuts the cloud-hypervisor VMM.
 *DefaultApi* | [**VmAddDevicePut**](docs/DefaultApi.md#vmadddeviceput) | **Put** /vm.add-device | Add a new device to the VM
 *DefaultApi* | [**VmAddDiskPut**](docs/DefaultApi.md#vmadddiskput) | **Put** /vm.add-disk | Add a new disk to the VM
+*DefaultApi* | [**VmAddFsPut**](docs/DefaultApi.md#vmaddfsput) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 *DefaultApi* | [**VmAddNetPut**](docs/DefaultApi.md#vmaddnetput) | **Put** /vm.add-net | Add a new network device to the VM
 *DefaultApi* | [**VmAddPmemPut**](docs/DefaultApi.md#vmaddpmemput) | **Put** /vm.add-pmem | Add a new pmem device to the VM
 *DefaultApi* | [**VmInfoGet**](docs/DefaultApi.md#vminfoget) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.

--- a/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -173,6 +173,21 @@ paths:
         "500":
           description: The new disk could not be added to the VM instance.
       summary: Add a new disk to the VM
+  /vm.add-fs:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsConfig'
+        description: The details of the new virtio-fs
+        required: true
+      responses:
+        "204":
+          description: The new device was successfully added to the VM instance.
+        "500":
+          description: The new device could not be added to the VM instance.
+      summary: Add a new virtio-fs device to the VM
   /vm.add-pmem:
     put:
       requestBody:
@@ -260,6 +275,8 @@ components:
             file: file
             iommu: false
           memory:
+            hugepages: false
+            shared: false
             mergeable: false
             file: file
             size: 1
@@ -382,6 +399,8 @@ components:
           file: file
           iommu: false
         memory:
+          hugepages: false
+          shared: false
           mergeable: false
           file: file
           size: 1
@@ -549,6 +568,8 @@ components:
       type: object
     MemoryConfig:
       example:
+        hugepages: false
+        shared: false
         mergeable: false
         file: file
         size: 1
@@ -569,6 +590,12 @@ components:
         hotplug_method:
           default: acpi
           type: string
+        shared:
+          default: false
+          type: boolean
+        hugepages:
+          default: false
+          type: boolean
       required:
       - size
       type: object
@@ -749,7 +776,6 @@ components:
           type: boolean
       required:
       - file
-      - size
       type: object
     ConsoleConfig:
       example:

--- a/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
@@ -664,6 +664,72 @@ func (a *DefaultApiService) VmAddDiskPut(ctx _context.Context, diskConfig DiskCo
 }
 
 /*
+VmAddFsPut Add a new virtio-fs device to the VM
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param fsConfig The details of the new virtio-fs
+*/
+func (a *DefaultApiService) VmAddFsPut(ctx _context.Context, fsConfig FsConfig) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/vm.add-fs"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = &fsConfig
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 VmAddNetPut Add a new network device to the VM
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param netConfig The details of the new network device

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**ShutdownVMM**](DefaultApi.md#ShutdownVMM) | **Put** /vmm.shutdown | Shuts the cloud-hypervisor VMM.
 [**VmAddDevicePut**](DefaultApi.md#VmAddDevicePut) | **Put** /vm.add-device | Add a new device to the VM
 [**VmAddDiskPut**](DefaultApi.md#VmAddDiskPut) | **Put** /vm.add-disk | Add a new disk to the VM
+[**VmAddFsPut**](DefaultApi.md#VmAddFsPut) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 [**VmAddNetPut**](DefaultApi.md#VmAddNetPut) | **Put** /vm.add-net | Add a new network device to the VM
 [**VmAddPmemPut**](DefaultApi.md#VmAddPmemPut) | **Put** /vm.add-pmem | Add a new pmem device to the VM
 [**VmInfoGet**](DefaultApi.md#VmInfoGet) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
@@ -298,6 +299,38 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **diskConfig** | [**DiskConfig**](DiskConfig.md)| The details of the new disk | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## VmAddFsPut
+
+> VmAddFsPut(ctx, fsConfig)
+
+Add a new virtio-fs device to the VM
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**fsConfig** | [**FsConfig**](FsConfig.md)| The details of the new virtio-fs | 
 
 ### Return type
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **File** | **string** |  | [optional] 
 **Mergeable** | **bool** |  | [optional] [default to false]
 **HotplugMethod** | **string** |  | [optional] [default to acpi]
+**Shared** | **bool** |  | [optional] [default to false]
+**Hugepages** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **File** | **string** |  | 
-**Size** | **int64** |  | 
+**Size** | **int64** |  | [optional] 
 **Iommu** | **bool** |  | [optional] [default to false]
 **Mergeable** | **bool** |  | [optional] [default to false]
 **DiscardWrites** | **bool** |  | [optional] [default to false]

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
@@ -15,4 +15,6 @@ type MemoryConfig struct {
 	File string `json:"file,omitempty"`
 	Mergeable bool `json:"mergeable,omitempty"`
 	HotplugMethod string `json:"hotplug_method,omitempty"`
+	Shared bool `json:"shared,omitempty"`
+	Hugepages bool `json:"hugepages,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
@@ -11,7 +11,7 @@ package openapi
 // PmemConfig struct for PmemConfig
 type PmemConfig struct {
 	File string `json:"file"`
-	Size int64 `json:"size"`
+	Size int64 `json:"size,omitempty"`
 	Iommu bool `json:"iommu,omitempty"`
 	Mergeable bool `json:"mergeable,omitempty"`
 	DiscardWrites bool `json:"discard_writes,omitempty"`

--- a/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -187,6 +187,22 @@ paths:
         500:
           description: The new disk could not be added to the VM instance.
 
+  /vm.add-fs:
+    put:
+      summary: Add a new virtio-fs device to the VM
+      requestBody:
+        description: The details of the new virtio-fs
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsConfig'
+        required: true
+      responses:
+        204:
+          description: The new device was successfully added to the VM instance.
+        500:
+          description: The new device could not be added to the VM instance.
+
   /vm.add-pmem:
     put:
       summary: Add a new pmem device to the VM
@@ -364,6 +380,12 @@ components:
         hotplug_method:
           type: string
           default: "acpi"
+        shared:
+          type: boolean
+          default: false
+        hugepages:
+          type: boolean
+          default: false
 
     KernelConfig:
       required:
@@ -492,7 +514,6 @@ components:
     PmemConfig:
       required:
       - file
-      - size
       type: object
       properties:
         file:


### PR DESCRIPTION
Changes:

f5debc4 build(deps): bump libssh2-sys from 0.2.16 to 0.2.17
37dfb4c build(deps): bump hermit-abi from 0.1.11 to 0.1.12
e1a07ce vmm: vm: Unpark the threads before shutdown when the current state is paused
1df38da vmm, tests: Make specifying a size optional for virtio-pmem
7481e4d vmm: config: Validate that shared memory is enabled if using vhost-user
2ac6971 vmm: MemoryManager: Cleanup the usage of std::ffi/io/result
3f42f86 vmm: Add the 'shared' and 'hugepages' controls to MemoryConfig
d6aa717 build(deps): bump syn from 1.0.17 to 1.0.18
3eaeba4 vm-virtio: Fix FS_IO callback for virtio-fs
df14a68 build(deps): bump smallvec from 1.3.0 to 1.4.0
e685854 gh: Separate the build and release jobs
c790bba tests: Migrate from Ubuntu Eoan to Focal
e525af7 build(deps): bump ryu from 1.0.3 to 1.0.4
3e8a6ba ci: Ignore test_snapshot_restore
9ebf052 build(deps): bump cc from 1.0.51 to 1.0.52
f6b150a ci: Add integration test for VM migration
9f08f53 build(deps): bump pin-utils from 0.1.0-alpha.4 to 0.1.0
9c7215d docs: Add the vhost-user-blk test doc
3574437 build(deps): bump cc from 1.0.50 to 1.0.51
4fc75cf vm-virtio: Implement Snapshottable trait for Console
d41ce90 vm-virtio: Implement Snapshottable trait for Pmem
f626bd6 build(deps): bump parking_lot_core from 0.7.1 to 0.7.2
5a380a6 vmm: memory_manager: Support non-power-of-2 block sizes
f8ee89a build(deps): bump arc-swap from 0.4.5 to 0.4.6
49322c5 vm-virtio: Implement the Snapshottable trait for Net
24c2b67 vm-virtio: Improve virtio-net rx queue processing
03dd249 vm-virtio: Restore queues based on used index
cf707da vm-virtio: Extend Queue helpers
c22fd39 vmm: Remove virtio device's userspace mapping on hot-unplug
0a97c25 vmm: Extend MemoryManager to remove userspace mappings
b2de1cd vm-virtio: Implement shutdown() for virtio-fs
fbcf3a7 vm-virtio: Implement userspace_mappings() for virtio-pmem
b035399 vm-virtio: Implement userspace_mappings() for virtio-fs
3fb0a02 vm-virtio: Get userspace mappings from VirtioDevice
8b823e5 build(deps): bump backtrace-sys from 0.1.35 to 0.1.36
c23b488 ci: Factorize virtio-fs hotplug integration tests
f68b08b tests: add integration tests for vm.add-fs route
18f7789 vmm: Add hotplugged virtio devices to the DeviceManager list
c2abadc vmm: Add ability to add virtio-fs device post-boot
bb2139a vmm/api: Add vm.add-fs route
d35e775 vmm: Update KVM userspace mapping when PCI BAR remapping
49cc73a vm-virtio: pci: Make sure to return the correct list of BARs
187b1ee vm-virtio: Implement the Snapshottable trait for Block
a484aa7 vm-virtio: Implement the Snapshottable trait for Rng
ac7178e vmm: Keep migratable devices list as a Vec
b6fdbf7 vm-virtio: Implement Snapshottable trait for MmioDevice
12fec55 vm-virtio: Add helpers to update queue indexes
fd45e94 vm-virtio: Add the ability to serialize a Queue
b7faf4f vhost_user_fs: Add the WRITE_KILL_PRIV write flag.
0870028 vhost_user_fs: Add the IOCTL_COMPAT_32 flag
592cfba vhost_user_fs: Add the EXPLICIT_INVAL_DATA capability flag
621ea83 vhost_user_fs: Add the ZERO_MESSAGE_OPENDIR capability flag
a2830da vhost_user_fs: Add the CACHE_SYMLINKS flag
926a414 vhost_user_fs: Add support for MAX_PAGES
747f31d vhost_user_fs: Add the ABORT_ERROR flag
5eb903a vhost_user_fs: Add support for FOPEN_CACHE_DIR
97e2d5d vhost_user_fs: Add support for CopyFileRange
b8cfdab pci: configuration: Use correct algorithm for BAR size reporting
9bd5ec8 pci, vfio, vm-virtio: Specify a PCI revision ID of 1 for virtio-pci
e7e0e8a vmm, devices: Add firmware debug port device
82d0cdf vhost_user_net: Simplify match values for handle_event()
a517be4 vhost_user_blk: Add multithreaded multiqueue support
13c8283 vhost_user_blk: Make everything private when possible
a31f5f8 vhost_user_blk: Move disk initialization to VhostUserBlkBackend
e78e34b vhost_user_blk: Make DiskFile sharable across threads
808586e vhost_user_blk: Simplify the code by removing VringWorker
ea82632 tests: Enhance test_pmem_hotplug to also unplug device
6389418 tests: Enhance test_disk_hotplug to also unplug device
f9a0445 vmm: vm: Remove device from configuration after unplug
444e5c2 vmm: device_manager: Generalise NoAvailableVfioDeviceName
5bab9c3 vmm: device_manager: Assign ids to pmem/net/disk devices if absent
514491a vmm: device_manager: Support unplugging virtio-pci devices
2fa652a vm-virtio: pci: Add virtio_device() accessor
476e4ce vmm: device_manager: Add virtio-pci devices into id to BDF map
b38470d vmm: config: Add "id" parameter to {Net, Disk, Pmem}Config
1beb62e vmm: vm: Don't panic on kernel load error

Fixes: #2609

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>