### PR TITLE
versions: Use new kata tag for virtiofs kernel

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -158,9 +158,9 @@ assets:
     version: "v5.4.32"
 
   kernel-experimental:
-    description: "Linux kernel with virtio-fs-dev branch"
+    description: "Linux kernel with virtio-fs support"
     url: "https://gitlab.com/virtio-fs/linux.git"
-    tag: "virtio-fs-dev"
+    tag: "kata-v5.6-april-09-2020"
 
 components:
   description: "Core system functionality"


### PR DESCRIPTION
Versions is pointing to virtiofs kernel branch,
recently it changed and CI is broken.

Lets use a new tag for kata.

The tag now include the kernel version so will
be shown on release notes.

Depends-on: github.com/kata-containers/packaging#1098

Fixes: #2842

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>