### PR TITLE
qemu: Remove PMU feature for Power (ppc64le) platform

### DIFF
--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -8,7 +8,7 @@
 MACHINETYPE := pseries
 KERNELPARAMS :=
 MACHINEACCELERATORS :=
-CPUFEATURES := pmu=off
+CPUFEATURES :=
 
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
 QEMUCMD := qemu-system-ppc64le


### PR DESCRIPTION
The bug got introduced in kata-containers/runtime@9e4b610
Fixes #2707 

Signed-off-by: bpradipt@in.ibm.com