### PR TITLE
cli: Fix kata-env output on Power

### DIFF
--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	runtim "runtime"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -223,9 +222,6 @@ func getHostInfo() (HostInfo, error) {
 	}
 
 	hostVMContainerCapable := true
-	if runtim.GOARCH == "ppc64le" {
-		hostVMContainerCapable = false
-	}
 
 	details := vmContainerCapableDetails{
 		cpuInfoFile:           procCPUInfo,

--- a/cli/kata-env_ppc64le_test.go
+++ b/cli/kata-env_ppc64le_test.go
@@ -10,7 +10,7 @@ import "testing"
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := ""
 	expectedModel := "POWER8"
-	expectedVMContainerCapable := false
+	expectedVMContainerCapable := true
 	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }
 


### PR DESCRIPTION
kata-env output always shows "VMContainerCapable=false" on Power.
This patch fixes the same.

Fixes: #2740

Signed-off-by: bpradipt@in.ibm.com