### PR TITLE
Fix rtc parameter is not set to qemu

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -533,8 +533,9 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	}
 
 	rtc := govmmQemu.RTC{
-		Base:     "utc",
-		DriftFix: "slew",
+		Base:     govmmQemu.UTC,
+		Clock:    govmmQemu.Host,
+		DriftFix: govmmQemu.Slew,
 	}
 
 	if q.state.UUID == "" {


### PR DESCRIPTION
Add default value for Clock, otherwise rtc parameter will be dropped
by Valid function.
Also there are 3 type value for Clock in qemu, "host/rt/vm".

Signed-off-by: Shuicheng Lin <shuicheng.lin@intel.com>