### PR TITLE
ci: Do not install virtcontainers with podman clh

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -9,6 +9,6 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 export CI_JOB="${CI_JOB:-default}"
 
-if [ "${CI_JOB}" != "PODMAN" ]; then
+if [ "${CI_JOB}" != "PODMAN" ] && [ "${CI_JOB}" != "CLOUD-HYPERVISOR-PODMAN" ]; then
 	run_go_test
 fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,7 +16,7 @@ pushd "${tests_repo_dir}"
 .ci/setup.sh
 popd
 
-if [ "${CI_JOB}" != "PODMAN" ]; then
+if [ "${CI_JOB}" != "PODMAN" ] && [ "${CI_JOB}" != "CLOUD-HYPERVISOR-PODMAN" ]; then
 	echo "Setup virtcontainers environment"
 	chronic sudo -E PATH=$PATH bash -c "${cidir}/../virtcontainers/utils/virtcontainers-setup.sh"
 


### PR DESCRIPTION
This PR skips the installation of virtcontainers in order to enable
the podman clh CI job.

Fixes #2704

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>