### PR TITLE
qemu: remove multidev in qemu/fsdev parameter on arm64

### DIFF
--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -476,12 +476,21 @@ func generic9PVolume(volume types.Volume, nestedRun bool) govmmQemu.FSDevice {
 	}
 }
 
+func genericAppend9PVolume(devices []govmmQemu.Device, volume types.Volume, nestedRun bool) (govmmQemu.FSDevice, error) {
+	d := generic9PVolume(volume, nestedRun)
+	return d, nil
+}
+
 func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
 	if volume.MountTag == "" || volume.HostPath == "" {
 		return devices, nil
 	}
 
-	d := generic9PVolume(volume, q.nestedRun)
+	d, err := genericAppend9PVolume(devices, volume, q.nestedRun)
+	if err != nil {
+		return nil, err
+	}
+
 	devices = append(devices, d)
 	return devices, nil
 }

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/kata-containers/runtime/virtcontainers/types"
 )
 
 type qemuArm64 struct {
@@ -109,4 +110,15 @@ func (q *qemuArm64) setIgnoreSharedMemoryMigrationCaps(_ context.Context, _ *gov
 
 func (q *qemuArm64) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
 	return devices, fmt.Errorf("Arm64 architecture does not support vIOMMU")
+}
+
+func (q *qemuArm64) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
+	d, err := genericAppend9PVolume(devices, volume, q.nestedRun)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Multidev = ""
+	devices = append(devices, d)
+	return devices, nil
 }


### PR DESCRIPTION
backport this from kata-containers.
As the current qemu of arm64 is so old, the new multidev parameter
in 9pfsdev is not supported on arm64, so disabled it temporarily.

Fixes:#2868
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@devimc @jodh-intel 