### PR TITLE
Add vIOMMU support to qemu q35

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,11 +412,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:13366d00de1cc5993e6585377c713be208e219b66b9d92b1668c8f2b15ce011a"
+  digest = "1:1e1ba2e121f1f7db23f0783c777aae4323f1af470886d1d507059ffa4537cb05"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "10b22acda6584998b491dc780bbba68bba8517e1"
+  revision = "7efaf0b1cde3883a3f38e656c2223f38b9086469"
 
 [[projects]]
   digest = "1:60f089a8a2e13f2ada9c1d8e07604e82011fb8b9950e6916e1fcedc3ca8e1a83"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "10b22acda6584998b491dc780bbba68bba8517e1"
+  revision = "7efaf0b1cde3883a3f38e656c2223f38b9086469"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/cli/config/configuration-fc.toml.in
+++ b/cli/config/configuration-fc.toml.in
@@ -130,6 +130,12 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_FC@"
 # result in memory pre allocation
 #enable_hugepages = true
 
+# Enable vIOMMU, default false
+# Enabling this will result in the VM having a vIOMMU device
+# This will also add the following options to the kernel's
+# command line: intel_iommu=on,iommu=pt
+#enable_iommu = true
+
 # Enable swap of vm memory. Default false.
 # The behaviour is undefined if mem_prealloc is also set to true
 #enable_swap = true

--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -189,6 +189,12 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# Enable vIOMMU, default false
+# Enabling this will result in the VM having a vIOMMU device
+# This will also add the following options to the kernel's
+# command line: intel_iommu=on,iommu=pt
+#enable_iommu = true
+
 # Enable file based guest memory support. The default is an empty string which
 # will disable this feature. In the case of virtio-fs, this is enabled
 # automatically and '/dev/shm' is used as the backing folder.

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -196,6 +196,12 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# Enable vIOMMU, default false
+# Enabling this will result in the VM having a vIOMMU device
+# This will also add the following options to the kernel's
+# command line: intel_iommu=on,iommu=pt
+#enable_iommu = true
+
 # Enable file based guest memory support. The default is an empty string which
 # will disable this feature. In the case of virtio-fs, this is enabled
 # automatically and '/dev/shm' is used as the backing folder.

--- a/pkg/katautils/config-settings.go.in
+++ b/pkg/katautils/config-settings.go.in
@@ -39,6 +39,7 @@ const defaultBlockDeviceCacheNoflush bool = false
 const defaultEnableIOThreads bool = false
 const defaultEnableMemPrealloc bool = false
 const defaultEnableHugePages bool = false
+const defaultEnableIOMMU bool = false
 const defaultFileBackedMemRootDir string = ""
 const defaultEnableSwap bool = false
 const defaultEnableDebug bool = false

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -120,6 +120,7 @@ type hypervisor struct {
 	MemPrealloc             bool     `toml:"enable_mem_prealloc"`
 	HugePages               bool     `toml:"enable_hugepages"`
 	VirtioMem               bool     `toml:"enable_virtio_mem"`
+	IOMMU                   bool     `toml:"enable_iommu"`
 	FileBackedMemRootDir    string   `toml:"file_mem_backend"`
 	Swap                    bool     `toml:"enable_swap"`
 	Debug                   bool     `toml:"enable_debug"`
@@ -668,6 +669,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		VirtioFSExtraArgs:       h.VirtioFSExtraArgs,
 		MemPrealloc:             h.MemPrealloc,
 		HugePages:               h.HugePages,
+		IOMMU:                   h.IOMMU,
 		FileBackedMemRootDir:    h.FileBackedMemRootDir,
 		Mlock:                   !h.Swap,
 		Debug:                   h.Debug,
@@ -1110,6 +1112,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		DefaultBridges:          defaultBridgesCount,
 		MemPrealloc:             defaultEnableMemPrealloc,
 		HugePages:               defaultEnableHugePages,
+		IOMMU:                   defaultEnableIOMMU,
 		FileBackedMemRootDir:    defaultFileBackedMemRootDir,
 		Mlock:                   !defaultEnableSwap,
 		Debug:                   defaultEnableDebug,

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -1861,6 +1861,52 @@ func (b BalloonDevice) deviceName(config *Config) string {
 	return BalloonDeviceTransport[b.Transport]
 }
 
+// IommuDev represents a Intel IOMMU Device
+type IommuDev struct {
+	Intremap    bool
+	DeviceIotlb bool
+	CachingMode bool
+}
+
+// Valid returns true if the IommuDev is valid
+func (dev IommuDev) Valid() bool {
+	return true
+}
+
+// deviceName the qemu device name
+func (dev IommuDev) deviceName() string {
+	return "intel-iommu"
+}
+
+// QemuParams returns the qemu parameters built out of the IommuDev.
+func (dev IommuDev) QemuParams(_ *Config) []string {
+	var qemuParams []string
+	var deviceParams []string
+
+	deviceParams = append(deviceParams, dev.deviceName())
+	if dev.Intremap {
+		deviceParams = append(deviceParams, "intremap=on")
+	} else {
+		deviceParams = append(deviceParams, "intremap=off")
+	}
+
+	if dev.DeviceIotlb {
+		deviceParams = append(deviceParams, "device-iotlb=on")
+	} else {
+		deviceParams = append(deviceParams, "device-iotlb=off")
+	}
+
+	if dev.CachingMode {
+		deviceParams = append(deviceParams, "caching-mode=on")
+	} else {
+		deviceParams = append(deviceParams, "caching-mode=off")
+	}
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
+	return qemuParams
+}
+
 // RTCBaseType is the qemu RTC base time type.
 type RTCBaseType string
 

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -361,6 +361,9 @@ type HypervisorConfig struct {
 	// VirtioMem is used to enable/disable virtio-mem
 	VirtioMem bool
 
+	// IOMMU specifies if the VM should have a vIOMMU
+	IOMMU bool
+
 	// Realtime Used to enable/disable realtime
 	Realtime bool
 

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -151,6 +151,9 @@ const (
 	// HugePages is a sandbox annotation to specify if the memory should be pre-allocated from huge pages
 	HugePages = kataAnnotHypervisorPrefix + "enable_hugepages"
 
+	// Iommu is a sandbox annotation to specify if the VM should have a vIOMMU device
+	IOMMU = kataAnnotHypervisorPrefix + "enable_iommu"
+
 	// FileBackedMemRootDir is a sandbox annotation to soecify file based memory backend root directory
 	FileBackedMemRootDir = kataAnnotHypervisorPrefix + "file_mem_backend"
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -545,6 +545,15 @@ func addHypervisorMemoryOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig
 
 		sbConfig.HypervisorConfig.HugePages = hugePages
 	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.IOMMU]; ok {
+		iommu, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("Error parsing annotation for iommu: Please specify boolean value 'true|false'")
+		}
+
+		sbConfig.HypervisorConfig.IOMMU = iommu
+	}
 	return nil
 }
 

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -771,6 +771,7 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	ocispec.Annotations[vcAnnotations.EnableSwap] = "true"
 	ocispec.Annotations[vcAnnotations.FileBackedMemRootDir] = "/dev/shm"
 	ocispec.Annotations[vcAnnotations.HugePages] = "true"
+	ocispec.Annotations[vcAnnotations.IOMMU] = "true"
 	ocispec.Annotations[vcAnnotations.BlockDeviceDriver] = "virtio-scsi"
 	ocispec.Annotations[vcAnnotations.DisableBlockDeviceUse] = "true"
 	ocispec.Annotations[vcAnnotations.EnableIOThreads] = "true"
@@ -803,6 +804,7 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	assert.Equal(config.HypervisorConfig.Mlock, false)
 	assert.Equal(config.HypervisorConfig.FileBackedMemRootDir, "/dev/shm")
 	assert.Equal(config.HypervisorConfig.HugePages, true)
+	assert.Equal(config.HypervisorConfig.IOMMU, true)
 	assert.Equal(config.HypervisorConfig.BlockDeviceDriver, "virtio-scsi")
 	assert.Equal(config.HypervisorConfig.DisableBlockDeviceUse, true)
 	assert.Equal(config.HypervisorConfig.EnableIOThreads, true)

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -409,6 +409,13 @@ func (q *qemu) buildDevices(initrdPath string) ([]govmmQemu.Device, *govmmQemu.I
 		}
 	}
 
+	if q.config.IOMMU {
+		devices, err = q.arch.appendIOMMU(devices)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	var ioThread *govmmQemu.IOThread
 	if q.config.BlockDeviceDriver == config.VirtioSCSI {
 		return q.arch.appendSCSIController(devices, q.config.EnableIOThreads)

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -49,7 +49,6 @@ var kernelParams = []Param{
 	{"reboot", "k"},
 	{"console", "hvc0"},
 	{"console", "hvc1"},
-	{"iommu", "off"},
 	{"cryptomgr.notests", ""},
 	{"net.ifnames", "0"},
 	{"pci", "lastbus=0"},
@@ -94,12 +93,31 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		factory = true
 	}
 
+	var qemuMachines = supportedQemuMachines
+	if config.IOMMU {
+		var q35QemuIOMMUOptions = "accel=kvm,kernel_irqchip=split"
+
+		kernelParams = append(kernelParams,
+			Param{"intel_iommu", "on"})
+		kernelParams = append(kernelParams,
+			Param{"iommu", "pt"})
+
+		for _, m := range qemuMachines {
+			if m.Type == QemuQ35 {
+				m.Options = q35QemuIOMMUOptions
+			}
+		}
+	} else {
+		kernelParams = append(kernelParams,
+			Param{"iommu", "off"})
+	}
+
 	q := &qemuAmd64{
 		qemuArchBase: qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -130,6 +130,9 @@ type qemuArch interface {
 
 	// appendPCIeRootPortDevice appends a pcie-root-port device to pcie.0 bus
 	appendPCIeRootPortDevice(devices []govmmQemu.Device, number uint32) []govmmQemu.Device
+
+	// append vIOMMU device
+	appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error)
 }
 
 type qemuArchBase struct {
@@ -768,4 +771,22 @@ func (q *qemuArchBase) addBridge(b types.Bridge) {
 // appendPCIeRootPortDevice appends to devices the given pcie-root-port
 func (q *qemuArchBase) appendPCIeRootPortDevice(devices []govmmQemu.Device, number uint32) []govmmQemu.Device {
 	return genericAppendPCIeRootPort(devices, number, q.machineType)
+
+}
+
+// appendIOMMU appends a virtual IOMMU device
+func (q *qemuArchBase) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
+	switch q.machineType {
+	case QemuQ35:
+		iommu := govmmQemu.IommuDev{
+			Intremap:    true,
+			DeviceIotlb: true,
+			CachingMode: true,
+		}
+
+		devices = append(devices, iommu)
+		return devices, nil
+	default:
+		return devices, fmt.Errorf("Machine Type %s does not support vIOMMU", q.machineType)
+	}
 }

--- a/virtcontainers/qemu_arch_base_test.go
+++ b/virtcontainers/qemu_arch_base_test.go
@@ -566,3 +566,27 @@ func TestQemuArchBaseAppendNetwork(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 }
+
+func TestQemuArchBaseAppendIOMMU(t *testing.T) {
+	var devices []govmmQemu.Device
+	var err error
+	assert := assert.New(t)
+	qemuArchBase := newQemuArchBase()
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.IommuDev{
+			Intremap:    true,
+			DeviceIotlb: true,
+			CachingMode: true,
+		},
+	}
+	// Test IOMMU is not appended to PC machine type
+	qemuArchBase.machineType = QemuPC
+	devices, err = qemuArchBase.appendIOMMU(devices)
+	assert.Error(err)
+
+	qemuArchBase.machineType = QemuQ35
+	devices, err = qemuArchBase.appendIOMMU(devices)
+	assert.NoError(err)
+	assert.Equal(expectedOut, devices)
+}

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -105,3 +105,7 @@ func (q *qemuArm64) setIgnoreSharedMemoryMigrationCaps(_ context.Context, _ *gov
 	// x-ignore-shared not support in arm64 for now
 	return nil
 }
+
+func (q *qemuArm64) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
+	return devices, fmt.Errorf("Arm64 architecture does not support vIOMMU")
+}

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -127,3 +127,7 @@ func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8)
 func (q *qemuPPC64le) appendBridges(devices []govmmQemu.Device) []govmmQemu.Device {
 	return genericAppendBridges(devices, q.Bridges, q.machineType)
 }
+
+func (q *qemuPPC64le) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
+	return devices, fmt.Errorf("PPC64le does not support appending a vIOMMU")
+}

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -268,3 +268,7 @@ func (q *qemuS390x) appendVSock(devices []govmmQemu.Device, vsock types.VSock) (
 	return devices, nil
 
 }
+
+func (q *qemuS390x) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
+	return devices, fmt.Errorf("S390x does not support appending a vIOMMU")
+}


### PR DESCRIPTION
Add vIOMMU support to q35 machines

- Use vIOMMU support added to govmm ([link](https://github.com/intel/govmm/commit/7efaf0b1cde3883a3f38e656c2223f38b9086469))
- Add a configuration.toml switch and a Pod annotation
- If enabled:
  - Add "kernel_irqchip=split" to machine options.
  - Add iommu device: "--device intel-iommu,intremap=on,device-iotlb=on,caching-mode=on"
  - Add iommu params to kernel command line

Fixes #2694 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>  

