### PR TITLE
versions: update QEMU to 5.0.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "4.1.1"
-      tag: "v4.1.1"
+      version: "5.0.0"
+      tag: "v5.0.0"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
New features that can improve/impact in kata containers:
x86:
    VMX features can be enabled/disabled via the "-cpu" flag.
    When nested virtualization is enabled with an option like
    "-cpu Haswell,+vmx", the set of VMX features will also be constrained to
    what was available on the corresponding CPU model.
    New "microvm" machine type that has virtio-mmio instead of PCI, and no ACPI
    support (so no hotplug too). The new machine type is meant as a baseline
    for performance optimizations of QEMU, firmware and guests. While inspired
    by Firecracker it is not entirely compatible with it (for example it does
    not have Firecracker's userspace IP stack and MicroVM Metadata Service).
    Reduce memory footprint when booting uncompressed kernels.
    
ARM:
    We now correctly support more than 256 CPUs when using KVM
    The virt board now supports memory hotplugging, when used with a UEFI
    guest BIOS and ACPI.
    virtio-iommu is now supported with machvirt.
    The Cortex-M7 CPU is now supported.
    
s390:
    Using KVM now explicitly requires a host kernel version of at least 3.15
    (which includes the 'flic' KVM device). This had been broken since QEMU
    2.10 already.
    
ppc64le:
    pseries machine type, now consumes less host resources when running a KVM
    guest with XIVE (with a recent enough host kernel). This allows running
    more concurrent guests with KVM accelerated XIVE.
    NVDIMMs with file backend is now supported and SLOF updated to work with
    iommu_platform=on for virtio devices.

fixes #2354

Signed-off-by: Julio Montes <julio.montes@intel.com>