### PR TITLE
DNM: clh: debug on issue #2864

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// Debug for issue: https://github.com/kata-containers/runtime/issues/2864
+
 package virtcontainers
 
 import (


### PR DESCRIPTION
It is a potential regression test failure observed as `VmInfoGet failed`
after block device hotplug and memory hotplug.

Fixes: #2864

Signed-off-by: Bo Chen <chen.bo@intel.com>