### PR TITLE
versions: Move to cloud-hypervisor v0.8.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v0.7.0"
+      version: "v0.8.0"
 
     firecracker:
       description: "Firecracker micro-VMM"

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -1133,7 +1133,7 @@ func (clh *cloudHypervisor) addVSock(cid int64, path string) {
 		"cid":  cid,
 	}).Info("Adding HybridVSock")
 
-	clh.vmconfig.Vsock = chclient.VsockConfig{Cid: cid, Sock: path}
+	clh.vmconfig.Vsock = chclient.VsockConfig{Cid: cid, Socket: path}
 }
 
 func (clh *cloudHypervisor) addNet(e Endpoint) error {
@@ -1177,14 +1177,14 @@ func (clh *cloudHypervisor) addVolume(volume types.Volume) error {
 			{
 				Tag:       volume.MountTag,
 				CacheSize: int64(clh.config.VirtioFSCacheSize << 20),
-				Sock:      vfsdSockPath,
+				Socket:    vfsdSockPath,
 			},
 		}
 	} else {
 		clh.vmconfig.Fs = []chclient.FsConfig{
 			{
-				Tag:  volume.MountTag,
-				Sock: vfsdSockPath,
+				Tag:    volume.MountTag,
+				Socket: vfsdSockPath,
 			},
 		}
 

--- a/virtcontainers/clh_test.go
+++ b/virtcontainers/clh_test.go
@@ -110,7 +110,7 @@ func TestCloudHypervisorAddVSock(t *testing.T) {
 
 	clh.addVSock(1, "path")
 	assert.Equal(clh.vmconfig.Vsock.Cid, int64(1))
-	assert.Equal(clh.vmconfig.Vsock.Sock, "path")
+	assert.Equal(clh.vmconfig.Vsock.Socket, "path")
 }
 
 // Check addNet appends to the network config list new configurations.

--- a/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -306,7 +306,6 @@ components:
             vhost_socket: vhost_socket
             vhost_user: false
             direct: false
-            wce: true
             poll_queue: true
             id: id
           - path: path
@@ -317,7 +316,6 @@ components:
             vhost_socket: vhost_socket
             vhost_user: false
             direct: false
-            wce: true
             poll_queue: true
             id: id
           cpus:
@@ -336,23 +334,23 @@ components:
             iommu: false
             src: /dev/urandom
           fs:
-          - sock: sock
-            num_queues: 3
+          - num_queues: 3
             queue_size: 2
             cache_size: 4
             dax: true
             tag: tag
+            socket: socket
             id: id
-          - sock: sock
-            num_queues: 3
+          - num_queues: 3
             queue_size: 2
             cache_size: 4
             dax: true
             tag: tag
+            socket: socket
             id: id
           vsock:
-            sock: sock
             iommu: false
+            socket: socket
             id: id
             cid: 3
           pmem:
@@ -436,7 +434,6 @@ components:
           vhost_socket: vhost_socket
           vhost_user: false
           direct: false
-          wce: true
           poll_queue: true
           id: id
         - path: path
@@ -447,7 +444,6 @@ components:
           vhost_socket: vhost_socket
           vhost_user: false
           direct: false
-          wce: true
           poll_queue: true
           id: id
         cpus:
@@ -466,23 +462,23 @@ components:
           iommu: false
           src: /dev/urandom
         fs:
-        - sock: sock
-          num_queues: 3
+        - num_queues: 3
           queue_size: 2
           cache_size: 4
           dax: true
           tag: tag
+          socket: socket
           id: id
-        - sock: sock
-          num_queues: 3
+        - num_queues: 3
           queue_size: 2
           cache_size: 4
           dax: true
           tag: tag
+          socket: socket
           id: id
         vsock:
-          sock: sock
           iommu: false
+          socket: socket
           id: id
           cid: 3
         pmem:
@@ -662,7 +658,6 @@ components:
         vhost_socket: vhost_socket
         vhost_user: false
         direct: false
-        wce: true
         poll_queue: true
         id: id
       properties:
@@ -688,9 +683,6 @@ components:
           type: boolean
         vhost_socket:
           type: string
-        wce:
-          default: true
-          type: boolean
         poll_queue:
           default: true
           type: boolean
@@ -756,17 +748,17 @@ components:
       type: object
     FsConfig:
       example:
-        sock: sock
         num_queues: 3
         queue_size: 2
         cache_size: 4
         dax: true
         tag: tag
+        socket: socket
         id: id
       properties:
         tag:
           type: string
-        sock:
+        socket:
           type: string
         num_queues:
           default: 1
@@ -783,7 +775,7 @@ components:
         id:
           type: string
       required:
-      - sock
+      - socket
       - tag
       type: object
     PmemConfig:
@@ -853,8 +845,8 @@ components:
       type: object
     VsockConfig:
       example:
-        sock: sock
         iommu: false
+        socket: socket
         id: id
         cid: 3
       properties:
@@ -863,7 +855,7 @@ components:
           format: int64
           minimum: 3
           type: integer
-        sock:
+        socket:
           description: Path to UNIX domain socket, used to proxy vsock connections.
           type: string
         iommu:
@@ -873,7 +865,7 @@ components:
           type: string
       required:
       - cid
-      - sock
+      - socket
       type: object
     VmResize:
       example:

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
@@ -12,7 +12,6 @@ Name | Type | Description | Notes
 **QueueSize** | **int32** |  | [optional] [default to 128]
 **VhostUser** | **bool** |  | [optional] [default to false]
 **VhostSocket** | **string** |  | [optional] 
-**Wce** | **bool** |  | [optional] [default to true]
 **PollQueue** | **bool** |  | [optional] [default to true]
 **Id** | **string** |  | [optional] 
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Tag** | **string** |  | 
-**Sock** | **string** |  | 
+**Socket** | **string** |  | 
 **NumQueues** | **int32** |  | [optional] [default to 1]
 **QueueSize** | **int32** |  | [optional] [default to 1024]
 **Dax** | **bool** |  | [optional] [default to true]

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/VsockConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/VsockConfig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cid** | **int64** | Guest Vsock CID | 
-**Sock** | **string** | Path to UNIX domain socket, used to proxy vsock connections. | 
+**Socket** | **string** | Path to UNIX domain socket, used to proxy vsock connections. | 
 **Iommu** | **bool** |  | [optional] [default to false]
 **Id** | **string** |  | [optional] 
 

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
@@ -18,7 +18,6 @@ type DiskConfig struct {
 	QueueSize int32 `json:"queue_size,omitempty"`
 	VhostUser bool `json:"vhost_user,omitempty"`
 	VhostSocket string `json:"vhost_socket,omitempty"`
-	Wce bool `json:"wce,omitempty"`
 	PollQueue bool `json:"poll_queue,omitempty"`
 	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
@@ -11,7 +11,7 @@ package openapi
 // FsConfig struct for FsConfig
 type FsConfig struct {
 	Tag string `json:"tag"`
-	Sock string `json:"sock"`
+	Socket string `json:"socket"`
 	NumQueues int32 `json:"num_queues,omitempty"`
 	QueueSize int32 `json:"queue_size,omitempty"`
 	Dax bool `json:"dax,omitempty"`

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
@@ -13,7 +13,7 @@ type VsockConfig struct {
 	// Guest Vsock CID
 	Cid int64 `json:"cid"`
 	// Path to UNIX domain socket, used to proxy vsock connections.
-	Sock string `json:"sock"`
+	Socket string `json:"socket"`
 	Iommu bool `json:"iommu,omitempty"`
 	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -454,9 +454,6 @@ components:
           default: false
         vhost_socket:
           type: string
-        wce:
-          type: boolean
-          default: true
         poll_queue:
           type: boolean
           default: true
@@ -509,12 +506,12 @@ components:
     FsConfig:
       required:
       - tag
-      - sock
+      - socket
       type: object
       properties:
         tag:
           type: string
-        sock:
+        socket:
           type: string
         num_queues:
           type: integer
@@ -584,7 +581,7 @@ components:
     VsockConfig:
       required:
       - cid
-      - sock
+      - socket
       type: object
       properties:
         cid:
@@ -592,7 +589,7 @@ components:
           format: int64
           minimum: 3
           description: Guest Vsock CID
-        sock:
+        socket:
           type: string
           description: Path to UNIX domain socket, used to proxy vsock connections.
         iommu:


### PR DESCRIPTION
This patch updated the version of cloud-hypervisor to its most recently release [v0.8.0](https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v0.8.0). Also, there are few changes to the clh driver to accommodate the changes from clh's HTTP API.

Major new functionalities added in clh v0.8.0 include Experimental
Snapshot and Restore Support, Experimental ARM64 Support, 5-level guest
paging support, etc. Also, there are quite some bug fixings and CLI/API
changes for cleanup. More details can be found in the release note:
https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v0.8.0.

Fixes: #2771

Signed-off-by: Bo Chen <chen.bo@intel.com>
