### PR TITLE
Backport bug fixes to 1.10

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -527,7 +527,7 @@ func (c *Container) shareFiles(m Mount, idx int, hostSharedDir, guestSharedDir s
 	} else {
 		// These mounts are created in the shared dir
 		mountDest := filepath.Join(hostSharedDir, c.sandbox.id, filename)
-		if err := bindMount(c.ctx, m.Source, mountDest, false); err != nil {
+		if err := bindMount(c.ctx, m.Source, mountDest, false, "private"); err != nil {
 			return "", false, err
 		}
 		// Save HostPath mount value into the mount list of the container.

--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -639,7 +639,7 @@ func (c *Container) unmountHostMounts() error {
 			span, _ := c.trace("unmount")
 			span.SetTag("host-path", m.HostPath)
 
-			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH); err != nil {
+			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH|UmountNoFollow); err != nil {
 				c.Logger().WithFields(logrus.Fields{
 					"host-path": m.HostPath,
 					"error":     err,

--- a/virtcontainers/container_test.go
+++ b/virtcontainers/container_test.go
@@ -182,15 +182,15 @@ func TestUnmountHostMountsRemoveBindHostPath(t *testing.T) {
 			ctx:    context.Background(),
 		}
 
-		if err := bindMount(c.ctx, src, hostPath, false); err != nil {
+		if err := bindMount(c.ctx, src, hostPath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(hostPath, 0)
-		if err := bindMount(c.ctx, src, nonEmptyHostpath, false); err != nil {
+		if err := bindMount(c.ctx, src, nonEmptyHostpath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(nonEmptyHostpath, 0)
-		if err := bindMount(c.ctx, src, devPath, false); err != nil {
+		if err := bindMount(c.ctx, src, devPath, false, "private"); err != nil {
 			t.Fatal(err)
 		}
 		defer syscall.Unmount(devPath, 0)

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -173,46 +173,6 @@ func (fc *firecracker) trace(name string) (opentracing.Span, context.Context) {
 	return span, ctx
 }
 
-// bindMount bind mounts a source in to a destination. This will
-// do some bookkeeping:
-// * evaluate all symlinks
-// * ensure the source exists
-// * recursively create the destination
-func (fc *firecracker) bindMount(ctx context.Context, source, destination string, readonly bool) error {
-	span, _ := trace(ctx, "bindMount")
-	defer span.Finish()
-
-	if source == "" {
-		return fmt.Errorf("source must be specified")
-	}
-	if destination == "" {
-		return fmt.Errorf("destination must be specified")
-	}
-
-	absSource, err := filepath.EvalSymlinks(source)
-	if err != nil {
-		return fmt.Errorf("Could not resolve symlink for source %v", source)
-	}
-
-	if err := ensureDestinationExists(absSource, destination); err != nil {
-		return fmt.Errorf("Could not create destination mount point %v: %v", destination, err)
-	}
-
-	fc.Logger().WithFields(logrus.Fields{"src": absSource, "dst": destination}).Debug("Bind mounting resource")
-
-	if err := syscall.Mount(absSource, destination, "bind", syscall.MS_BIND|syscall.MS_SLAVE, ""); err != nil {
-		return fmt.Errorf("Could not bind mount %v to %v: %v", absSource, destination, err)
-	}
-
-	// For readonly bind mounts, we need to remount with the readonly flag.
-	// This is needed as only very recent versions of libmount/util-linux support "bind,ro"
-	if readonly {
-		return syscall.Mount(absSource, destination, "bind", uintptr(syscall.MS_BIND|syscall.MS_SLAVE|syscall.MS_REMOUNT|syscall.MS_RDONLY), "")
-	}
-
-	return nil
-}
-
 // For firecracker this call only sets the internal structure up.
 // The sandbox will be created and started through startSandbox().
 func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig, vcStore *store.VCStore, stateful bool) error {
@@ -535,7 +495,7 @@ func (fc *firecracker) fcJailResource(src, dst string) (string, error) {
 			src, dst)
 	}
 	jailedLocation := filepath.Join(fc.jailerRoot, dst)
-	if err := fc.bindMount(context.Background(), src, jailedLocation, false); err != nil {
+	if err := bindMount(context.Background(), src, jailedLocation, false, "slave"); err != nil {
 		fc.Logger().WithField("bindMount failed", err).Error()
 		return "", err
 	}

--- a/virtcontainers/mount.go
+++ b/virtcontainers/mount.go
@@ -24,6 +24,9 @@ import (
 // IPC is used.
 const DefaultShmSize = 65536 * 1024
 
+// Sadly golang/sys doesn't have UmountNoFollow although it's there since Linux 2.6.34
+const UmountNoFollow = 0x8
+
 var rootfsDir = "rootfs"
 
 var systemMountPrefixes = []string{"/proc", "/sys"}
@@ -333,7 +336,7 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, sandboxID, cID s
 	defer span.Finish()
 
 	rootfsDest := filepath.Join(sharedDir, sandboxID, cID, rootfsDir)
-	err := syscall.Unmount(rootfsDest, syscall.MNT_DETACH)
+	err := syscall.Unmount(rootfsDest, syscall.MNT_DETACH|UmountNoFollow)
 	if err == syscall.ENOENT {
 		logrus.Warnf("%s: %s", err, rootfsDest)
 		return nil

--- a/virtcontainers/syscall_test.go
+++ b/virtcontainers/syscall_test.go
@@ -7,93 +7,12 @@
 package virtcontainers
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
-	ktu "github.com/kata-containers/runtime/pkg/katatestutils"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestBindMountInvalidSourceSymlink(t *testing.T) {
-	source := filepath.Join(testDir, "fooFile")
-	os.Remove(source)
-
-	err := bindMount(context.Background(), source, "", false)
-	assert.Error(t, err)
-}
-
-func TestBindMountFailingMount(t *testing.T) {
-	source := filepath.Join(testDir, "fooLink")
-	fakeSource := filepath.Join(testDir, "fooFile")
-	os.Remove(source)
-	os.Remove(fakeSource)
-	assert := assert.New(t)
-
-	_, err := os.OpenFile(fakeSource, os.O_CREATE, mountPerm)
-	assert.NoError(err)
-
-	err = os.Symlink(fakeSource, source)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, "", false)
-	assert.Error(err)
-}
-
-func TestBindMountSuccessful(t *testing.T) {
-	assert := assert.New(t)
-	if tc.NotValid(ktu.NeedRoot()) {
-		t.Skip(testDisabledAsNonRoot)
-	}
-
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
-
-	err := os.MkdirAll(source, mountPerm)
-	assert.NoError(err)
-
-	err = os.MkdirAll(dest, mountPerm)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, dest, false)
-	assert.NoError(err)
-
-	syscall.Unmount(dest, 0)
-}
-
-func TestBindMountReadonlySuccessful(t *testing.T) {
-	assert := assert.New(t)
-	if tc.NotValid(ktu.NeedRoot()) {
-		t.Skip(testDisabledAsNonRoot)
-	}
-
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
-
-	err := os.MkdirAll(source, mountPerm)
-	assert.NoError(err)
-
-	err = os.MkdirAll(dest, mountPerm)
-	assert.NoError(err)
-
-	err = bindMount(context.Background(), source, dest, true)
-	assert.NoError(err)
-
-	defer syscall.Unmount(dest, 0)
-
-	// should not be able to create file in read-only mount
-	destFile := filepath.Join(dest, "foo")
-	_, err = os.OpenFile(destFile, os.O_CREATE, mountPerm)
-	assert.Error(err)
-}
 
 func TestEnsureDestinationExistsNonExistingSource(t *testing.T) {
 	err := ensureDestinationExists("", "")
@@ -107,8 +26,9 @@ func TestEnsureDestinationExistsWrongParentDir(t *testing.T) {
 	os.Remove(dest)
 	assert := assert.New(t)
 
-	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	file, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	assert.NoError(err)
+	defer file.Close()
 
 	err = ensureDestinationExists(source, dest)
 	assert.Error(err)
@@ -123,20 +43,22 @@ func TestEnsureDestinationExistsSuccessfulSrcDir(t *testing.T) {
 
 	err := os.MkdirAll(source, mountPerm)
 	assert.NoError(err)
+	defer os.Remove(source)
 
 	err = ensureDestinationExists(source, dest)
 	assert.NoError(err)
 }
 
 func TestEnsureDestinationExistsSuccessfulSrcFile(t *testing.T) {
-	source := filepath.Join(testDir, "fooDirSrc")
-	dest := filepath.Join(testDir, "fooDirDest")
+	source := filepath.Join(testDir, "fooFileSrc")
+	dest := filepath.Join(testDir, "fooFileDest")
 	os.Remove(source)
 	os.Remove(dest)
 	assert := assert.New(t)
 
-	_, err := os.OpenFile(source, os.O_CREATE, mountPerm)
+	file, err := os.OpenFile(source, os.O_CREATE, mountPerm)
 	assert.NoError(err)
+	defer file.Close()
 
 	err = ensureDestinationExists(source, dest)
 	assert.NoError(err)


### PR DESCRIPTION
This includes 
00da1270 unit-test: refine related unit tests
9d3022a8 mount: modify func bindMount
231bbe2c vc: validate container path when cleaning up
11f4560b vc: do not follow symlink when umounting contanier host path