### PR TITLE
Fix ARM build failure

### DIFF
--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -7,6 +7,7 @@ package virtcontainers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	govmmQemu "github.com/intel/govmm/qemu"


### PR DESCRIPTION
This is breakage was introduced by the following commit[0].

[0]: https://github.com/kata-containers/runtime/commit/66b54f88c5f4023bbd69c02d0b3274e8567e8b35

Fixes: #2753

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>