### PR TITLE
[backport | stable-1.11] sandbox: Stop and clean up containers that fail to create

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2016 Intel Corporation
+// Copyright (c) 2020 Adobe Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -1166,6 +1167,16 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 	defer func() {
 		// Rollback if error happens.
 		if err != nil {
+			logger := s.Logger().WithFields(logrus.Fields{"container-id": c.id, "sandox-id": s.id, "rollback": true})
+
+			logger.Warning("Cleaning up partially created container")
+
+			if err2 := c.stop(true); err2 != nil {
+				logger.WithError(err2).Warning("Could not delete container")
+			}
+
+			logger.Debug("Removing stopped container from sandbox store")
+
 			s.removeContainer(c.id)
 		}
 	}()


### PR DESCRIPTION
sandbox: Stop and clean up containers that fail to create

A container that is created and added to a sandbox can still fail
the final creation steps. In this case, the container must be stopped
and have its resources cleaned up to prevent leaking sandbox mounts.

Fixes #2816

Signed-off-by: Evan Foster <efoster@adobe.com>
(cherry picked from commit 337f2e0c7ba5f8dff5ac46e568886a42ca56d683)