### PR TITLE
qemu: Fix kernel_irqchip=split option for IOMMU enabled sandbox

### DIFF
--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -102,9 +102,9 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		kernelParams = append(kernelParams,
 			Param{"iommu", "pt"})
 
-		for _, m := range qemuMachines {
+		for i, m := range qemuMachines {
 			if m.Type == QemuQ35 {
-				m.Options = q35QemuIOMMUOptions
+				qemuMachines[i].Options = q35QemuIOMMUOptions
 			}
 		}
 	} else {

--- a/virtcontainers/qemu_amd64_test.go
+++ b/virtcontainers/qemu_amd64_test.go
@@ -257,3 +257,19 @@ func TestQemuAmd64Microvm(t *testing.T) {
 
 	assert.False(amd64.supportGuestMemoryHotplug())
 }
+
+func TestQemuAmd64Iommu(t *testing.T) {
+	assert := assert.New(t)
+
+	config := qemuConfig(QemuQ35)
+	config.IOMMU = true
+	qemu := newQemuArch(config)
+
+	p := qemu.kernelParameters(false)
+	assert.Contains(p, Param{"intel_iommu", "on"})
+
+	m, err := qemu.machine()
+
+	assert.NoError(err)
+	assert.Contains(m.Options, "kernel_irqchip=split")
+}


### PR DESCRIPTION
When an x86 sandbox has a vIOMMU (needed for VFIO), it needs the
'kernel_irqchip=split' option or it can't start.  fdcd1f3a2 attempts to set
that, but ends up just writing it to a temporary (looks like Go for range
loops pass by value).

Fixes: fdcd1f3a2 "qemu: enable iommu on q35"
Signed-off-by: David Gibson <david@gibson.dropbear.id.au>