### PR TITLE
FC: add rate limiter

### DIFF
--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -192,6 +192,16 @@ use_vsock = true
 # but it will not abort container execution.
 #guest_hook_path = "/usr/share/oci/hooks"
 
+# Firecracker provides a rate limiter, which is useful for I/O operations that need to be throttled.
+# This option determines maximun number of bytes to receive per second per pod.
+# (default: 0, which means unlimited bandwidth)
+#rx_rate_limiter = 0
+#
+# Firecracker provides a rate limiter, which is useful for I/O operations that need to be throttled.
+# This option determines maximun number of bytes to send per second per pod.
+# (default: 0, which means unlimited bandwidth)
+#tx_rate_limiter = 0
+
 [factory]
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and

--- a/pkg/katautils/config-settings.go.in
+++ b/pkg/katautils/config-settings.go.in
@@ -65,3 +65,6 @@ var defaultSysConfRuntimeConfiguration = "@SYSCONFIG@"
 var name = "kata"
 var defaultProxyPath = "/usr/libexec/kata-containers/kata-proxy"
 var defaultNetmonPath = "/usr/libexec/kata-containers/kata-netmon"
+
+var defaultRxRateLimiter = int64(0)
+var defaultTxRateLimiter = int64(0)

--- a/pkg/katautils/config_test.go
+++ b/pkg/katautils/config_test.go
@@ -766,6 +766,103 @@ func TestMinimalRuntimeConfigWithVsock(t *testing.T) {
 	}
 }
 
+func TestNewFirecrackerHypervisorConfig(t *testing.T) {
+	dir, err := ioutil.TempDir(testDir, "hypervisor-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	hypervisorPath := path.Join(dir, "hypervisor")
+	kernelPath := path.Join(dir, "kernel")
+	imagePath := path.Join(dir, "image")
+	jailerPath := path.Join(dir, "jailer")
+	disableBlockDeviceUse := false
+	disableVhostNet := true
+	useVSock := true
+	blockDeviceDriver := "virtio-mmio"
+	rxRateLimiter := int64(0)
+	txRateLimiter := int64(10485760)
+	orgVHostVSockDevicePath := utils.VHostVSockDevicePath
+	defer func() {
+		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
+	}()
+	utils.VHostVSockDevicePath = "/dev/null"
+
+	hypervisor := hypervisor{
+		Path:                  hypervisorPath,
+		Kernel:                kernelPath,
+		Image:                 imagePath,
+		JailerPath:            jailerPath,
+		DisableBlockDeviceUse: disableBlockDeviceUse,
+		BlockDeviceDriver:     blockDeviceDriver,
+		RxRateLimiter:         rxRateLimiter,
+		TxRateLimiter:         txRateLimiter,
+	}
+
+	files := []string{hypervisorPath, kernelPath, imagePath, jailerPath}
+	filesLen := len(files)
+
+	for i, file := range files {
+		_, err := newFirecrackerHypervisorConfig(hypervisor)
+		if err == nil {
+			t.Fatalf("Expected newFirecrackerHypervisorConfig to fail as not all paths exist (not created %v)",
+				strings.Join(files[i:filesLen], ","))
+		}
+
+		// create the resource
+		err = createEmptyFile(file)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	config, err := newFirecrackerHypervisorConfig(hypervisor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.HypervisorPath != hypervisor.Path {
+		t.Errorf("Expected hypervisor path %v, got %v", hypervisor.Path, config.HypervisorPath)
+	}
+
+	if config.KernelPath != hypervisor.Kernel {
+		t.Errorf("Expected kernel path %v, got %v", hypervisor.Kernel, config.KernelPath)
+	}
+
+	if config.ImagePath != hypervisor.Image {
+		t.Errorf("Expected image path %v, got %v", hypervisor.Image, config.ImagePath)
+	}
+
+	if config.JailerPath != hypervisor.JailerPath {
+		t.Errorf("Expected jailer path %v, got %v", hypervisor.JailerPath, config.JailerPath)
+	}
+
+	if config.DisableBlockDeviceUse != disableBlockDeviceUse {
+		t.Errorf("Expected value for disable block usage %v, got %v", disableBlockDeviceUse, config.DisableBlockDeviceUse)
+	}
+
+	if config.BlockDeviceDriver != blockDeviceDriver {
+		t.Errorf("Expected value for block device driver %v, got %v", blockDeviceDriver, config.BlockDeviceDriver)
+	}
+
+	if config.DisableVhostNet != disableVhostNet {
+		t.Errorf("Expected value for disable vhost net usage %v, got %v", disableVhostNet, config.DisableVhostNet)
+	}
+
+	if config.UseVSock != useVSock {
+		t.Errorf("Expected value for vsock usage %v, got %v", useVSock, config.UseVSock)
+	}
+
+	if config.RxRateLimiter != rxRateLimiter {
+		t.Errorf("Expected value for rx rate limiter %v, got %v", rxRateLimiter, config.RxRateLimiter)
+	}
+
+	if config.TxRateLimiter != txRateLimiter {
+		t.Errorf("Expected value for tx rate limiter %v, got %v", txRateLimiter, config.TxRateLimiter)
+	}
+}
+
 func TestNewQemuHypervisorConfig(t *testing.T) {
 	dir, err := ioutil.TempDir(testDir, "hypervisor-config-")
 	if err != nil {

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -412,6 +412,14 @@ type HypervisorConfig struct {
 
 	// SELinux label for the VM
 	SELinuxProcessLabel string
+
+	// RxRateLimiter specifies the inbound bandwidth(maximum number of bytes to receive per pod per second).
+	// The default 0-sized means unlimited bandwidth.
+	RxRateLimiter int64
+
+	// TxRateLimiter specifies the outbound bandwidth(maximum number of bytes to send per pod per second).
+	// The default 0-sized means unlimited bandwidth..
+	TxRateLimiter int64
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/virtcontainers/persist.go
+++ b/virtcontainers/persist.go
@@ -257,6 +257,8 @@ func (s *Sandbox) dumpConfig(ss *persistapi.SandboxState) {
 		VhostUserStorePath:      sconfig.HypervisorConfig.VhostUserStorePath,
 		GuestHookPath:           sconfig.HypervisorConfig.GuestHookPath,
 		VMid:                    sconfig.HypervisorConfig.VMid,
+		RxRateLimiter:           sconfig.HypervisorConfig.RxRateLimiter,
+		TxRateLimiter:           sconfig.HypervisorConfig.TxRateLimiter,
 	}
 
 	if sconfig.AgentType == "kata" {
@@ -547,6 +549,8 @@ func loadSandboxConfig(id string) (*SandboxConfig, error) {
 		VhostUserStorePath:      hconf.VhostUserStorePath,
 		GuestHookPath:           hconf.GuestHookPath,
 		VMid:                    hconf.VMid,
+		RxRateLimiter:           hconf.RxRateLimiter,
+		TxRateLimiter:           hconf.TxRateLimiter,
 	}
 
 	if savedConf.AgentType == "kata" {

--- a/virtcontainers/persist/api/config.go
+++ b/virtcontainers/persist/api/config.go
@@ -182,6 +182,14 @@ type HypervisorConfig struct {
 	// VMid is the id of the VM that create the hypervisor if the VM is created by the factory.
 	// VMid is "" if the hypervisor is not created by the factory.
 	VMid string
+
+	// RxRateLimiter specifies the inbound bandwidth(maximum number of bytes to receive per pod per second).
+	// The default 0-sized means unlimited bandwidth.
+	RxRateLimiter int64
+
+	// TxRateLimiter specifies the outbound bandwidth(maximum number of bytes to send per pod per second).
+	// The default 0-sized means unlimited bandwidth..
+	TxRateLimiter int64
 }
 
 // KataAgentConfig is a structure storing information needed

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -200,6 +200,12 @@ const (
 	// BlockDeviceCacheNoflush is a sandbox annotation that specifies cache-related options for block devices.
 	// Denotes whether flush requests for the device are ignored.
 	BlockDeviceCacheNoflush = kataAnnotHypervisorPrefix + "block_device_cache_noflush"
+
+	// RxRateLimiter is a sandbox annotation that specifies limitation on network I/O inbound bandwidth.
+	RxRateLimiter = kataAnnotHypervisorPrefix + "rx_rate_limiter"
+
+	// TxRateLimiter is a sandbox annotation that specifies limitation on network I/O outbound bandwidth
+	TxRateLimiter = kataAnnotHypervisorPrefix + "tx_rate_limiter"
 )
 
 // Agent related annotations

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -791,6 +791,8 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	ocispec.Annotations[vcAnnotations.HotplugVFIOOnRootBus] = "true"
 	ocispec.Annotations[vcAnnotations.PCIeRootPort] = "2"
 	ocispec.Annotations[vcAnnotations.EntropySource] = "/dev/urandom"
+	ocispec.Annotations[vcAnnotations.RxRateLimiter] = "0"
+	ocispec.Annotations[vcAnnotations.TxRateLimiter] = "0"
 
 	addAnnotations(ocispec, &config)
 	assert.Equal(config.HypervisorConfig.NumVCPUs, uint32(1))
@@ -823,6 +825,8 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	assert.Equal(config.HypervisorConfig.HotplugVFIOOnRootBus, true)
 	assert.Equal(config.HypervisorConfig.PCIeRootPort, uint32(2))
 	assert.Equal(config.HypervisorConfig.EntropySource, "/dev/urandom")
+	assert.Equal(config.HypervisorConfig.RxRateLimiter, int64(0))
+	assert.Equal(config.HypervisorConfig.TxRateLimiter, int64(0))
 
 	// In case an absurd large value is provided, the config value if not over-ridden
 	ocispec.Annotations[vcAnnotations.DefaultVCPUs] = "655536"


### PR DESCRIPTION
Hi guys

Firecracker has implemented rate limiter to monitor pod-based network I/O operations, which is useful for those I/O operations needed to be throttled.
Here, I tried to enable this feature in kata-containers, then user could specify `rx_rate_limiter/tx_rate_limiter` to control pod-based I/O Bandwidth. Those two values specify the maximum number of bytes one pod could receiver/send per second.
Here is the example: 
**Before:**
the default value of `rx_rate_limiter/tx_rate_limiter` is zero and that means unlimited bandwidth.
Doing iperf3 test: kata-container as client, and host as server.
```
Accepted connection from 172.17.0.2, port 35216
[  5] local 10.169.36.70 port 5201 connected to 172.17.0.2 port 35218
[ ID] Interval           Transfer     Bandwidth
[  5]   0.00-1.00   sec  1018 MBytes  8.54 Gbits/sec
[  5]   1.00-2.00   sec   826 MBytes  6.93 Gbits/sec
[  5]   2.00-3.00   sec   781 MBytes  6.55 Gbits/sec
[  5]   3.00-4.00   sec   777 MBytes  6.52 Gbits/sec
[  5]   4.00-5.00   sec   781 MBytes  6.55 Gbits/sec
[  5]   5.00-6.00   sec   784 MBytes  6.58 Gbits/sec
[  5]   6.00-7.00   sec   830 MBytes  6.96 Gbits/sec
[  5]   7.00-8.00   sec   860 MBytes  7.21 Gbits/sec
[  5]   8.00-9.00   sec   802 MBytes  6.73 Gbits/sec
[  5]   9.00-10.00  sec   777 MBytes  6.52 Gbits/sec
[  5]  10.00-10.00  sec   389 KBytes  1.50 Gbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth
[  5]   0.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  sender
[  5]   0.00-10.00  sec  8.04 GBytes  6.91 Gbits/sec                  receiver
```
After:
We set `tx_rate_limiter` as 1048576 (**10MBytes/s**). 
```
Accepted connection from 172.17.0.2, port 53922
[  5] local 10.169.36.70 port 5201 connected to 172.17.0.2 port 53924
[ ID] Interval           Transfer     Bandwidth
[  5]   0.00-1.00   sec  19.1 MBytes   160 Mbits/sec
[  5]   1.00-2.00   sec  10.1 MBytes  85.0 Mbits/sec
[  5]   2.00-3.00   sec  10.1 MBytes  85.0 Mbits/sec
[  5]   3.00-4.00   sec  10.1 MBytes  84.4 Mbits/sec
[  5]   4.00-5.00   sec  10.1 MBytes  85.0 Mbits/sec
[  5]   5.00-6.00   sec  10.1 MBytes  84.4 Mbits/sec
[  5]   6.00-7.00   sec  10.1 MBytes  85.0 Mbits/sec
[  5]   7.00-8.00   sec  10.1 MBytes  84.4 Mbits/sec
[  5]   8.00-9.00   sec  9.13 MBytes  76.6 Mbits/sec
[  5]   9.00-10.00  sec  10.1 MBytes  84.4 Mbits/sec
[  5]  10.00-10.02  sec   700 KBytes   262 Mbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth
[  5]   0.00-10.02  sec  0.00 Bytes  0.00 bits/sec                  sender
[  5]   0.00-10.02  sec   110 MBytes  91.8 Mbits/sec                  receiver
```
Seeing from the output, I/O transfer has already been throttled to the expected value. ;)