### PR TITLE
clh: Allow add virtiofs args and cache options from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,13 @@ DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
 DEFVIRTIOFSDAEMON := $(VIRTIOFSDBINDIR)/virtiofsd
 # Default DAX mapping cache size in MiB
 DEFVIRTIOFSCACHESIZE := 1024
-DEFVIRTIOFSCACHE := always
-DEFVIRTIOFSEXTRAARGS := []
+DEFVIRTIOFSCACHE ?= always
+# Format example:
+#   [\"-o\", \"arg1=xxx,arg2\", \"-o\", \"hello world\", \"--arg3=yyy\"]
+#
+# see `virtiofsd -h` for possible options.
+# Make sure you quote args.
+DEFVIRTIOFSEXTRAARGS ?= []
 DEFENABLEIOTHREADS := false
 DEFENABLEMEMPREALLOC := false
 DEFENABLEHUGEPAGES := false

--- a/cli/config/configuration-clh.toml.in
+++ b/cli/config/configuration-clh.toml.in
@@ -65,8 +65,28 @@ virtio_fs_daemon = "@DEFVIRTIOFSDAEMON@"
 # Default size of DAX cache in MiB
 virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 
-# cloud-hypervisor prefers virtiofs caching (dax) for performance reasons
-virtio_fs_cache = "always"
+# Extra args for virtiofsd daemon
+#
+# Format example:
+#   ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+#
+# see `virtiofsd -h` for possible options.
+virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
+
+# Cache mode:
+#
+#  - none
+#    Metadata, data, and pathname lookup are not cached in guest. They are
+#    always fetched from host and any changes are immediately pushed to host.
+#
+#  - auto
+#    Metadata and pathname lookup cache expires after a configured amount of
+#    time (default is 1 second). Data is cached while the file is open (close
+#    to open consistency).
+#
+#  - always
+#    Metadata, data, and pathname lookup are cached in guest and never expire.
+virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
 # Block storage driver to be used for the hypervisor in case the container
 # rootfs is backed by a block device. This is virtio-scsi, virtio-blk

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -835,6 +835,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		PCIeRootPort:            h.PCIeRootPort,
 		DisableVhostNet:         true,
 		UseVSock:                true,
+		VirtioFSExtraArgs:       h.VirtioFSExtraArgs,
 	}, nil
 }
 


### PR DESCRIPTION
Today some options for virtiofsd could improve compatibility
for example xattrs for dnf or cache=auto for file consistency
for changes in the host. Allow users can enabled as requiered.

Fixes: #2735

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>