### PR TITLE
qemu: Set govmmQemu NoReboot Knob

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -420,11 +420,11 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  digest = "1:ded834b4e437433e3f75a95041ca4e0013e1acd358218c833289986566108f67"
+  digest = "1:e800a48df8e5709baa6b78062d47d43829cddbc54871e049e8bbeb1aaf50fe40"
   name = "github.com/intel/govmm"
   packages = ["qemu"]
   pruneopts = "NUT"
-  revision = "af9e34b91ae99aff4b4ac126141259d34d98e9f2"
+  revision = "6c3315ba8a4262df4300b735b2c53ce3b15d21dd"
 
 [[projects]]
   digest = "1:dc74f6b065e6204ee3a90ce4209dae99126a110a4cd318f696a69a781916c849"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "af9e34b91ae99aff4b4ac126141259d34d98e9f2"
+  revision = "6c3315ba8a4262df4300b735b2c53ce3b15d21dd"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"

--- a/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -2122,6 +2122,9 @@ type Knobs struct {
 
 	// Realtime will enable realtime QEMU
 	Realtime bool
+
+	// Exit instead of rebooting
+	NoReboot bool
 }
 
 // IOThread allows IO to be performed on a separate thread.
@@ -2455,6 +2458,10 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoGraphic {
 		config.qemuParams = append(config.qemuParams, "-nographic")
+	}
+
+	if config.Knobs.NoReboot {
+		config.qemuParams = append(config.qemuParams, "--no-reboot")
 	}
 
 	if config.Knobs.Daemonize {

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -489,6 +489,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		NoUserConfig: true,
 		NoDefaults:   true,
 		NoGraphic:    true,
+		NoReboot:     true,
 		Daemonize:    true,
 		MemPrealloc:  q.config.MemPrealloc,
 		HugePages:    q.config.HugePages,

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -187,6 +187,23 @@ func TestQemuMemoryTopology(t *testing.T) {
 	assert.Exactly(memory, expectedOut)
 }
 
+func TestQemuKnobs(t *testing.T) {
+	assert := assert.New(t)
+
+	sandbox, err := createQemuSandboxConfig()
+	assert.NoError(err)
+
+	q := &qemu{
+		store: sandbox.newStore,
+	}
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig, false)
+	assert.NoError(err)
+
+	assert.Equal(q.qemuConfig.Knobs.NoUserConfig, true)
+	assert.Equal(q.qemuConfig.Knobs.NoDefaults, true)
+	assert.Equal(q.qemuConfig.Knobs.NoGraphic, true)
+}
+
 func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {
 	assert := assert.New(t)
 	q := &qemu{

--- a/virtcontainers/qemu_test.go
+++ b/virtcontainers/qemu_test.go
@@ -202,6 +202,7 @@ func TestQemuKnobs(t *testing.T) {
 	assert.Equal(q.qemuConfig.Knobs.NoUserConfig, true)
 	assert.Equal(q.qemuConfig.Knobs.NoDefaults, true)
 	assert.Equal(q.qemuConfig.Knobs.NoGraphic, true)
+	assert.Equal(q.qemuConfig.Knobs.NoReboot, true)
 }
 
 func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {


### PR DESCRIPTION
The Kata architecture does not support rebooting VMs (the lifecycle being start/exec/kill) and if a VM is killed (e.g. using sysrq-trigger), the VM does not exit fully and other layers do not notice the state change.

The QEMU instance needs to be told to exit and not reboot which can be done by passing the --no-reboot command line option when creating the VM.

Fix for  #2866