### PR TITLE
Fix kubectl cp cannot end, because kata agent stdin not close, when no stdin.

### DIFF
--- a/containerd-shim-v2/stream.go
+++ b/containerd-shim-v2/stream.go
@@ -95,6 +95,7 @@ func ioCopy(exitch chan struct{}, tty *ttyIO, stdinPipe io.WriteCloser, stdoutPi
 			p := bufPool.Get().(*[]byte)
 			defer bufPool.Put(p)
 			io.CopyBuffer(stdinPipe, tty.Stdin, *p)
+			stdinPipe.Close()
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
Fix kubectl cp cannot end, because kata agent stdin not close, when no stdin.

Fixes: #2061

Signed-off-by: quanweiZhou <edensky01@163.com>
Signed-off-by: quanweiZhou <quanweiZhou@linux.alibaba.com>