### PR TITLE
[stable-1.5] clh: Fix shared directory path for virtiofsd

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -666,7 +666,7 @@ func (clh *cloudHypervisor) waitVirtiofsd(start time.Time, timeout int, ready ch
 
 func (clh *cloudHypervisor) virtiofsdArgs(sockPath string) ([]string, error) {
 
-	sourcePath := filepath.Join(kataHostSharedDir(), clh.id)
+	sourcePath := filepath.Join(getSharePath(clh.id))
 	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {
 		if err = os.MkdirAll(sourcePath, os.ModePerm); err != nil {
 			return nil, err


### PR DESCRIPTION
The shared directory path changed recently as part of a backport:

4d0f3c5 vc: make host shared path readonly

The backport was missing update the new path to be used by virtiofsd in
the cloud-hypervisor driver.

Fixes: #2757

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>