### PR TITLE
shimv2: check correct error variable for deferred func in service#StartShim

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -211,10 +211,10 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 
 	// make sure to wait after start
 	go cmd.Wait()
-	if err := cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
+	if err = cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
 		return "", err
 	}
-	if err := cdshim.WriteAddress("address", address); err != nil {
+	if err = cdshim.WriteAddress("address", address); err != nil {
 		return "", err
 	}
 	return address, nil


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

In service#StartShim, there is no applicable error variable which is checked by deferred func because the err variable is redefined:
```
       if err := cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
```
This PR fixes #2727.