### PR TITLE
[backport 1.11] fix logs parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 	$(QUIET_BUILD)(cd $(CLI_DIR) && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
 
 $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
-	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) -i -o $@ .)
+	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDTAGS) -i -o $@ .)
 
 .PHONY: \
 	check \

--- a/virtcontainers/api.go
+++ b/virtcontainers/api.go
@@ -14,6 +14,7 @@ import (
 	deviceApi "github.com/kata-containers/runtime/virtcontainers/device/api"
 	deviceConfig "github.com/kata-containers/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/runtime/virtcontainers/persist"
+	"github.com/kata-containers/runtime/virtcontainers/pkg/cgroups"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/compatoci"
 	vcTypes "github.com/kata-containers/runtime/virtcontainers/pkg/types"
 	"github.com/kata-containers/runtime/virtcontainers/store"
@@ -53,6 +54,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 	compatoci.SetLogger(virtLog)
 	store.SetLogger(virtLog)
 	deviceConfig.SetLogger(virtLog)
+	cgroups.SetLogger(virtLog)
 }
 
 // CreateSandbox is the virtcontainers sandbox creation entry point.

--- a/virtcontainers/pkg/cgroups/manager.go
+++ b/virtcontainers/pkg/cgroups/manager.go
@@ -59,6 +59,13 @@ var (
 	cgroupsLogger = logrus.WithField("source", "virtcontainers/pkg/cgroups")
 )
 
+// SetLogger sets up a logger for this pkg
+func SetLogger(logger *logrus.Entry) {
+	fields := cgroupsLogger.Data
+
+	cgroupsLogger = logger.WithFields(fields)
+}
+
 func EnableSystemdCgroup() {
 	systemd := true
 	systemdCgroup = &systemd


### PR DESCRIPTION
Call the `pkg/cgroups` package `SetLogger()` function to ensure all its log
records contain all required structured logging fields.

Fixes: #2782

Signed-off-by: Julio Montes <julio.montes@intel.com>