### PR TITLE
clh: Support to add block device and volumes from host to container

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -412,6 +412,9 @@ func (clh *cloudHypervisor) hotplugBlockDevice(drive *config.BlockDrive) error {
 		return openAPIClientError(err)
 	}
 
+	//Explicitly set PCIAddr to NULL, so that VirtPath can be used
+	drive.PCIAddr = ""
+
 	if drive.Pmem {
 		err = fmt.Errorf("pmem device hotplug not supported")
 	} else {

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1537,7 +1537,11 @@ func (k *kataAgent) handleDeviceBlockVolume(c *Container, device api.Device) (*g
 		vol.Source = blockDrive.DevNo
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioBlock:
 		vol.Driver = kataBlkDevType
-		vol.Source = blockDrive.PCIAddr
+		if blockDrive.PCIAddr == "" {
+			vol.Source = blockDrive.VirtPath
+		} else {
+			vol.Source = blockDrive.PCIAddr
+		}
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioMmio:
 		vol.Driver = kataMmioBlkDevType
 		vol.Source = blockDrive.VirtPath

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1179,6 +1179,7 @@ func (k *kataAgent) appendBlockDevice(dev ContainerDevice, c *Container) *grpc.D
 	case config.VirtioBlock:
 		kataDevice.Type = kataBlkDevType
 		kataDevice.Id = d.PCIAddr
+		kataDevice.VmPath = d.VirtPath
 	case config.VirtioSCSI:
 		kataDevice.Type = kataSCSIDevType
 		kataDevice.Id = d.SCSIAddr

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -41,8 +41,13 @@ import (
 
 var (
 	testKataProxyURLTempl  = "unix://%s/kata-proxy-test.sock"
+	testBlkDriveFormat     = "testBlkDriveFormat"
 	testBlockDeviceCtrPath = "testBlockDeviceCtrPath"
+	testDevNo              = "testDevNo"
+	testNvdimmID           = "testNvdimmID"
 	testPCIAddr            = "04/02"
+	testSCSIAddr           = "testSCSIAddr"
+	testVirtPath           = "testVirtPath"
 )
 
 func proxyHandlerDiscard(c net.Conn) {
@@ -401,6 +406,110 @@ func TestHandleLocalStorage(t *testing.T) {
 	localMountPoint := localStorages[0].GetMountPoint()
 	expected := filepath.Join(kataGuestSharedDir(), sandboxID, rootfsSuffix, KataLocalDevType, filepath.Base(mountSource))
 	assert.Equal(t, localMountPoint, expected)
+}
+
+func TestHandleDeviceBlockVolume(t *testing.T) {
+	k := kataAgent{}
+
+	tests := []struct {
+		BlockDeviceDriver string
+		inputDev          *drivers.BlockDevice
+		resultVol         *pb.Storage
+	}{
+		{
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					Pmem:     true,
+					NvdimmID: testNvdimmID,
+					Format:   testBlkDriveFormat,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver:  kataNvdimmDevType,
+				Source:  fmt.Sprintf("/dev/pmem%s", testNvdimmID),
+				Fstype:  testBlkDriveFormat,
+				Options: []string{"dax"},
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioBlockCCW,
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					DevNo: testDevNo,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataBlkCCWDevType,
+				Source: testDevNo,
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioBlock,
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					PCIAddr:  testPCIAddr,
+					VirtPath: testVirtPath,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataBlkDevType,
+				Source: testPCIAddr,
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioBlock,
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					VirtPath: testVirtPath,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataBlkDevType,
+				Source: testVirtPath,
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioMmio,
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					VirtPath: testVirtPath,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataMmioBlkDevType,
+				Source: testVirtPath,
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioSCSI,
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					SCSIAddr: testSCSIAddr,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataSCSIDevType,
+				Source: testSCSIAddr,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c := &Container{
+			sandbox: &Sandbox{
+				config: &SandboxConfig{
+					HypervisorConfig: HypervisorConfig{
+						BlockDeviceDriver: test.BlockDeviceDriver,
+					},
+				},
+			},
+		}
+
+		vol, _ := k.handleDeviceBlockVolume(c, test.inputDev)
+		assert.True(t, reflect.DeepEqual(vol, test.resultVol),
+			"Volume didn't match: got %+v, expecting %+v",
+			vol, test.resultVol)
+	}
 }
 
 func TestHandleBlockVolume(t *testing.T) {


### PR DESCRIPTION
This patch allows agent to use the `VirtPath` field of block device for creating containers, beacuse the `PCIAddr` field may not be available (e.g. when using cloud-hypervisor).

Fixes: #2720

Signed-off-by: Bo Chen <chen.bo@intel.com>