### PR TITLE
qemu: Don't leak file descriptors in case of error

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -663,6 +663,7 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 
 	const sockFd = 3 // Cmd.ExtraFiles[] fds are numbered starting from 3
 	cmd := exec.Command(q.config.VirtioFSDaemon, q.virtiofsdArgs(sockFd)...)


### PR DESCRIPTION
If we take one of the error paths from setupVirtiofsd() after
opening the fd variable, the fd.Close() function is not called.

Fixes: #2683

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>