### PR TITLE
virtiofsd: Use cache auto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
 DEFVIRTIOFSDAEMON := $(VIRTIOFSDBINDIR)/virtiofsd
 # Default DAX mapping cache size in MiB
 DEFVIRTIOFSCACHESIZE := 1024
-DEFVIRTIOFSCACHE ?= always
+DEFVIRTIOFSCACHE ?= auto
 # Format example:
 #   [\"-o\", \"arg1=xxx,arg2\", \"-o\", \"hello world\", \"--arg3=yyy\"]
 #


### PR DESCRIPTION
Today for virtiofsd kata sets by default `cache=always`. This option is
useful for performance but if the shared files are modified from the
host changes are not updated in the guest as virtiofsd uses cached value
all time.

This patch changes to  `cache=auto` to fix consistency issues. The option
can still be set to always if it is wanted by the user.

Fixes: #2748

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>