### PR TITLE
readme: add feature freeze notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,9 @@
+---
+name: Bug Report 🐞
+about: Something isn't working as expected? Here is the right place to report.
+labels: "type: bug"
+---
+
 # Description of problem
 
 (replace this text with the list of steps you followed)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for the project.
+labels: "type: feature or enhancement"
+---
+
+# Repository consolidation notice
+We have consolidated all code repositories to the
+github.com/kata-containers/kata-containers repository
+and new feature development happens there as well.
+
+Also we have decided to feature freeze for kata 1.x releases.
+Please submit any new feature requests to
+github.com/kata-containers/kata-containers, Thanks!
+
+If it is strongly desired to include a feature in the 1.x kata
+releases, please backport it from the 2.0-dev branch after it
+is merged there.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@
 # Runtime
 
 This repository contains the runtime for the
-[Kata Containers](https://github.com/kata-containers) project.
+[Kata Containers](https://github.com/kata-containers) project for the 1.x
+releases.
 
-For details of the other Kata Containers repositories, see the
-[repository summary](https://github.com/kata-containers/kata-containers).
+Right now Kata Containers 1.x releases are in feature freeze mode and
+this repository only accpets bugfixes. We have consolidated all code
+repositories to the github.com/kata-containers/kata-containers repository
+and new feature development happens there as well.
 
 * [Introduction](#introduction)
 * [License](#license)


### PR DESCRIPTION
We have moved development to 2.0-dev branch of
github.com/kata-containers/kata-containers, and also
decided that Kata 1.x is in feature freeze mode.
Add a notice about the change in both readme and the
feature request issue template.

Fixes: #2716