### PR TITLE
Backport Power arch fixes to 1.11

### DIFF
--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -9,4 +9,4 @@ MACHINETYPE := pseries
 KERNELPARAMS :=
 MACHINEACCELERATORS :=
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
-QEMUCMD := qemu-system-ppc64le
+QEMUCMD := qemu-system-ppc64

--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -7,6 +7,6 @@
 
 MACHINETYPE := pseries
 KERNELPARAMS :=
-MACHINEACCELERATORS :=
+MACHINEACCELERATORS := "cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off,cap-ccf-assist=off"
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
 QEMUCMD := qemu-system-ppc64

--- a/cli/kata-env.go
+++ b/cli/kata-env.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	runtim "runtime"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -223,9 +222,6 @@ func getHostInfo() (HostInfo, error) {
 	}
 
 	hostVMContainerCapable := true
-	if runtim.GOARCH == "ppc64le" {
-		hostVMContainerCapable = false
-	}
 
 	details := vmContainerCapableDetails{
 		cpuInfoFile:           procCPUInfo,

--- a/cli/kata-env_ppc64le_test.go
+++ b/cli/kata-env_ppc64le_test.go
@@ -10,7 +10,7 @@ import "testing"
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := ""
 	expectedModel := "POWER8"
-	expectedVMContainerCapable := false
+	expectedVMContainerCapable := true
 	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }
 

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -22,7 +22,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off"
 
 const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
 

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -18,7 +18,7 @@ type qemuPPC64le struct {
 	qemuArchBase
 }
 
-const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
+const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 


### PR DESCRIPTION
This PR backports the following Power arch fixes to stable-1.11 branch
- https://github.com/kata-containers/runtime/commit/2c3b3440b98b6254f4dd9504c19da04141eade0d qemu: Fix Qemu binary path for Power across distros
- https://github.com/kata-containers/runtime/commit/cecd7f7f4818a6c8e0981feb18c473c0d8dea101 cli: Fix kata-env output on Power
- https://github.com/kata-containers/runtime/commit/3eee00eca5ffec9129d11e7132d8669f7eeee336 qemu: Remove hard-coding of Qemu machine options for ppc64le