### PR TITLE
virtcontainers: fix delete sandbox failed problem

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1164,6 +1164,10 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 			if len(s.config.Containers) > 0 {
 				// delete container config
 				s.config.Containers = s.config.Containers[:len(s.config.Containers)-1]
+				// need to flush change to persist storage
+				if newErr := s.storeSandbox(); newErr != nil {
+					s.Logger().WithError(newErr).Error("Fail to flush s.config.Containers change into sandbox store")
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
fixes: #2882

reason: If error happens after container create and before sandbox
updateResouce in the `CreateContainer()`, then delete sandbox
forcefully will return error because s.config.Containers config not
flushed into persist store.

Signed-off-by: jiangpengfei <jiangpengfei9@huawei.com>