### PR TITLE
vendor: update govmm

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@
 
 [[constraint]]
   name = "github.com/intel/govmm"
-  revision = "6c3315ba8a4262df4300b735b2c53ce3b15d21dd"
+  revision = "547a8518098aaa71c5d5d7a370f211e00161016b"
 
 [[constraint]]
   name = "github.com/kata-containers/agent"


### PR DESCRIPTION
qemu: Add iommu_paltform annotations for qemu for s390x ccw, so that the supported devices can make use of that.
for virtcontainers/hypervisor, pic device can also enabled it if supported

add iommu_platform=on option for ccw virtio devices for

Fixes #2830

Signed-off-by: Qi Feng Huo <huoqif@cn.ibm.com>