### PR TITLE
virtcontainers: vhost-user-blk/scsi are block device nodes

### DIFF
--- a/virtcontainers/device/manager/utils.go
+++ b/virtcontainers/device/manager/utils.go
@@ -139,10 +139,10 @@ func isLargeBarSpace(resourcePath string) (bool, error) {
 
 // isVhostUserBlk checks if the device is a VhostUserBlk device.
 func isVhostUserBlk(devInfo config.DeviceInfo) bool {
-	return devInfo.Major == config.VhostUserBlkMajor
+	return devInfo.DevType == "b" && devInfo.Major == config.VhostUserBlkMajor
 }
 
 // isVhostUserSCSI checks if the device is a VhostUserSCSI device.
 func isVhostUserSCSI(devInfo config.DeviceInfo) bool {
-	return devInfo.Major == config.VhostUserSCSIMajor
+	return devInfo.DevType == "b" && devInfo.Major == config.VhostUserSCSIMajor
 }

--- a/virtcontainers/device/manager/utils_test.go
+++ b/virtcontainers/device/manager/utils_test.go
@@ -58,36 +58,50 @@ func TestIsBlock(t *testing.T) {
 
 func TestIsVhostUserBlk(t *testing.T) {
 	type testData struct {
+		devType  string
 		major    int64
 		expected bool
 	}
 
 	data := []testData{
-		{config.VhostUserBlkMajor, true},
-		{config.VhostUserSCSIMajor, false},
-		{240, false},
+		{"b", config.VhostUserBlkMajor, true},
+		{"c", config.VhostUserBlkMajor, false},
+		{"b", config.VhostUserSCSIMajor, false},
+		{"c", config.VhostUserSCSIMajor, false},
+		{"b", 240, false},
 	}
 
 	for _, d := range data {
-		isVhostUserBlk := isVhostUserBlk(config.DeviceInfo{Major: d.major})
+		isVhostUserBlk := isVhostUserBlk(
+			config.DeviceInfo{
+				DevType: d.devType,
+				Major:   d.major,
+			})
 		assert.Equal(t, d.expected, isVhostUserBlk)
 	}
 }
 
 func TestIsVhostUserSCSI(t *testing.T) {
 	type testData struct {
+		devType  string
 		major    int64
 		expected bool
 	}
 
 	data := []testData{
-		{config.VhostUserBlkMajor, false},
-		{config.VhostUserSCSIMajor, true},
-		{240, false},
+		{"b", config.VhostUserBlkMajor, false},
+		{"c", config.VhostUserBlkMajor, false},
+		{"b", config.VhostUserSCSIMajor, true},
+		{"c", config.VhostUserSCSIMajor, false},
+		{"b", 240, false},
 	}
 
 	for _, d := range data {
-		isVhostUserSCSI := isVhostUserSCSI(config.DeviceInfo{Major: d.major})
+		isVhostUserSCSI := isVhostUserSCSI(
+			config.DeviceInfo{
+				DevType: d.devType,
+				Major:   d.major,
+			})
 		assert.Equal(t, d.expected, isVhostUserSCSI)
 	}
 }


### PR DESCRIPTION
When checking if a device is an emulated vhost-user-blk or
vhost-user-scsi one, we should not only check for their major number but
also their device node type. They must be block devices.

Fixes: #2822

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>