### PR TITLE
virtcontainers: fix hotplug huge size memory cause agent hang bug

### DIFF
--- a/virtcontainers/acrn.go
+++ b/virtcontainers/acrn.go
@@ -813,3 +813,7 @@ func (a *Acrn) loadInfo() error {
 	}
 	return nil
 }
+
+func (a *Acrn) getMemorySize() uint32 {
+	return a.config.MemorySize
+}

--- a/virtcontainers/agent.go
+++ b/virtcontainers/agent.go
@@ -201,7 +201,8 @@ type agent interface {
 	// This function should be called after hot adding vCPUs or Memory.
 	// cpus specifies the number of CPUs that were added and the agent should online
 	// cpuOnly specifies that we should online cpu or online memory or both
-	onlineCPUMem(cpus uint32, cpuOnly bool) error
+	// wait specifies that we should wait all cpu or memory online in the VM synchronously
+	onlineCPUMem(cpus uint32, cpuOnly bool, wait bool) error
 
 	// memHotplugByProbe will notify the guest kernel about memory hotplug event through
 	// probe interface.

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -1266,3 +1266,7 @@ func (clh *cloudHypervisor) vmInfo() (chclient.VmInfo, error) {
 	return info, openAPIClientError(err)
 
 }
+
+func (clh *cloudHypervisor) getMemorySize() uint32 {
+	return clh.config.MemorySize
+}

--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -1212,3 +1212,7 @@ func (fc *firecracker) watchConsole() (*os.File, error) {
 
 	return stdio, nil
 }
+
+func (fc *firecracker) getMemorySize() uint32 {
+	return fc.config.MemorySize
+}

--- a/virtcontainers/hypervisor.go
+++ b/virtcontainers/hypervisor.go
@@ -781,6 +781,9 @@ type hypervisor interface {
 	hotplugRemoveDevice(devInfo interface{}, devType deviceType) (interface{}, error)
 	resizeMemory(memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, memoryDevice, error)
 	resizeVCPUs(vcpus uint32) (uint32, uint32, error)
+	// getMemorySize return the total memory in the guest include default memory size + hot plugged memory
+	// return memory size unit is MB
+	getMemorySize() uint32
 	getSandboxConsole(sandboxID string) (string, error)
 	disconnect()
 	capabilities() types.Capabilities

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1831,9 +1831,9 @@ func (k *kataAgent) memHotplugByProbe(addr uint64, sizeMB uint32, memorySectionS
 	return err
 }
 
-func (k *kataAgent) onlineCPUMem(cpus uint32, cpuOnly bool) error {
+func (k *kataAgent) onlineCPUMem(cpus uint32, cpuOnly bool, wait bool) error {
 	req := &grpc.OnlineCPUMemRequest{
-		Wait:    false,
+		Wait:    wait,
 		NbCpus:  cpus,
 		CpuOnly: cpuOnly,
 	}

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -337,7 +337,7 @@ func TestKataAgentSendReq(t *testing.T) {
 	err = k.resumeContainer(sandbox, Container{})
 	assert.Nil(err)
 
-	err = k.onlineCPUMem(1, true)
+	err = k.onlineCPUMem(1, true, false)
 	assert.Nil(err)
 
 	_, err = k.statsContainer(sandbox, Container{})

--- a/virtcontainers/mock_hypervisor.go
+++ b/virtcontainers/mock_hypervisor.go
@@ -128,3 +128,7 @@ func (m *mockHypervisor) check() error {
 func (m *mockHypervisor) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return types.Socket{HostPath: "/tmp/socket", Name: "socket"}, nil
 }
+
+func (m *mockHypervisor) getMemorySize() uint32 {
+	return 0
+}

--- a/virtcontainers/noop_agent.go
+++ b/virtcontainers/noop_agent.go
@@ -102,7 +102,7 @@ func (n *noopAgent) memHotplugByProbe(addr uint64, sizeMB uint32, memorySectionS
 }
 
 // onlineCPUMem is the Noop agent Container online CPU and Memory implementation. It does nothing.
-func (n *noopAgent) onlineCPUMem(cpus uint32, cpuOnly bool) error {
+func (n *noopAgent) onlineCPUMem(cpus uint32, cpuOnly bool, wait bool) error {
 	return nil
 }
 

--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -2267,3 +2267,7 @@ func (q *qemu) check() error {
 func (q *qemu) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return generateVMSocket(id, useVsock, q.store.RunVMStoragePath())
 }
+
+func (q *qemu) getMemorySize() uint32 {
+	return q.config.MemorySize + uint32(q.state.HotpluggedMemory)
+}

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 	"github.com/kata-containers/runtime/virtcontainers/types"
+	"github.com/kata-containers/runtime/virtcontainers/utils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -1311,6 +1312,17 @@ func TestSandboxUpdateResources(t *testing.T) {
 		c.Resources.CPU.Period = &containerCPUPeriod
 		c.Resources.CPU.Quota = &containerCPUQouta
 	}
+	err = s.updateResources()
+	assert.NoError(t, err)
+
+	// add a container with huge memory equal utils.MaxHotplugMemMBOnceTime
+	contConfig3 := newTestContainerConfigNoop("cont-00003")
+	contConfig3.Resources.Memory = &specs.LinuxMemory{
+		Limit: new(int64),
+	}
+	container3MemLimitInBytes := int64(utils.MaxHotplugMemMBOnceTime << utils.MibToBytesShift)
+	contConfig3.Resources.Memory.Limit = &container3MemLimitInBytes
+	s.config.Containers = append(s.config.Containers, contConfig3)
 	err = s.updateResources()
 	assert.NoError(t, err)
 }

--- a/virtcontainers/utils/utils.go
+++ b/virtcontainers/utils/utils.go
@@ -22,6 +22,9 @@ const fileMode0755 = os.FileMode(0755)
 // MibToBytesShift the number to shift needed to convert MiB to Bytes
 const MibToBytesShift = 20
 
+// Max Hotplug Memory size at once time, unit is MB
+const MaxHotplugMemMBOnceTime = 32 * 1024
+
 // MaxSocketPathLen is the effective maximum Unix domain socket length.
 //
 // See unix(7).

--- a/virtcontainers/vm.go
+++ b/virtcontainers/vm.go
@@ -370,7 +370,7 @@ func (v *VM) AddMemory(numMB uint32) error {
 // OnlineCPUMemory puts the hotplugged CPU and memory online.
 func (v *VM) OnlineCPUMemory() error {
 	v.logger().Infof("online CPU %d and memory", v.cpuDelta)
-	err := v.agent.onlineCPUMem(v.cpuDelta, false)
+	err := v.agent.onlineCPUMem(v.cpuDelta, false, false)
 	if err == nil {
 		v.cpuDelta = 0
 	}


### PR DESCRIPTION
virtcontainers: fix hotplug huge size memory cause agent hang bug

fixes: #2872

reason: If hotplug huge size memory into kata VM at once time,
the guest kernel will allocate some extra memory for memory management,
which may cause kata-agent hang and out of responding.
And hotplug more memory into VM, more extra memory is needed.

In order to solve this problem, we divide hotplug huge memory into
two steps. First, hotplug the max allowed memory into VM and wait
all first step hotplugged memory online. Second Step, hotplug the
left memory into VM.

Signed-off-by: jiangpengfei <jiangpengfei9@huawei.com>