### PR TITLE
qemu: Fix Qemu binary path for Power across distros

### DIFF
--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -11,4 +11,4 @@ MACHINEACCELERATORS := "cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large
 CPUFEATURES :=
 
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
-QEMUCMD := qemu-system-ppc64le
+QEMUCMD := qemu-system-ppc64

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -18,7 +18,7 @@ type qemuPPC64le struct {
 	qemuArchBase
 }
 
-const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
+const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 


### PR DESCRIPTION
The default ppc64le Qemu binary path was specific for Ubuntu.
This patch fixes the default binary path for both Fedora and Ubuntu

Fixes: #2738

Signed-off-by: bpradipt@in.ibm.com