### PR TITLE
dnm: virtiofsd: clh: experiment with threads

### DIFF
--- a/virtcontainers/virtiofsd.go
+++ b/virtcontainers/virtiofsd.go
@@ -168,6 +168,8 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		"-o", "source=" + v.sourcePath,
 		// fd number of vhost-user socket
 		fmt.Sprintf("--fd=%v", FdSocketNumber),
+		// --thread-pool-size=NUM     thread pool size limit (default 64)
+		"--thread-pool-size=5",
 	}
 
 	if v.debug {


### PR DESCRIPTION
Experment to track threads in metrics CI.
This should reduce the number of threads in ported threads.

DO not merge the threads sould be defined by user
or based in cgroup size.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>