### PR TITLE
vc: do not follow symlink when umounting contanier host path

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -639,7 +639,7 @@ func (c *Container) unmountHostMounts() error {
 			span, _ := c.trace("unmount")
 			span.SetTag("host-path", m.HostPath)
 
-			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH); err != nil {
+			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH|UmountNoFollow); err != nil {
 				c.Logger().WithFields(logrus.Fields{
 					"host-path": m.HostPath,
 					"error":     err,

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -24,6 +24,9 @@ import (
 // IPC is used.
 const DefaultShmSize = 65536 * 1024
 
+// Sadly golang/sys doesn't have UmountNoFollow although it's there since Linux 2.6.34
+const UmountNoFollow = 0x8
+
 var rootfsDir = "rootfs"
 
 var systemMountPrefixes = []string{"/proc", "/sys"}
@@ -333,7 +336,7 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID s
 	defer span.Finish()
 
 	rootfsDest := filepath.Join(sharedDir, sandboxID, cID, rootfsDir)
-	err := syscall.Unmount(rootfsDest, syscall.MNT_DETACH)
+	err := syscall.Unmount(rootfsDest, syscall.MNT_DETACH|UmountNoFollow)
 	if err == syscall.ENOENT {
 		logrus.Warnf("%s: %s", err, rootfsDest)
 		return nil


### PR DESCRIPTION
So that if a guest changes it, we do not end up
propergating the error.

backport from master commit 5bf32312131af572334eaf5a3ef5ccaf9e08a19f