### PR TITLE
clh: backport: Move to v0.7.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "a8ec8f3326628d34021ccae0f259a9509ff1e6da"
+      version: "f5debc4bc001fb14dad0aee28fef102e6c263565"
 
     firecracker:
       description: "Firecracker micro-VMM"

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "f5debc4bc001fb14dad0aee28fef102e6c263565"
+      version: "v0.7.0"
 
     firecracker:
       description: "Firecracker micro-VMM"

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -1076,7 +1076,7 @@ func (clh *cloudHypervisor) addVSock(cid int64, path string) {
 		"cid":  cid,
 	}).Info("Adding HybridVSock")
 
-	clh.vmconfig.Vsock = append(clh.vmconfig.Vsock, chclient.VsockConfig{Cid: cid, Sock: path})
+	clh.vmconfig.Vsock = chclient.VsockConfig{Cid: cid, Sock: path}
 }
 
 func (clh *cloudHypervisor) addNet(e Endpoint) error {

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -218,6 +218,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	// Convert to int64 openApiClient only support int64
 	clh.vmconfig.Memory.Size = int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes())
 	clh.vmconfig.Memory.File = "/dev/shm"
+	// shared memory should be enabled if using vhost-user(kata uses virtiofsd)
+	clh.vmconfig.Memory.Shared = true
 	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
 	if err != nil {
 		return nil

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -271,14 +271,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 		return errors.New("image path is empty")
 	}
 
-	st, err := os.Stat(imagePath)
-	if err != nil {
-		return fmt.Errorf("Failed to get information for image file '%v': %v", imagePath, err)
-	}
-
 	pmem := chclient.PmemConfig{
 		File:          imagePath,
-		Size:          st.Size(),
 		DiscardWrites: true,
 	}
 	clh.vmconfig.Pmem = append(clh.vmconfig.Pmem, pmem)

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -103,12 +103,8 @@ func TestCloudHypervisorAddVSock(t *testing.T) {
 	clh := cloudHypervisor{}
 
 	clh.addVSock(1, "path")
-	assert.Equal(clh.vmconfig.Vsock[0].Cid, int64(1))
-	assert.Equal(clh.vmconfig.Vsock[0].Sock, "path")
-
-	clh.addVSock(2, "path2")
-	assert.Equal(clh.vmconfig.Vsock[1].Cid, int64(2))
-	assert.Equal(clh.vmconfig.Vsock[1].Sock, "path2")
+	assert.Equal(clh.vmconfig.Vsock.Cid, int64(1))
+	assert.Equal(clh.vmconfig.Vsock.Sock, "path")
 }
 
 // Check addNet appends to the network config list new configurations.

--- a/virtcontainers/pkg/cloud-hypervisor/client/README.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/README.md
@@ -42,6 +42,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**ShutdownVMM**](docs/DefaultApi.md#shutdownvmm) | **Put** /vmm.shutdown | Shuts the cloud-hypervisor VMM.
 *DefaultApi* | [**VmAddDevicePut**](docs/DefaultApi.md#vmadddeviceput) | **Put** /vm.add-device | Add a new device to the VM
 *DefaultApi* | [**VmAddDiskPut**](docs/DefaultApi.md#vmadddiskput) | **Put** /vm.add-disk | Add a new disk to the VM
+*DefaultApi* | [**VmAddFsPut**](docs/DefaultApi.md#vmaddfsput) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 *DefaultApi* | [**VmAddNetPut**](docs/DefaultApi.md#vmaddnetput) | **Put** /vm.add-net | Add a new network device to the VM
 *DefaultApi* | [**VmAddPmemPut**](docs/DefaultApi.md#vmaddpmemput) | **Put** /vm.add-pmem | Add a new pmem device to the VM
 *DefaultApi* | [**VmInfoGet**](docs/DefaultApi.md#vminfoget) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.

--- a/virtcontainers/pkg/cloud-hypervisor/client/README.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/README.md
@@ -45,6 +45,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**VmAddFsPut**](docs/DefaultApi.md#vmaddfsput) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 *DefaultApi* | [**VmAddNetPut**](docs/DefaultApi.md#vmaddnetput) | **Put** /vm.add-net | Add a new network device to the VM
 *DefaultApi* | [**VmAddPmemPut**](docs/DefaultApi.md#vmaddpmemput) | **Put** /vm.add-pmem | Add a new pmem device to the VM
+*DefaultApi* | [**VmAddVsockPut**](docs/DefaultApi.md#vmaddvsockput) | **Put** /vm.add-vsock | Add a new vsock device to the VM
 *DefaultApi* | [**VmInfoGet**](docs/DefaultApi.md#vminfoget) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
 *DefaultApi* | [**VmRemoveDevicePut**](docs/DefaultApi.md#vmremovedeviceput) | **Put** /vm.remove-device | Remove a device from the VM
 *DefaultApi* | [**VmResizePut**](docs/DefaultApi.md#vmresizeput) | **Put** /vm.resize | Resize the VM

--- a/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -218,6 +218,21 @@ paths:
         "500":
           description: The new device could not be added to the VM instance.
       summary: Add a new network device to the VM
+  /vm.add-vsock:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VsockConfig'
+        description: The details of the new vsock device
+        required: true
+      responses:
+        "204":
+          description: The new device was successfully added to the VM instance.
+        "500":
+          description: The new device could not be added to the VM instance.
+      summary: Add a new vsock device to the VM
   /vm.snapshot:
     put:
       requestBody:
@@ -293,6 +308,7 @@ components:
             direct: false
             wce: true
             poll_queue: true
+            id: id
           - path: path
             num_queues: 5
             readonly: false
@@ -303,6 +319,7 @@ components:
             direct: false
             wce: true
             poll_queue: true
+            id: id
           cpus:
             boot_vcpus: 1
             max_vcpus: 1
@@ -325,29 +342,31 @@ components:
             cache_size: 4
             dax: true
             tag: tag
+            id: id
           - sock: sock
             num_queues: 3
             queue_size: 2
             cache_size: 4
             dax: true
             tag: tag
+            id: id
           vsock:
-          - sock: sock
+            sock: sock
             iommu: false
-            cid: 3
-          - sock: sock
-            iommu: false
+            id: id
             cid: 3
           pmem:
           - mergeable: false
             file: file
             size: 7
             iommu: false
+            id: id
             discard_writes: false
           - mergeable: false
             file: file
             size: 7
             iommu: false
+            id: id
             discard_writes: false
           cmdline:
             args: args
@@ -366,6 +385,7 @@ components:
             vhost_socket: vhost_socket
             vhost_user: false
             ip: 192.168.249.1
+            id: id
             mac: mac
             mask: 255.255.255.0
           - tap: tap
@@ -375,6 +395,7 @@ components:
             vhost_socket: vhost_socket
             vhost_user: false
             ip: 192.168.249.1
+            id: id
             mac: mac
             mask: 255.255.255.0
       properties:
@@ -417,6 +438,7 @@ components:
           direct: false
           wce: true
           poll_queue: true
+          id: id
         - path: path
           num_queues: 5
           readonly: false
@@ -427,6 +449,7 @@ components:
           direct: false
           wce: true
           poll_queue: true
+          id: id
         cpus:
           boot_vcpus: 1
           max_vcpus: 1
@@ -449,29 +472,31 @@ components:
           cache_size: 4
           dax: true
           tag: tag
+          id: id
         - sock: sock
           num_queues: 3
           queue_size: 2
           cache_size: 4
           dax: true
           tag: tag
+          id: id
         vsock:
-        - sock: sock
+          sock: sock
           iommu: false
-          cid: 3
-        - sock: sock
-          iommu: false
+          id: id
           cid: 3
         pmem:
         - mergeable: false
           file: file
           size: 7
           iommu: false
+          id: id
           discard_writes: false
         - mergeable: false
           file: file
           size: 7
           iommu: false
+          id: id
           discard_writes: false
         cmdline:
           args: args
@@ -490,6 +515,7 @@ components:
           vhost_socket: vhost_socket
           vhost_user: false
           ip: 192.168.249.1
+          id: id
           mac: mac
           mask: 255.255.255.0
         - tap: tap
@@ -499,6 +525,7 @@ components:
           vhost_socket: vhost_socket
           vhost_user: false
           ip: 192.168.249.1
+          id: id
           mac: mac
           mask: 255.255.255.0
       properties:
@@ -539,9 +566,7 @@ components:
             $ref: '#/components/schemas/DeviceConfig'
           type: array
         vsock:
-          items:
-            $ref: '#/components/schemas/VsockConfig'
-          type: array
+          $ref: '#/components/schemas/VsockConfig'
         iommu:
           default: false
           type: boolean
@@ -639,6 +664,7 @@ components:
         direct: false
         wce: true
         poll_queue: true
+        id: id
       properties:
         path:
           type: string
@@ -668,6 +694,8 @@ components:
         poll_queue:
           default: true
           type: boolean
+        id:
+          type: string
       required:
       - path
       type: object
@@ -680,6 +708,7 @@ components:
         vhost_socket: vhost_socket
         vhost_user: false
         ip: 192.168.249.1
+        id: id
         mac: mac
         mask: 255.255.255.0
       properties:
@@ -708,6 +737,8 @@ components:
           type: boolean
         vhost_socket:
           type: string
+        id:
+          type: string
       type: object
     RngConfig:
       example:
@@ -731,6 +762,7 @@ components:
         cache_size: 4
         dax: true
         tag: tag
+        id: id
       properties:
         tag:
           type: string
@@ -748,6 +780,8 @@ components:
         cache_size:
           format: int64
           type: integer
+        id:
+          type: string
       required:
       - sock
       - tag
@@ -758,6 +792,7 @@ components:
         file: file
         size: 7
         iommu: false
+        id: id
         discard_writes: false
       properties:
         file:
@@ -774,6 +809,8 @@ components:
         discard_writes:
           default: false
           type: boolean
+        id:
+          type: string
       required:
       - file
       type: object
@@ -818,6 +855,7 @@ components:
       example:
         sock: sock
         iommu: false
+        id: id
         cid: 3
       properties:
         cid:
@@ -831,6 +869,8 @@ components:
         iommu:
           default: false
           type: boolean
+        id:
+          type: string
       required:
       - cid
       - sock

--- a/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -173,6 +173,21 @@ paths:
         "500":
           description: The new disk could not be added to the VM instance.
       summary: Add a new disk to the VM
+  /vm.add-fs:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsConfig'
+        description: The details of the new virtio-fs
+        required: true
+      responses:
+        "204":
+          description: The new device was successfully added to the VM instance.
+        "500":
+          description: The new device could not be added to the VM instance.
+      summary: Add a new virtio-fs device to the VM
   /vm.add-pmem:
     put:
       requestBody:
@@ -260,6 +275,8 @@ components:
             file: file
             iommu: false
           memory:
+            hugepages: false
+            shared: false
             mergeable: false
             file: file
             size: 1
@@ -382,6 +399,8 @@ components:
           file: file
           iommu: false
         memory:
+          hugepages: false
+          shared: false
           mergeable: false
           file: file
           size: 1
@@ -549,6 +568,8 @@ components:
       type: object
     MemoryConfig:
       example:
+        hugepages: false
+        shared: false
         mergeable: false
         file: file
         size: 1
@@ -569,6 +590,12 @@ components:
         hotplug_method:
           default: acpi
           type: string
+        shared:
+          default: false
+          type: boolean
+        hugepages:
+          default: false
+          type: boolean
       required:
       - size
       type: object
@@ -749,7 +776,6 @@ components:
           type: boolean
       required:
       - file
-      - size
       type: object
     ConsoleConfig:
       example:

--- a/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
@@ -664,6 +664,72 @@ func (a *DefaultApiService) VmAddDiskPut(ctx _context.Context, diskConfig DiskCo
 }
 
 /*
+VmAddFsPut Add a new virtio-fs device to the VM
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param fsConfig The details of the new virtio-fs
+*/
+func (a *DefaultApiService) VmAddFsPut(ctx _context.Context, fsConfig FsConfig) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/vm.add-fs"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = &fsConfig
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 VmAddNetPut Add a new network device to the VM
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param netConfig The details of the new network device

--- a/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api_default.go
@@ -862,6 +862,72 @@ func (a *DefaultApiService) VmAddPmemPut(ctx _context.Context, pmemConfig PmemCo
 }
 
 /*
+VmAddVsockPut Add a new vsock device to the VM
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param vsockConfig The details of the new vsock device
+*/
+func (a *DefaultApiService) VmAddVsockPut(ctx _context.Context, vsockConfig VsockConfig) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/vm.add-vsock"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = &vsockConfig
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 VmInfoGet Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 @return VmInfo

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**ShutdownVMM**](DefaultApi.md#ShutdownVMM) | **Put** /vmm.shutdown | Shuts the cloud-hypervisor VMM.
 [**VmAddDevicePut**](DefaultApi.md#VmAddDevicePut) | **Put** /vm.add-device | Add a new device to the VM
 [**VmAddDiskPut**](DefaultApi.md#VmAddDiskPut) | **Put** /vm.add-disk | Add a new disk to the VM
+[**VmAddFsPut**](DefaultApi.md#VmAddFsPut) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 [**VmAddNetPut**](DefaultApi.md#VmAddNetPut) | **Put** /vm.add-net | Add a new network device to the VM
 [**VmAddPmemPut**](DefaultApi.md#VmAddPmemPut) | **Put** /vm.add-pmem | Add a new pmem device to the VM
 [**VmInfoGet**](DefaultApi.md#VmInfoGet) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
@@ -298,6 +299,38 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **diskConfig** | [**DiskConfig**](DiskConfig.md)| The details of the new disk | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## VmAddFsPut
+
+> VmAddFsPut(ctx, fsConfig)
+
+Add a new virtio-fs device to the VM
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**fsConfig** | [**FsConfig**](FsConfig.md)| The details of the new virtio-fs | 
 
 ### Return type
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**VmAddFsPut**](DefaultApi.md#VmAddFsPut) | **Put** /vm.add-fs | Add a new virtio-fs device to the VM
 [**VmAddNetPut**](DefaultApi.md#VmAddNetPut) | **Put** /vm.add-net | Add a new network device to the VM
 [**VmAddPmemPut**](DefaultApi.md#VmAddPmemPut) | **Put** /vm.add-pmem | Add a new pmem device to the VM
+[**VmAddVsockPut**](DefaultApi.md#VmAddVsockPut) | **Put** /vm.add-vsock | Add a new vsock device to the VM
 [**VmInfoGet**](DefaultApi.md#VmInfoGet) | **Get** /vm.info | Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
 [**VmRemoveDevicePut**](DefaultApi.md#VmRemoveDevicePut) | **Put** /vm.remove-device | Remove a device from the VM
 [**VmResizePut**](DefaultApi.md#VmResizePut) | **Put** /vm.resize | Resize the VM
@@ -395,6 +396,38 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **pmemConfig** | [**PmemConfig**](PmemConfig.md)| The details of the new pmem device | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## VmAddVsockPut
+
+> VmAddVsockPut(ctx, vsockConfig)
+
+Add a new vsock device to the VM
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**vsockConfig** | [**VsockConfig**](VsockConfig.md)| The details of the new vsock device | 
 
 ### Return type
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **VhostSocket** | **string** |  | [optional] 
 **Wce** | **bool** |  | [optional] [default to true]
 **PollQueue** | **bool** |  | [optional] [default to true]
+**Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **QueueSize** | **int32** |  | [optional] [default to 1024]
 **Dax** | **bool** |  | [optional] [default to true]
 **CacheSize** | **int64** |  | [optional] 
+**Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **File** | **string** |  | [optional] 
 **Mergeable** | **bool** |  | [optional] [default to false]
 **HotplugMethod** | **string** |  | [optional] [default to acpi]
+**Shared** | **bool** |  | [optional] [default to false]
+**Hugepages** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **QueueSize** | **int32** |  | [optional] [default to 256]
 **VhostUser** | **bool** |  | [optional] [default to false]
 **VhostSocket** | **string** |  | [optional] 
+**Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **Iommu** | **bool** |  | [optional] [default to false]
 **Mergeable** | **bool** |  | [optional] [default to false]
 **DiscardWrites** | **bool** |  | [optional] [default to false]
+**Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/PmemConfig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **File** | **string** |  | 
-**Size** | **int64** |  | 
+**Size** | **int64** |  | [optional] 
 **Iommu** | **bool** |  | [optional] [default to false]
 **Mergeable** | **bool** |  | [optional] [default to false]
 **DiscardWrites** | **bool** |  | [optional] [default to false]

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/VmConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/VmConfig.md
@@ -17,7 +17,7 @@ Name | Type | Description | Notes
 **Serial** | [**ConsoleConfig**](ConsoleConfig.md) |  | [optional] 
 **Console** | [**ConsoleConfig**](ConsoleConfig.md) |  | [optional] 
 **Devices** | [**[]DeviceConfig**](DeviceConfig.md) |  | [optional] 
-**Vsock** | [**[]VsockConfig**](VsockConfig.md) |  | [optional] 
+**Vsock** | [**VsockConfig**](VsockConfig.md) |  | [optional] 
 **Iommu** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/VsockConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/VsockConfig.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Cid** | **int64** | Guest Vsock CID | 
 **Sock** | **string** | Path to UNIX domain socket, used to proxy vsock connections. | 
 **Iommu** | **bool** |  | [optional] [default to false]
+**Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
@@ -20,4 +20,5 @@ type DiskConfig struct {
 	VhostSocket string `json:"vhost_socket,omitempty"`
 	Wce bool `json:"wce,omitempty"`
 	PollQueue bool `json:"poll_queue,omitempty"`
+	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
@@ -16,4 +16,5 @@ type FsConfig struct {
 	QueueSize int32 `json:"queue_size,omitempty"`
 	Dax bool `json:"dax,omitempty"`
 	CacheSize int64 `json:"cache_size,omitempty"`
+	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
@@ -15,4 +15,6 @@ type MemoryConfig struct {
 	File string `json:"file,omitempty"`
 	Mergeable bool `json:"mergeable,omitempty"`
 	HotplugMethod string `json:"hotplug_method,omitempty"`
+	Shared bool `json:"shared,omitempty"`
+	Hugepages bool `json:"hugepages,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -19,4 +19,5 @@ type NetConfig struct {
 	QueueSize int32 `json:"queue_size,omitempty"`
 	VhostUser bool `json:"vhost_user,omitempty"`
 	VhostSocket string `json:"vhost_socket,omitempty"`
+	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
@@ -15,4 +15,5 @@ type PmemConfig struct {
 	Iommu bool `json:"iommu,omitempty"`
 	Mergeable bool `json:"mergeable,omitempty"`
 	DiscardWrites bool `json:"discard_writes,omitempty"`
+	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
@@ -11,7 +11,7 @@ package openapi
 // PmemConfig struct for PmemConfig
 type PmemConfig struct {
 	File string `json:"file"`
-	Size int64 `json:"size"`
+	Size int64 `json:"size,omitempty"`
 	Iommu bool `json:"iommu,omitempty"`
 	Mergeable bool `json:"mergeable,omitempty"`
 	DiscardWrites bool `json:"discard_writes,omitempty"`

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_vm_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_vm_config.go
@@ -23,6 +23,6 @@ type VmConfig struct {
 	Serial ConsoleConfig `json:"serial,omitempty"`
 	Console ConsoleConfig `json:"console,omitempty"`
 	Devices []DeviceConfig `json:"devices,omitempty"`
-	Vsock []VsockConfig `json:"vsock,omitempty"`
+	Vsock VsockConfig `json:"vsock,omitempty"`
 	Iommu bool `json:"iommu,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
@@ -15,4 +15,5 @@ type VsockConfig struct {
 	// Path to UNIX domain socket, used to proxy vsock connections.
 	Sock string `json:"sock"`
 	Iommu bool `json:"iommu,omitempty"`
+	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -187,6 +187,22 @@ paths:
         500:
           description: The new disk could not be added to the VM instance.
 
+  /vm.add-fs:
+    put:
+      summary: Add a new virtio-fs device to the VM
+      requestBody:
+        description: The details of the new virtio-fs
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsConfig'
+        required: true
+      responses:
+        204:
+          description: The new device was successfully added to the VM instance.
+        500:
+          description: The new device could not be added to the VM instance.
+
   /vm.add-pmem:
     put:
       summary: Add a new pmem device to the VM
@@ -364,6 +380,12 @@ components:
         hotplug_method:
           type: string
           default: "acpi"
+        shared:
+          type: boolean
+          default: false
+        hugepages:
+          type: boolean
+          default: false
 
     KernelConfig:
       required:
@@ -492,7 +514,6 @@ components:
     PmemConfig:
       required:
       - file
-      - size
       type: object
       properties:
         file:

--- a/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -235,6 +235,23 @@ paths:
         500:
           description: The new device could not be added to the VM instance.
 
+  /vm.add-vsock:
+    put:
+      summary: Add a new vsock device to the VM
+      requestBody:
+        description: The details of the new vsock device
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VsockConfig'
+        required: true
+      responses:
+        204:
+          description: The new device was successfully added to the VM instance.
+        500:
+          description: The new device could not be added to the VM instance.
+
+
   /vm.snapshot:
     put:
       summary: Returns a VM snapshot.
@@ -337,8 +354,6 @@ components:
           items:
             $ref: '#/components/schemas/DeviceConfig'
         vsock:
-          type: array
-          items:
             $ref: '#/components/schemas/VsockConfig'
         iommu:
           type: boolean
@@ -445,6 +460,8 @@ components:
         poll_queue:
           type: boolean
           default: true
+        id:
+          type: string
 
     NetConfig:
       type: object
@@ -473,6 +490,8 @@ components:
           type: boolean
           default: false
         vhost_socket:
+          type: string
+        id:
           type: string
 
     RngConfig:
@@ -510,6 +529,8 @@ components:
           type: integer
           format: int64
           default: 8589934592
+        id:
+          type: string
 
     PmemConfig:
       required:
@@ -530,6 +551,8 @@ components:
         discard_writes:
           type: boolean
           default: false
+        id:
+          type: string
 
     ConsoleConfig:
       required:
@@ -575,6 +598,8 @@ components:
         iommu:
           type: boolean
           default: false
+        id:
+          type: string
 
     VmResize:
       type: object


### PR DESCRIPTION
Changes:
2d251652 clh: vsock: Supply the right VsockConfig to Vmconfig
fcc9e93b versions: Move to cloud-hypervisor v0.7.0
34be9e0c clh: memory: remove pmem size argument
9798e8a5 versions: Move to latest cloud-hypervisor
