### PR TITLE
virtcontainer/cgroup: create cgroup manager after creating the network

### DIFF
--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -100,6 +100,10 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 
 	// Move runtime to sandbox cgroup so all process are created there.
 	if s.config.SandboxCgroupOnly {
+		if err := s.createCgroupManager(); err != nil {
+			return nil, err
+		}
+
 		if err := s.setupSandboxCgroup(); err != nil {
 			return nil, err
 		}

--- a/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/virtcontainers/bridgedmacvlan_endpoint.go
@@ -84,7 +84,8 @@ func (endpoint *BridgedMacvlanEndpoint) NetworkPair() *NetworkInterfacePair {
 
 // Attach for virtual endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
-func (endpoint *BridgedMacvlanEndpoint) Attach(h hypervisor) error {
+func (endpoint *BridgedMacvlanEndpoint) Attach(s *Sandbox) error {
+	h := s.hypervisor
 	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual ep")
 		return err

--- a/virtcontainers/device/config/config.go
+++ b/virtcontainers/device/config/config.go
@@ -117,6 +117,10 @@ type DeviceInfo struct {
 	// for a nvdimm device in the guest.
 	Pmem bool
 
+	// ColdPlug specifies whether the device must be cold plugged (true)
+	// or hot plugged (false).
+	ColdPlug bool
+
 	// FileMode permission bits for the device.
 	FileMode os.FileMode
 

--- a/virtcontainers/device/drivers/generic.go
+++ b/virtcontainers/device/drivers/generic.go
@@ -140,6 +140,7 @@ func (device *GenericDevice) Save() persistapi.DeviceState {
 		dss.Major = info.Major
 		dss.Minor = info.Minor
 		dss.DriverOptions = info.DriverOptions
+		dss.ColdPlug = info.ColdPlug
 	}
 	return dss
 }
@@ -155,5 +156,6 @@ func (device *GenericDevice) Load(ds persistapi.DeviceState) {
 		Major:         ds.Major,
 		Minor:         ds.Minor,
 		DriverOptions: ds.DriverOptions,
+		ColdPlug:      ds.ColdPlug,
 	}
 }

--- a/virtcontainers/endpoint.go
+++ b/virtcontainers/endpoint.go
@@ -22,7 +22,7 @@ type Endpoint interface {
 
 	SetProperties(NetworkInfo)
 	SetPciAddr(string)
-	Attach(hypervisor) error
+	Attach(*Sandbox) error
 	Detach(netNsCreated bool, netNsPath string) error
 	HotAttach(h hypervisor) error
 	HotDetach(h hypervisor, netNsCreated bool, netNsPath string) error

--- a/virtcontainers/ipvlan_endpoint.go
+++ b/virtcontainers/ipvlan_endpoint.go
@@ -87,7 +87,8 @@ func (endpoint *IPVlanEndpoint) NetworkPair() *NetworkInterfacePair {
 
 // Attach for virtual endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
-func (endpoint *IPVlanEndpoint) Attach(h hypervisor) error {
+func (endpoint *IPVlanEndpoint) Attach(s *Sandbox) error {
+	h := s.hypervisor
 	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual ep")
 		return err

--- a/virtcontainers/macvtap_endpoint.go
+++ b/virtcontainers/macvtap_endpoint.go
@@ -56,8 +56,9 @@ func (endpoint *MacvtapEndpoint) SetProperties(properties NetworkInfo) {
 }
 
 // Attach for macvtap endpoint passes macvtap device to the hypervisor.
-func (endpoint *MacvtapEndpoint) Attach(h hypervisor) error {
+func (endpoint *MacvtapEndpoint) Attach(s *Sandbox) error {
 	var err error
+	h := s.hypervisor
 
 	endpoint.VMFds, err = createMacvtapFds(endpoint.EndpointProperties.Iface.Index, int(h.hypervisorConfig().NumVCPUs))
 	if err != nil {

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1270,7 +1270,7 @@ func (n *Network) Run(networkNSPath string, cb func() error) error {
 }
 
 // Add adds all needed interfaces inside the network namespace.
-func (n *Network) Add(ctx context.Context, config *NetworkConfig, hypervisor hypervisor, hotplug bool) ([]Endpoint, error) {
+func (n *Network) Add(ctx context.Context, config *NetworkConfig, s *Sandbox, hotplug bool) ([]Endpoint, error) {
 	span, _ := n.trace(ctx, "add")
 	defer span.Finish()
 
@@ -1283,11 +1283,11 @@ func (n *Network) Add(ctx context.Context, config *NetworkConfig, hypervisor hyp
 		for _, endpoint := range endpoints {
 			networkLogger().WithField("endpoint-type", endpoint.Type()).WithField("hotplug", hotplug).Info("Attaching endpoint")
 			if hotplug {
-				if err := endpoint.HotAttach(hypervisor); err != nil {
+				if err := endpoint.HotAttach(s.hypervisor); err != nil {
 					return err
 				}
 			} else {
-				if err := endpoint.Attach(hypervisor); err != nil {
+				if err := endpoint.Attach(s); err != nil {
 					return err
 				}
 			}

--- a/virtcontainers/persist/api/device.go
+++ b/virtcontainers/persist/api/device.go
@@ -103,6 +103,10 @@ type DeviceState struct {
 	Major int64
 	Minor int64
 
+	// ColdPlug specifies whether the device must be cold plugged (true)
+	// or hot plugged (false).
+	ColdPlug bool
+
 	// DriverOptions is specific options for each device driver
 	// for example, for BlockDevice, we can set DriverOptions["blockDriver"]="virtio-blk"
 	DriverOptions map[string]string

--- a/virtcontainers/physical_endpoint.go
+++ b/virtcontainers/physical_endpoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/device/drivers"
 	persistapi "github.com/kata-containers/runtime/virtcontainers/persist/api"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/cgroups"
 	"github.com/safchain/ethtool"
 )
 
@@ -72,27 +73,29 @@ func (endpoint *PhysicalEndpoint) NetworkPair() *NetworkInterfacePair {
 
 // Attach for physical endpoint binds the physical network interface to
 // vfio-pci and adds device to the hypervisor with vfio-passthrough.
-func (endpoint *PhysicalEndpoint) Attach(h hypervisor) error {
+func (endpoint *PhysicalEndpoint) Attach(s *Sandbox) error {
 	// Unbind physical interface from host driver and bind to vfio
 	// so that it can be passed to qemu.
-	if err := bindNICToVFIO(endpoint); err != nil {
+	vfioPath, err := bindNICToVFIO(endpoint)
+	if err != nil {
 		return err
 	}
 
-	// TODO: use device manager as general device management entrance
-	var vendorID, deviceID string
-	if splits := strings.Split(endpoint.VendorDeviceID, " "); len(splits) == 2 {
-		vendorID = splits[0]
-		deviceID = splits[1]
+	c, err := cgroups.DeviceToCgroupDevice(vfioPath)
+	if err != nil {
+		return err
 	}
 
-	d := config.VFIODev{
-		BDF:      endpoint.BDF,
-		VendorID: vendorID,
-		DeviceID: deviceID,
+	d := config.DeviceInfo{
+		ContainerPath: c.Path,
+		DevType:       string(c.Type),
+		Major:         c.Major,
+		Minor:         c.Minor,
+		ColdPlug:      true,
 	}
 
-	return h.addDevice(d, vfioDev)
+	_, err = s.AddDevice(d)
+	return err
 }
 
 // Detach for physical endpoint unbinds the physical network interface from vfio-pci

--- a/virtcontainers/physical_endpoint.go
+++ b/virtcontainers/physical_endpoint.go
@@ -202,7 +202,7 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 	return physicalEndpoint, nil
 }
 
-func bindNICToVFIO(endpoint *PhysicalEndpoint) error {
+func bindNICToVFIO(endpoint *PhysicalEndpoint) (string, error) {
 	return drivers.BindDevicetoVFIO(endpoint.BDF, endpoint.Driver, endpoint.VendorDeviceID)
 }
 

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1768,7 +1768,7 @@ func (q *qemu) addDevice(devInfo interface{}, devType deviceType) error {
 	case config.VFIODev:
 		q.qemuConfig.Devices = q.arch.appendVFIODevice(q.qemuConfig.Devices, v)
 	default:
-		break
+		q.Logger().WithField("dev-type", v).Warn("Could not append device: unsupported device type")
 	}
 
 	return err

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -876,7 +876,7 @@ func (s *Sandbox) createNetwork() error {
 	// after vm is started.
 	if s.factory == nil {
 		// Add the network
-		endpoints, err := s.network.Add(s.ctx, &s.config.NetworkConfig, s.hypervisor, false)
+		endpoints, err := s.network.Add(s.ctx, &s.config.NetworkConfig, s, false)
 		if err != nil {
 			return err
 		}
@@ -1044,7 +1044,7 @@ func (s *Sandbox) startVM() (err error) {
 	// In case of vm factory, network interfaces are hotplugged
 	// after vm is started.
 	if s.factory != nil {
-		endpoints, err := s.network.Add(s.ctx, &s.config.NetworkConfig, s.hypervisor, true)
+		endpoints, err := s.network.Add(s.ctx, &s.config.NetworkConfig, s, true)
 		if err != nil {
 			return err
 		}

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1769,7 +1769,16 @@ func (s *Sandbox) AppendDevice(device api.Device) error {
 	switch device.DeviceType() {
 	case config.VhostUserSCSI, config.VhostUserNet, config.VhostUserBlk, config.VhostUserFS:
 		return s.hypervisor.addDevice(device.GetDeviceInfo().(*config.VhostUserDeviceAttrs), vhostuserDev)
+	case config.DeviceVFIO:
+		vfioDevs := device.GetDeviceInfo().([]*config.VFIODev)
+		for _, d := range vfioDevs {
+			return s.hypervisor.addDevice(*d, vfioDev)
+		}
+	default:
+		s.Logger().WithField("device-type", device.DeviceType()).
+			Warn("Could not append device: unsupported device type")
 	}
+
 	return fmt.Errorf("unsupported device type")
 }
 

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -606,10 +606,6 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 		}
 	}
 
-	if err := s.createCgroupManager(); err != nil {
-		return nil, err
-	}
-
 	agentConfig, err := newAgentConfig(sandboxConfig.AgentType, sandboxConfig.AgentConfig)
 	if err != nil {
 		return nil, err
@@ -737,6 +733,12 @@ func fetchSandbox(ctx context.Context, sandboxID string) (sandbox *Sandbox, err 
 	sandbox, err = createSandbox(ctx, config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sandbox with config %+v: %v", config, err)
+	}
+
+	if sandbox.config.SandboxCgroupOnly {
+		if err := sandbox.createCgroupManager(); err != nil {
+			return nil, err
+		}
 	}
 
 	// This sandbox already exists, we don't need to recreate the containers in the guest.

--- a/virtcontainers/tap_endpoint.go
+++ b/virtcontainers/tap_endpoint.go
@@ -64,7 +64,7 @@ func (endpoint *TapEndpoint) SetProperties(properties NetworkInfo) {
 }
 
 // Attach for tap endpoint adds the tap interface to the hypervisor.
-func (endpoint *TapEndpoint) Attach(h hypervisor) error {
+func (endpoint *TapEndpoint) Attach(s *Sandbox) error {
 	return fmt.Errorf("TapEndpoint does not support Attach, if you're using docker please use --net none")
 }
 

--- a/virtcontainers/tuntap_endpoint.go
+++ b/virtcontainers/tuntap_endpoint.go
@@ -66,7 +66,8 @@ func (endpoint *TuntapEndpoint) SetProperties(properties NetworkInfo) {
 }
 
 // Attach for tap endpoint adds the tap interface to the hypervisor.
-func (endpoint *TuntapEndpoint) Attach(h hypervisor) error {
+func (endpoint *TuntapEndpoint) Attach(s *Sandbox) error {
+	h := s.hypervisor
 	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual endpoint")
 		return err

--- a/virtcontainers/veth_endpoint.go
+++ b/virtcontainers/veth_endpoint.go
@@ -87,7 +87,8 @@ func (endpoint *VethEndpoint) SetProperties(properties NetworkInfo) {
 
 // Attach for veth endpoint bridges the network pair and adds the
 // tap interface of the network pair to the hypervisor.
-func (endpoint *VethEndpoint) Attach(h hypervisor) error {
+func (endpoint *VethEndpoint) Attach(s *Sandbox) error {
+	h := s.hypervisor
 	if err := xConnectVMNetwork(endpoint, h); err != nil {
 		networkLogger().WithError(err).Error("Error bridging virtual endpoint")
 		return err

--- a/virtcontainers/vhostuser_endpoint.go
+++ b/virtcontainers/vhostuser_endpoint.go
@@ -74,7 +74,7 @@ func (endpoint *VhostUserEndpoint) NetworkPair() *NetworkInterfacePair {
 }
 
 // Attach for vhostuser endpoint
-func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
+func (endpoint *VhostUserEndpoint) Attach(s *Sandbox) error {
 	// Generate a unique ID to be used for hypervisor commandline fields
 	randBytes, err := utils.GenerateRandomBytes(8)
 	if err != nil {
@@ -89,7 +89,7 @@ func (endpoint *VhostUserEndpoint) Attach(h hypervisor) error {
 		Type:       config.VhostUserNet,
 	}
 
-	return h.addDevice(d, vhostuserDev)
+	return s.hypervisor.addDevice(d, vhostuserDev)
 }
 
 // Detach for vhostuser endpoint

--- a/virtcontainers/vhostuser_endpoint_test.go
+++ b/virtcontainers/vhostuser_endpoint_test.go
@@ -78,9 +78,11 @@ func TestVhostUserEndpointAttach(t *testing.T) {
 		EndpointType: VhostUserEndpointType,
 	}
 
-	h := &mockHypervisor{}
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+	}
 
-	err := v.Attach(h)
+	err := v.Attach(s)
 	assert.NoError(err)
 }
 


### PR DESCRIPTION
Create the cgroup manager once the network has been created, this way the
list of device will include the network VFIO devices attached to the sandbox,
when the physical enpoint is the network driver.

fixes #2774

Signed-off-by: Julio Montes <julio.montes@intel.com>

 @yadzhang please take a look