### PR TITLE
qemu: Remove hard-coding of Qemu machine options for ppc64le

### DIFF
--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -7,7 +7,7 @@
 
 MACHINETYPE := pseries
 KERNELPARAMS :=
-MACHINEACCELERATORS :=
+MACHINEACCELERATORS := "cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off,cap-ccf-assist=off"
 CPUFEATURES :=
 
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -22,7 +22,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off"
 
 const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
 


### PR DESCRIPTION
Hard-coded Qemu machine options create challenges when running Kata
with latest Qemu (v5.0) or with latest processor version.
This patch makes it configurable by leveraging the existing machine_accelerators
option in configuration.toml.

This patch fixes #2657 for ppc64le

Signed-off-by: bpradipt@in.ibm.com