### PR TITLE
vendor: Update govmm to enable virtio-fs support for ppc64le

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,11 +412,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:7cd1d981fa3f8fd7b18aad291cbe71b37fc272b840d21a579542f87ba273dc6d"
+  digest = "1:13366d00de1cc5993e6585377c713be208e219b66b9d92b1668c8f2b15ce011a"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "f6f627acef29a176463e0a0bd558ae1d47ece9a1"
+  revision = "10b22acda6584998b491dc780bbba68bba8517e1"
 
 [[projects]]
   digest = "1:60f089a8a2e13f2ada9c1d8e07604e82011fb8b9950e6916e1fcedc3ca8e1a83"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "f6f627acef29a176463e0a0bd558ae1d47ece9a1"
+  revision = "10b22acda6584998b491dc780bbba68bba8517e1"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"


### PR DESCRIPTION
Enable virtio-fs support for ppc64le

shortlog:
b2aa022 Enable Numa support for Power (ppc64le) architecture
29529a5 Add rt clock definition for rtc clock in qemu
0e98b61 qemu: Add max_ports option to virtio-serial device

Fixes #2056 

Signed-off-by: bpradipt@in.ibm.com