### PR TITLE
shimv2: fix the issue of close IO stream (backport from 2.0)

### DIFF
--- a/containerd-shim-v2/exec.go
+++ b/containerd-shim-v2/exec.go
@@ -7,6 +7,7 @@ package containerdshim
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -31,6 +32,9 @@ type exec struct {
 
 	exitIOch chan struct{}
 	exitCh   chan uint32
+
+	stdinCloser chan struct{}
+	stdinPipe   io.WriteCloser
 
 	exitTime time.Time
 }
@@ -108,13 +112,14 @@ func newExec(c *container, stdin, stdout, stderr string, terminal bool, jspec *g
 	}
 
 	exec := &exec{
-		container: c,
-		cmds:      cmds,
-		tty:       tty,
-		exitCode:  exitCode255,
-		exitIOch:  make(chan struct{}),
-		exitCh:    make(chan uint32, 1),
-		status:    task.StatusCreated,
+		container:   c,
+		cmds:        cmds,
+		tty:         tty,
+		exitCode:    exitCode255,
+		exitIOch:    make(chan struct{}),
+		stdinCloser: make(chan struct{}),
+		exitCh:      make(chan uint32, 1),
+		status:      task.StatusCreated,
 	}
 
 	return exec, nil

--- a/containerd-shim-v2/service.go
+++ b/containerd-shim-v2/service.go
@@ -725,19 +725,23 @@ func (s *service) CloseIO(ctx context.Context, r *taskAPI.CloseIORequest) (_ *pt
 		return nil, err
 	}
 
-	tty := c.ttyio
+	stdin := c.stdinPipe
+	stdinCloser := c.stdinCloser
+
 	if r.ExecID != "" {
 		execs, err := c.getExec(r.ExecID)
 		if err != nil {
 			return nil, err
 		}
-		tty = execs.ttyio
+		stdin = execs.stdinPipe
+		stdinCloser = execs.stdinCloser
 	}
 
-	if tty != nil && tty.Stdin != nil {
-		if err := tty.Stdin.Close(); err != nil {
-			return nil, errors.Wrap(err, "close stdin")
-		}
+	// wait until the stdin io copy terminated, otherwise
+	// some contents would not be forwarded to the process.
+	<-stdinCloser
+	if err := stdin.Close(); err != nil {
+		return nil, errors.Wrap(err, "close stdin")
 	}
 
 	return empty, nil

--- a/containerd-shim-v2/stream.go
+++ b/containerd-shim-v2/stream.go
@@ -85,7 +85,7 @@ func newTtyIO(ctx context.Context, stdin, stdout, stderr string, console bool) (
 	return ttyIO, nil
 }
 
-func ioCopy(exitch chan struct{}, tty *ttyIO, stdinPipe io.WriteCloser, stdoutPipe, stderrPipe io.Reader) {
+func ioCopy(exitch, stdinCloser chan struct{}, tty *ttyIO, stdinPipe io.WriteCloser, stdoutPipe, stderrPipe io.Reader) {
 	var wg sync.WaitGroup
 	var closeOnce sync.Once
 
@@ -95,6 +95,8 @@ func ioCopy(exitch chan struct{}, tty *ttyIO, stdinPipe io.WriteCloser, stdoutPi
 			p := bufPool.Get().(*[]byte)
 			defer bufPool.Put(p)
 			io.CopyBuffer(stdinPipe, tty.Stdin, *p)
+			// notify that we can close process's io safely.
+			close(stdinCloser)
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
It should wait until the stdin io copy
termianted to close the process's io stream,
otherwise, it would miss forwarding some contents
to process stdin.

Fixes: #2884

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>