### PR TITLE
katatestutils: Use the configured virtiofs daemon path

### DIFF
--- a/cli/kata-env_test.go
+++ b/cli/kata-env_test.go
@@ -96,6 +96,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := filepath.Join(prefixDir, "virtiofsd")
 
 	filesToCreate := []string{
 		hypervisorPath,
@@ -168,6 +169,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 		AgentDebug:           agentDebug,
 		AgentTrace:           agentTrace,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfig := katatestutils.MakeRuntimeConfigFileData(configFileOptions)

--- a/containerd-shim-v2/create_test.go
+++ b/containerd-shim-v2/create_test.go
@@ -401,6 +401,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := path.Join(dir, "virtiofsd")
 
 	configFileOptions := ktu.RuntimeConfigOptions{
 		Hypervisor:           "qemu",
@@ -420,6 +421,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 		PCIeRootPort:         pcieRootPort,
 		DisableNewNetNs:      disableNewNetNs,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfigFileData := ktu.MakeRuntimeConfigFileData(configFileOptions)

--- a/pkg/katatestutils/utils.go
+++ b/pkg/katatestutils/utils.go
@@ -28,6 +28,7 @@ type RuntimeConfigOptions struct {
 	AgentTraceMode       string
 	AgentTraceType       string
 	SharedFS             string
+	VirtioFSDaemon       string
 	PCIeRootPort         uint32
 	DisableBlock         bool
 	EnableIOThreads      bool
@@ -65,7 +66,7 @@ func MakeRuntimeConfigFileData(config RuntimeConfigOptions) string {
 	enable_debug = ` + strconv.FormatBool(config.HypervisorDebug) + `
 	guest_hook_path = "` + config.DefaultGuestHookPath + `"
 	shared_fs = "` + config.SharedFS + `"
-	virtio_fs_daemon = "/path/to/virtiofsd"
+	virtio_fs_daemon = "` + config.VirtioFSDaemon + `"
 
 	[proxy.kata]
 	enable_debug = ` + strconv.FormatBool(config.ProxyDebug) + `

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -85,6 +85,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := path.Join(dir, "virtiofsd")
 
 	configFileOptions := ktu.RuntimeConfigOptions{
 		Hypervisor:           "qemu",
@@ -117,6 +118,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		AgentDebug:           agentDebug,
 		AgentTrace:           agentTrace,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfigFileData := ktu.MakeRuntimeConfigFileData(configFileOptions)
@@ -167,7 +169,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		GuestHookPath:         defaultGuestHookPath,
 		VhostUserStorePath:    defaultVhostUserStorePath,
 		SharedFS:              sharedFS,
-		VirtioFSDaemon:        "/path/to/virtiofsd",
+		VirtioFSDaemon:        virtioFSdaemon,
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 	}
 


### PR DESCRIPTION
The current path is hardcoded as follows:
  virtio_fs_daemon = "/path/to/virtiofsd"

Switch to using the value of config.VirtioFSDaemon instead.

Fixes: #2686

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>