### PR TITLE
virtcontainers: drop deferred func for GetAndSetSandboxBlockIndex()

### DIFF
--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -235,7 +235,9 @@ func (a *Acrn) appendImage(devices []Device, imagePath string) ([]Device, error)
 	if sandbox == nil && err != nil {
 		return nil, err
 	}
-	sandbox.GetAndSetSandboxBlockIndex()
+	if _, err = sandbox.GetAndSetSandboxBlockIndex(); err != nil {
+		return nil, err
+	}
 
 	devices, err = a.arch.appendImage(devices, imagePath)
 	if err != nil {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1606,7 +1606,6 @@ const maxBlockIndex = 65535
 // the BlockIndexMap and marks it as used. This index is used to maintain the
 // index at which a block device is assigned to a container in the sandbox.
 func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
-	var err error
 	currentIndex := -1
 	for i := 0; i < maxBlockIndex; i++ {
 		if _, ok := s.state.BlockIndexMap[i]; !ok {
@@ -1618,11 +1617,6 @@ func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
 		return -1, errors.New("no available block index")
 	}
 	s.state.BlockIndexMap[currentIndex] = struct{}{}
-	defer func() {
-		if err != nil {
-			delete(s.state.BlockIndexMap, currentIndex)
-		}
-	}()
 
 	return currentIndex, nil
 }


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

In Acrn#appendImage(), we should check the error return value from GetAndSetSandboxBlockIndex().

This PR also names the error return for getAndSetSandboxBlockIndex so that the deferred func checks the right variable.

Fixes #2726