### PR TITLE
dnm: test new virtiofs kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The runtime is
 [OCI](https://github.com/opencontainers/runtime-spec)-compatible,
 [CRI-O](https://github.com/cri-o/cri-o)-compatible, and
 [Containerd](https://github.com/containerd/containerd)-compatible,
- allowing it
+allowing it
 to work seamlessly with both Docker and Kubernetes respectively.
 
 ## License


### PR DESCRIPTION
PR to check if virtiofs new kernel version does not break CI.

Depends-on: github.com/kata-containers/packaging#1096

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>