### PR TITLE
[dnm] clh: make memory mergeable

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -238,6 +238,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 		MaxVcpus:  int32(clh.config.DefaultMaxVCPUs),
 	}
 
+	clh.vmconfig.Memory.Mergeable = true
+
 	// Add the kernel path
 	kernelPath, err := clh.config.KernelAssetPath()
 	if err != nil {


### PR DESCRIPTION
Useful when ksm is enabled.

Fixes: #1

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>