### PR TITLE
virtcontainers: Add function to capabilities test

### DIFF
--- a/virtcontainers/types/capabilities_test.go
+++ b/virtcontainers/types/capabilities_test.go
@@ -34,3 +34,12 @@ func TestFsSharingCapability(t *testing.T) {
 	caps.SetFsSharingSupport()
 	assert.True(t, caps.IsFsSharingSupported())
 }
+
+func TestMultiQueueCapability(t *testing.T) {
+	assert := assert.New(t)
+	var caps Capabilities
+
+	assert.False(caps.IsMultiQueueSupported())
+	caps.SetMultiQueueSupport()
+	assert.True(caps.IsMultiQueueSupported())
+}


### PR DESCRIPTION
Add function that tests multiqueue functions in types/capabilities.go.

Fixes #2844

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>