### PR TITLE
[backport | stable-1.11] Backport Ted Yu fixes

### DIFF
--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -211,10 +211,10 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 
 	// make sure to wait after start
 	go cmd.Wait()
-	if err := cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
+	if err = cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
 		return "", err
 	}
-	if err := cdshim.WriteAddress("address", address); err != nil {
+	if err = cdshim.WriteAddress("address", address); err != nil {
 		return "", err
 	}
 	return address, nil

--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -235,7 +235,9 @@ func (a *Acrn) appendImage(devices []Device, imagePath string) ([]Device, error)
 	if sandbox == nil && err != nil {
 		return nil, err
 	}
-	sandbox.GetAndSetSandboxBlockIndex()
+	if _, err = sandbox.GetAndSetSandboxBlockIndex(); err != nil {
+		return nil, err
+	}
 
 	devices, err = a.arch.appendImage(devices, imagePath)
 	if err != nil {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1606,7 +1606,6 @@ const maxBlockIndex = 65535
 // the BlockIndexMap and marks it as used. This index is used to maintain the
 // index at which a block device is assigned to a container in the sandbox.
 func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
-	var err error
 	currentIndex := -1
 	for i := 0; i < maxBlockIndex; i++ {
 		if _, ok := s.state.BlockIndexMap[i]; !ok {
@@ -1618,11 +1617,6 @@ func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
 		return -1, errors.New("no available block index")
 	}
 	s.state.BlockIndexMap[currentIndex] = struct{}{}
-	defer func() {
-		if err != nil {
-			delete(s.state.BlockIndexMap, currentIndex)
-		}
-	}()
 
 	return currentIndex, nil
 }

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -505,7 +505,7 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 	return s, nil
 }
 
-func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
+func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (sb *Sandbox, retErr error) {
 	span, ctx := trace(ctx, "newSandbox")
 	defer span.Finish()
 
@@ -547,8 +547,8 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	}
 
 	defer func() {
-		if err != nil {
-			s.Logger().WithError(err).WithField("sandboxid", s.id).Error("Create new sandbox failed")
+		if retErr != nil {
+			s.Logger().WithError(retErr).WithField("sandboxid", s.id).Error("Create new sandbox failed")
 			globalSandboxList.removeSandbox(s.id)
 			s.newStore.Destroy(s.id)
 		}


### PR DESCRIPTION
The commits backported are bringing fixes for:
- #2727 - Ineffective error variable for deferred func in service#StartShim 
- #2726 - the error return from GetAndSetSandboxBlockIndex() should be checked
- #2759 - Ineffective error variable check for sandbox creation