### PR TITLE
versions: update k8s and its dependencies to 1.18

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -189,7 +189,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "0eec454168e381e460b3d6de07bf50bfd9b0d082"
+    version: "v1.18.0"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2
@@ -206,7 +206,7 @@ externals:
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"
     url: "https://github.com/kubernetes-sigs/cri-tools"
-    version: "1.17.0"
+    version: "1.18.0"
 
   docker:
     description: "Moby project container manager"
@@ -224,7 +224,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.17.3-00"
+    version: "1.18.2-00"
 
   openshift:
     description: |


### PR DESCRIPTION
Updates included here:
- kubernetes from 1.17.3 to 1.18.2
- cri-o from 0eec454168e381e460b3d6de07bf50bfd9b0d082 (1.17) to 1.18.0
- critools from 1.17.0 to 1.18.0

Fixes: #2486.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>