### PR TITLE
qemu: add annotations for iommu_platform for s390x virtio devices

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -420,11 +420,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:e800a48df8e5709baa6b78062d47d43829cddbc54871e049e8bbeb1aaf50fe40"
+  digest = "1:e4b04b215d8cb0310c06f4a5af631f7df6648ffebf1911d3f4de7f3ea605db87"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "6c3315ba8a4262df4300b735b2c53ce3b15d21dd"
+  revision = "547a8518098aaa71c5d5d7a370f211e00161016b"
 
 [[projects]]
   digest = "1:f03425555be45830e86903bba35dd82a1b76e322beff9873e6b888d2b054c217"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "6c3315ba8a4262df4300b735b2c53ce3b15d21dd"
+  revision = "547a8518098aaa71c5d5d7a370f211e00161016b"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -195,6 +195,10 @@ vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 # command line: intel_iommu=on,iommu=pt
 #enable_iommu = true
 
+# Enable IOMMU_PLATFORM, default false
+# Enabling this will result in the VM device having iommu_platform=on set
+#enable_iommu_platform = true
+
 # Enable file based guest memory support. The default is an empty string which
 # will disable this feature. In the case of virtio-fs, this is enabled
 # automatically and '/dev/shm' is used as the backing folder.

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -202,6 +202,10 @@ vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 # command line: intel_iommu=on,iommu=pt
 #enable_iommu = true
 
+# Enable IOMMU_PLATFORM, default false
+# Enabling this will result in the VM device having iommu_platform=on set
+#enable_iommu_platform = true
+
 # Enable file based guest memory support. The default is an empty string which
 # will disable this feature. In the case of virtio-fs, this is enabled
 # automatically and '/dev/shm' is used as the backing folder.

--- a/pkg/katautils/config-settings.go.in
+++ b/pkg/katautils/config-settings.go.in
@@ -40,6 +40,7 @@ const defaultEnableIOThreads bool = false
 const defaultEnableMemPrealloc bool = false
 const defaultEnableHugePages bool = false
 const defaultEnableIOMMU bool = false
+const defaultEnableIOMMUPlatform bool = false
 const defaultFileBackedMemRootDir string = ""
 const defaultEnableSwap bool = false
 const defaultEnableDebug bool = false

--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -121,6 +121,7 @@ type hypervisor struct {
 	HugePages               bool     `toml:"enable_hugepages"`
 	VirtioMem               bool     `toml:"enable_virtio_mem"`
 	IOMMU                   bool     `toml:"enable_iommu"`
+	IOMMUPlatform           bool     `toml:"enable_iommu_platform"`
 	FileBackedMemRootDir    string   `toml:"file_mem_backend"`
 	Swap                    bool     `toml:"enable_swap"`
 	Debug                   bool     `toml:"enable_debug"`
@@ -444,6 +445,15 @@ func (h hypervisor) getInitrdAndImage() (initrd string, image string, err error)
 	return
 }
 
+func (h hypervisor) getIOMMUPlatform() bool {
+	if h.IOMMUPlatform {
+		kataUtilsLogger.Info("IOMMUPlatform is enabled by default.")
+	} else {
+		kataUtilsLogger.Info("IOMMUPlatform is disabled by default.")
+	}
+	return h.IOMMUPlatform
+}
+
 func (p proxy) path() (string, error) {
 	path := p.Path
 	if path == "" {
@@ -671,6 +681,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		MemPrealloc:             h.MemPrealloc,
 		HugePages:               h.HugePages,
 		IOMMU:                   h.IOMMU,
+		IOMMUPlatform:           h.getIOMMUPlatform(),
 		FileBackedMemRootDir:    h.FileBackedMemRootDir,
 		Mlock:                   !h.Swap,
 		Debug:                   h.Debug,
@@ -1115,6 +1126,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		MemPrealloc:             defaultEnableMemPrealloc,
 		HugePages:               defaultEnableHugePages,
 		IOMMU:                   defaultEnableIOMMU,
+		IOMMUPlatform:           defaultEnableIOMMUPlatform,
 		FileBackedMemRootDir:    defaultFileBackedMemRootDir,
 		Mlock:                   !defaultEnableSwap,
 		Debug:                   defaultEnableDebug,

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -406,6 +406,9 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", fsdev.ROMFile))
 	}
 	if fsdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", fsdev.DevNo))
 	}
 
@@ -537,6 +540,9 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	}
 
 	if cdev.Driver == VirtioSerial && cdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", cdev.DevNo))
 	}
 
@@ -804,6 +810,9 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 	}
 
 	if netdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", netdev.DevNo))
 	}
 
@@ -937,6 +946,9 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	}
 
 	if dev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", dev.DevNo))
 	}
 
@@ -1528,6 +1540,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 
 	if scsiCon.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			devParams = append(devParams, ",iommu_platform=on")
+		}
 		devParams = append(devParams, fmt.Sprintf("devno=%s", scsiCon.DevNo))
 	}
 
@@ -1710,6 +1725,9 @@ func (vsock VSOCKDevice) QemuParams(config *Config) []string {
 	}
 
 	if vsock.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", vsock.DevNo))
 	}
 
@@ -1780,6 +1798,9 @@ func (v RngDevice) QemuParams(config *Config) []string {
 	}
 
 	if v.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", v.DevNo))
 	}
 
@@ -2125,6 +2146,9 @@ type Knobs struct {
 
 	// Exit instead of rebooting
 	NoReboot bool
+
+	// IOMMUPlatform will enable IOMMU for supported devices
+	IOMMUPlatform bool
 }
 
 // IOThread allows IO to be performed on a separate thread.

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -364,6 +364,9 @@ type HypervisorConfig struct {
 	// IOMMU specifies if the VM should have a vIOMMU
 	IOMMU bool
 
+	// IOMMUPlatform is used to indicate if IOMMU_PLATFORM is enabled for supported devices
+	IOMMUPlatform bool
+
 	// Realtime Used to enable/disable realtime
 	Realtime bool
 

--- a/virtcontainers/pkg/annotations/annotations.go
+++ b/virtcontainers/pkg/annotations/annotations.go
@@ -154,6 +154,9 @@ const (
 	// Iommu is a sandbox annotation to specify if the VM should have a vIOMMU device
 	IOMMU = kataAnnotHypervisorPrefix + "enable_iommu"
 
+	// Enable Hypervisor Devices IOMMU_PLATFORM
+	IOMMUPlatform = kataAnnotHypervisorPrefix + "enable_iommu_platform"
+
 	// FileBackedMemRootDir is a sandbox annotation to soecify file based memory backend root directory
 	FileBackedMemRootDir = kataAnnotHypervisorPrefix + "file_mem_backend"
 

--- a/virtcontainers/pkg/oci/utils.go
+++ b/virtcontainers/pkg/oci/utils.go
@@ -557,6 +557,15 @@ func addHypervisorMemoryOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig
 
 		sbConfig.HypervisorConfig.IOMMU = iommu
 	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.IOMMUPlatform]; ok {
+		deviceIOMMU, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("Error parsing annotation for enable_iommu_platform: Please specify boolean value 'true|false'")
+		}
+
+		sbConfig.HypervisorConfig.IOMMUPlatform = deviceIOMMU
+	}
 	return nil
 }
 

--- a/virtcontainers/pkg/oci/utils_test.go
+++ b/virtcontainers/pkg/oci/utils_test.go
@@ -792,6 +792,7 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	ocispec.Annotations[vcAnnotations.HotplugVFIOOnRootBus] = "true"
 	ocispec.Annotations[vcAnnotations.PCIeRootPort] = "2"
 	ocispec.Annotations[vcAnnotations.EntropySource] = "/dev/urandom"
+	ocispec.Annotations[vcAnnotations.IOMMUPlatform] = "true"
 
 	addAnnotations(ocispec, &config)
 	assert.Equal(config.HypervisorConfig.NumVCPUs, uint32(1))
@@ -825,6 +826,7 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	assert.Equal(config.HypervisorConfig.HotplugVFIOOnRootBus, true)
 	assert.Equal(config.HypervisorConfig.PCIeRootPort, uint32(2))
 	assert.Equal(config.HypervisorConfig.EntropySource, "/dev/urandom")
+	assert.Equal(config.HypervisorConfig.IOMMUPlatform, true)
 
 	// In case an absurd large value is provided, the config value if not over-ridden
 	ocispec.Annotations[vcAnnotations.DefaultVCPUs] = "655536"

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -486,15 +486,16 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	}
 
 	knobs := govmmQemu.Knobs{
-		NoUserConfig: true,
-		NoDefaults:   true,
-		NoGraphic:    true,
-		NoReboot:     true,
-		Daemonize:    true,
-		MemPrealloc:  q.config.MemPrealloc,
-		HugePages:    q.config.HugePages,
-		Realtime:     q.config.Realtime,
-		Mlock:        q.config.Mlock,
+		NoUserConfig:  true,
+		NoDefaults:    true,
+		NoGraphic:     true,
+		NoReboot:      true,
+		Daemonize:     true,
+		MemPrealloc:   q.config.MemPrealloc,
+		HugePages:     q.config.HugePages,
+		Realtime:      q.config.Realtime,
+		Mlock:         q.config.Mlock,
+		IOMMUPlatform: q.config.IOMMUPlatform,
 	}
 
 	kernelPath, err := q.config.KernelAssetPath()


### PR DESCRIPTION
qemu: Add iommu annotations for qemu for s390x ccw, so that the supported devices can make use of that.
for virtcontainers/hypervisor

add iommu_platform=on option for virtio devices

Fixes https://github.com/kata-containers/runtime/issues/2830

Signed-off-by: Qi Feng Huo <huoqif@cn.ibm.com>