### PR TITLE
truncate the kata-runtime log file to avoid OOM

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -296,6 +296,14 @@ func beforeSubcommands(c *cli.Context) error {
 		ignoreConfigLogs = true
 	} else {
 		if path := c.GlobalString("log"); path != "" {
+			// avoid log.json file too large consume the memory footprint in the tmpfs,
+			// truncate the log.json file every time before kata subcommand is executed
+			if path != "/dev/null" && katautils.FileExists(path) {
+				if err := os.Truncate(path, 0); err != nil {
+					return err
+				}
+			}
+
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0640)
 			if err != nil {
 				return err


### PR DESCRIPTION
reason: If huge times of kata-runtime exec command are called, kata-runtime log file
size will increase rapidly and consume the memory footprint in the run dir, which may
trigger the oom event. So fix this problem by truncate the kata-runtime log file before
kata-runtime subcommand is executed.

Fixes: #2790

Signed-off-by: flyflypeng <woshijpfgg@gmail.com>