### PR TITLE
utils: Fix case version check for stable releases

### DIFF
--- a/cli/kata-check_test.go
+++ b/cli/kata-check_test.go
@@ -959,6 +959,13 @@ func TestCheckVersionConsistencyInComponents(t *testing.T) {
 			"",
 			"0.2.0-rc0",
 		},
+		{
+			false,
+			false,
+			"kata-shim version 0.2.0-xxxxxxxxxxxxx",
+			"",
+			"0.2.0",
+		},
 	}
 
 	origVersion := version

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -161,7 +161,13 @@ func constructVersionInfo(version string) VersionInfo {
 		return unknownVersionInfo
 	}
 
-	pres := strings.Split(sv.Pre[0].VersionStr, "-")
+	var pres string
+	if len(sv.Pre) > 0 {
+		presSplit := strings.Split(sv.Pre[0].VersionStr, "-")
+		if len(presSplit) > 2 {
+			pres = presSplit[1]
+		}
+	}
 
 	// version contains Commit info.
 	if len(pres) > 1 {
@@ -170,7 +176,7 @@ func constructVersionInfo(version string) VersionInfo {
 			Major:  sv.Major,
 			Minor:  sv.Minor,
 			Patch:  sv.Patch,
-			Commit: pres[1],
+			Commit: pres,
 		}
 	}
 


### PR DESCRIPTION
For stable versions the format used `x.y.z`.

kata-env was failing trying to make a new release from 1.11.0-rc to
1.11.0

This fix kata-env for releases 1.11+ where this regression was
introduced.

Fixes: #2674

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>