### PR TITLE
clh: Enable disk block device hotplug support

### DIFF
--- a/cli/config/configuration-clh.toml.in
+++ b/cli/config/configuration-clh.toml.in
@@ -68,6 +68,11 @@ virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 # cloud-hypervisor prefers virtiofs caching (dax) for performance reasons
 virtio_fs_cache = "always"
 
+# Block storage driver to be used for the hypervisor in case the container
+# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
+# or nvdimm.
+block_device_driver = "virtio-blk"
+
 # This option changes the default hypervisor and kernel parameters
 # to enable debug output where available. This extra output is added
 # to the proxy logs, but only when proxy debug is also enabled.

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -88,6 +88,8 @@ type clhClient interface {
 	VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error)
 	// Add VFIO PCI device to the VM
 	VmAddDevicePut(ctx context.Context, vmAddDevice chclient.VmAddDevice) (*http.Response, error)
+	// Add a new disk device to the VM
+	VmAddDiskPut(ctx context.Context, diskConfig chclient.DiskConfig) (*http.Response, error)
 }
 
 type CloudHypervisorVersion struct {
@@ -410,6 +412,33 @@ func (clh *cloudHypervisor) getThreadIDs() (vcpuThreadIDs, error) {
 	return vcpuInfo, nil
 }
 
+func (clh *cloudHypervisor) hotplugBlockDevice(drive *config.BlockDrive) error {
+	cl := clh.client()
+	ctx, cancel := context.WithTimeout(context.Background(), clhHotPlugAPITimeout*time.Second)
+	defer cancel()
+
+	_, _, err := cl.VmmPingGet(ctx)
+	if err != nil {
+		return openAPIClientError(err)
+	}
+
+	if drive.Pmem {
+		err = fmt.Errorf("pmem device hotplug not supported")
+	} else {
+		blkDevice := chclient.DiskConfig{
+			Path:      drive.File,
+			Readonly:  drive.ReadOnly,
+			VhostUser: false,
+		}
+		_, err = cl.VmAddDiskPut(ctx, blkDevice)
+	}
+
+	if err != nil {
+		err = fmt.Errorf("failed to hotplug block device %+v %s", drive, openAPIClientError(err))
+	}
+	return err
+}
+
 func (clh *cloudHypervisor) hotPlugVFIODevice(device config.VFIODev) error {
 	cl := clh.client()
 	ctx, cancel := context.WithTimeout(context.Background(), clhHotPlugAPITimeout*time.Second)
@@ -432,6 +461,9 @@ func (clh *cloudHypervisor) hotplugAddDevice(devInfo interface{}, devType device
 	defer span.Finish()
 
 	switch devType {
+	case blockDev:
+		drive := devInfo.(*config.BlockDrive)
+		return nil, clh.hotplugBlockDevice(drive)
 	case vfioDev:
 		device := devInfo.(*config.VFIODev)
 		return nil, clh.hotPlugVFIODevice(*device)
@@ -663,6 +695,7 @@ func (clh *cloudHypervisor) capabilities() types.Capabilities {
 	clh.Logger().WithField("function", "capabilities").Info("get Capabilities")
 	var caps types.Capabilities
 	caps.SetFsSharingSupport()
+	caps.SetBlockDeviceHotplugSupport()
 	return caps
 }
 

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -413,6 +413,11 @@ func (clh *cloudHypervisor) getThreadIDs() (vcpuThreadIDs, error) {
 }
 
 func (clh *cloudHypervisor) hotplugBlockDevice(drive *config.BlockDrive) error {
+	if clh.config.BlockDeviceDriver != config.VirtioBlock {
+		return fmt.Errorf("incorrect hypervisor configuration on 'block_device_driver':"+
+			" using '%v' but only support '%v'", clh.config.BlockDeviceDriver, config.VirtioBlock)
+	}
+
 	cl := clh.client()
 	ctx, cancel := context.WithTimeout(context.Background(), clhHotPlugAPITimeout*time.Second)
 	defer cancel()

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -99,6 +99,11 @@ func (c *clhClientMock) VmAddDevicePut(ctx context.Context, vmAddDevice chclient
 	return nil, nil
 }
 
+//nolint:golint
+func (c *clhClientMock) VmAddDiskPut(ctx context.Context, diskConfig chclient.DiskConfig) (*http.Response, error) {
+	return nil, nil
+}
+
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}
@@ -356,4 +361,26 @@ func TestCheckVersion(t *testing.T) {
 			assert.Error(err, msg)
 		}
 	}
+}
+
+func TestCloudHypervisorHotplugBlockDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	clhConfig, err := newClhConfig()
+	assert.NoError(err)
+
+	clh := &cloudHypervisor{}
+	clh.config = clhConfig
+	clh.APIClient = &clhClientMock{}
+
+	clh.config.BlockDeviceDriver = config.VirtioBlock
+	err = clh.hotplugBlockDevice(&config.BlockDrive{Pmem: false})
+	assert.NoError(err, "Hotplug disk block device expected no error")
+
+	err = clh.hotplugBlockDevice(&config.BlockDrive{Pmem: true})
+	assert.Error(err, "Hotplug pmem block device expected error")
+
+	clh.config.BlockDeviceDriver = config.VirtioSCSI
+	err = clh.hotplugBlockDevice(&config.BlockDrive{Pmem: false})
+	assert.Error(err, "Hotplug block device not using 'virtio-blk' expected error")
 }


### PR DESCRIPTION
This patch enables the disk (block) device hotplug in Kata with cloud-hypervisor (CLH). With this patch, the container image can be shared from host with guest as a block device when the docker is configured to use `devicemapper` as its the storage driver. Also, this patch sets the default block device driver to `virtio-blk` in the hypervisor configuration (toml) file, as it is required by the disk (block) device model from cloud-hypervisor.

Fixes: #2570

Signed-off-by: Bo Chen <chen.bo@intel.com>