### PR TITLE
clh: Remove the use of deprecated '--memory file=' parameter

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -221,7 +221,6 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	// Set initial memomory size of the virtual machine
 	// Convert to int64 openApiClient only support int64
 	clh.vmconfig.Memory.Size = int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes())
-	clh.vmconfig.Memory.File = "/dev/shm"
 	// shared memory should be enabled if using vhost-user(kata uses virtiofsd)
 	clh.vmconfig.Memory.Shared = true
 	hostMemKb, err := getHostMemorySizeKb(procMemInfo)


### PR DESCRIPTION
Along with the release of cloud-hypervisor v0.8.0, this option has been
deprecated. clh now enforces to use the alternative controls,
e.g. "shared" and "hugepages", which can infer the backing file
paths. Also, we don't use "hugepages" in kata, so we are fine now as the
"shared" control  is already enabled.

Fixes: #2803

Signed-off-by: Bo Chen <chen.bo@intel.com>