### PR TITLE
Fixup systemd cgroup handling

### DIFF
--- a/virtcontainers/pkg/cgroups/manager.go
+++ b/virtcontainers/pkg/cgroups/manager.go
@@ -53,9 +53,6 @@ const (
 )
 
 var (
-	// If set to true, expects cgroupsPath to be of form "slice:prefix:name", otherwise cgroups creation will fail
-	systemdCgroup *bool
-
 	cgroupsLogger = logrus.WithField("source", "virtcontainers/pkg/cgroups")
 )
 
@@ -64,18 +61,6 @@ func SetLogger(logger *logrus.Entry) {
 	fields := cgroupsLogger.Data
 
 	cgroupsLogger = logger.WithFields(fields)
-}
-
-func EnableSystemdCgroup() {
-	systemd := true
-	systemdCgroup = &systemd
-}
-
-func UseSystemdCgroup() bool {
-	if systemdCgroup != nil {
-		return *systemdCgroup
-	}
-	return false
 }
 
 // returns the list of devices that a hypervisor may need

--- a/virtcontainers/pkg/cgroups/manager.go
+++ b/virtcontainers/pkg/cgroups/manager.go
@@ -107,7 +107,6 @@ func hypervisorDevices() []specs.LinuxDeviceCgroup {
 // New creates a new CgroupManager
 func New(config *Config) (*Manager, error) {
 	var err error
-	useSystemdCgroup := UseSystemdCgroup()
 
 	devices := config.Resources.Devices
 	devices = append(devices, hypervisorDevices()...)
@@ -124,6 +123,9 @@ func New(config *Config) (*Manager, error) {
 
 	cgroups := config.Cgroups
 	cgroupPaths := config.CgroupPaths
+
+	// determine if we are utilizing systemd managed cgroups based on the path provided
+	useSystemdCgroup := IsSystemdCgroup(config.CgroupPath)
 
 	// Create a new cgroup if the current one is nil
 	// this cgroups must be saved later
@@ -220,7 +222,14 @@ func (m *Manager) moveToParent() error {
 	m.Lock()
 	defer m.Unlock()
 	for _, cgroupPath := range m.mgr.GetPaths() {
+
 		pids, err := readPids(cgroupPath)
+		// possible that the cgroupPath doesn't exist. If so, skip:
+		if os.IsNotExist(err) {
+			// The cgroup is not present on the filesystem: no pids to move. The systemd cgroup
+			// manager lists all of the subsystems, including those that are not actually being managed.
+			continue
+		}
 		if err != nil {
 			return err
 		}
@@ -286,7 +295,10 @@ func (m *Manager) GetPaths() map[string]string {
 func (m *Manager) Destroy() error {
 	// cgroup can't be destroyed if it contains running processes
 	if err := m.moveToParent(); err != nil {
-		return fmt.Errorf("Could not move processes into parent cgroup: %v", err)
+		// If the process migration to the parent cgroup fails, then
+		// we expect the Destroy to fail as well. Let's log an error here
+		// and attempt to execute the Destroy still to help cleanup the hosts' FS.
+		m.logger().WithError(err).Error("Could not move processes into parent cgroup")
 	}
 
 	m.Lock()

--- a/virtcontainers/pkg/cgroups/manager_test.go
+++ b/virtcontainers/pkg/cgroups/manager_test.go
@@ -11,34 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEnableSystemdCgroup(t *testing.T) {
-	assert := assert.New(t)
-
-	orgSystemdCgroup := systemdCgroup
-	defer func() {
-		systemdCgroup = orgSystemdCgroup
-	}()
-
-	useSystemdCgroup := UseSystemdCgroup()
-	if systemdCgroup != nil {
-		assert.Equal(*systemdCgroup, useSystemdCgroup)
-	} else {
-		assert.False(useSystemdCgroup)
-	}
-
-	EnableSystemdCgroup()
-	assert.True(UseSystemdCgroup())
-}
-
+//very very basic test; should be expanded
 func TestNew(t *testing.T) {
 	assert := assert.New(t)
-	useSystemdCgroup := false
-	orgSystemdCgroup := systemdCgroup
-	defer func() {
-		systemdCgroup = orgSystemdCgroup
-	}()
-	systemdCgroup = &useSystemdCgroup
 
+	// create a cgroupfs cgroup manager
 	c := &Config{
 		Cgroups:    nil,
 		CgroupPath: "",
@@ -48,8 +25,14 @@ func TestNew(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(mgr.mgr)
 
-	useSystemdCgroup = true
-	mgr, err = New(c)
-	assert.Error(err)
-	assert.Nil(mgr)
+	// create a systemd cgroup manager
+	s := &Config{
+		Cgroups:    nil,
+		CgroupPath: "system.slice:kubepod:container",
+	}
+
+	mgr, err = New(s)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
 }

--- a/virtcontainers/pkg/cgroups/utils_test.go
+++ b/virtcontainers/pkg/cgroups/utils_test.go
@@ -22,8 +22,8 @@ func TestIsSystemdCgroup(t *testing.T) {
 		path     string
 		expected bool
 	}{
-		{"slice:kata:afhts2e5d4g5s", true},
-		{"slice.system:kata:afhts2e5d4g5s", true},
+		{"foo.slice:kata:afhts2e5d4g5s", true},
+		{"system.slice:kata:afhts2e5d4g5s", true},
 		{"/kata/afhts2e5d4g5s", false},
 		{"a:b:c:d", false},
 		{":::", false},
@@ -78,9 +78,9 @@ func TestValidCgroupPath(t *testing.T) {
 		{":a:b", true, true},
 		{"@:@:@", true, true},
 
-		// valid system paths
-		{"slice:kata:55555", true, false},
-		{"slice.system:kata:afhts2e5d4g5s", true, false},
+		// valid systemd paths
+		{"x.slice:kata:55555", true, false},
+		{"system.slice:kata:afhts2e5d4g5s", true, false},
 	} {
 		path, err := ValidCgroupPath(t.path, t.systemdCgroup)
 		if t.error {

--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -2268,7 +2268,7 @@ func (s *Sandbox) getSandboxCPUSet() (string, error) {
 		if ctr.Resources.CPU != nil {
 			currSet, err := cpuset.Parse(ctr.Resources.CPU.Cpus)
 			if err != nil {
-				return "", fmt.Errorf("unable to parse CPUset for container %s", ctr.ID)
+				return "", fmt.Errorf("unable to parse CPUset for container %s: %v", ctr.ID, err)
 			}
 			result = result.Union(currSet)
 		}


### PR DESCRIPTION
Systemd cgroups aren't supported today in Kata. This is a first pass at properly creating applicable subsystem croups when using a systemd CPU manager.

- [x] - Tested on Fedora 31 with legacy systemd cgroups (ie, not cgroups v2/unified). Verified cgroups are created in the correct cgroup-path.
- [x] - Tested on Fedora 31 with K8S/Containerd, and see the expected cgroup creation (and settings for cpusets).
