### PR TITLE
[backport stable-1.11] shimv2: Use BUILDTAGS when building shimv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 	$(QUIET_BUILD)(cd $(CLI_DIR) && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
 
 $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
-	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) -i -o $@ .)
+	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDTAGS) -i -o $@ .)
 
 .PHONY: \
 	check \


### PR DESCRIPTION
If not used, SELinux support will never be enabled.

It's important to mention that this issue has been already been fixed on
kata-containers/kata-containers, unintentionally, as part of
https://github.com/kata-containers/kata-containers/commit/e90c5d45b3ceef

Fixes: #2776

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit c51baf8df595bb19b84366860d07bd89841320c5)