### PR TITLE
 qemu: Report all errors on virtiofsd execution

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -641,10 +641,6 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	var listener *net.UnixListener
 	var fd *os.File
 
-	if _, err = os.Stat(q.config.VirtioFSDaemon); os.IsNotExist(err) {
-		return fmt.Errorf("virtiofsd path (%s) does not exist", q.config.VirtioFSDaemon)
-	}
-
 	sockPath, err := q.vhostFSSocketPath(q.id)
 	if err != nil {
 		return err
@@ -676,9 +672,10 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	}
 
 	err = cmd.Start()
-	if err == nil {
-		q.state.VirtiofsdPid = cmd.Process.Pid
+	if err != nil {
+		return fmt.Errorf("virtiofs daemon %v returned with error: %v", q.config.VirtioFSDaemon, err)
 	}
+	q.state.VirtiofsdPid = cmd.Process.Pid
 	fd.Close()
 
 	// Monitor virtiofsd's stderr and stop sandbox if virtiofsd quits


### PR DESCRIPTION
qemu: Report all errors on `virtiofsd` execution

The `virtiofs` daemon may run into errors other than the file not existing, e.g. the file may not be executable.

Fixes: #2682

Message is now:
```
virtiofs daemon /usr/local/bin/hello returned with error: fork/exec /usr/local/bin/virtiofsd: permission denied
```

instead of a segmentation fault with stack trace in `setupVirtiofsd`:
```
panic: runtime error: invalid memory address or nil
```

Fixes: #2582

This makes the original fix for #2582 unnecessary. The result is a change in error message.

Message is now:
```
virtiofs daemon /usr/local/bin/hello-not-found returned with error: fork/exec /usr/local/bin/hello-not-found: no such file or directory
```

instead of:
```
virtiofsd path (/usr/local/bin/hello-no-found) does not exist
```
