### PR TITLE
shimv2: Add a "--version" cli option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,14 +559,16 @@ define MAKE_KERNEL_VIRTIOFS_NAME
 $(if $(findstring uncompressed,$1),vmlinux-virtiofs.container,vmlinuz-virtiofs.container)
 endef
 
+GENERATED_CONFIG = $(abspath $(CLI_DIR)/config-generated.go)
 
-GENERATED_FILES += $(CLI_DIR)/config-generated.go
+GENERATED_FILES += $(GENERATED_CONFIG)
 GENERATED_FILES += pkg/katautils/config-settings.go
 
 $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 	$(QUIET_BUILD)(cd $(CLI_DIR) && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
 
 $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
+	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && ln -fs $(GENERATED_CONFIG))
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDTAGS) -i -o $@ .)
 
 .PHONY: \
@@ -711,7 +713,13 @@ install-completions:
 	$(QUIET_INST)install --mode 0644 -D  $(BASH_COMPLETIONS) $(DESTDIR)/$(BASH_COMPLETIONSDIR)/$(notdir $(BASH_COMPLETIONS));
 
 clean:
-	$(QUIET_CLEAN)rm -f $(TARGET) $(SHIMV2) $(NETMON_TARGET) $(CONFIGS) $(GENERATED_FILES) .git-commit .git-commit.tmp
+	$(QUIET_CLEAN)rm -f \
+		$(CONFIGS) \
+		$(GENERATED_FILES) \
+		$(NETMON_TARGET) \
+		$(SHIMV2) \
+		$(TARGET) \
+		.git-commit .git-commit.tmp
 
 show-usage: show-header
 	@printf "• Overview:\n"

--- a/Makefile
+++ b/Makefile
@@ -718,6 +718,7 @@ clean:
 		$(GENERATED_FILES) \
 		$(NETMON_TARGET) \
 		$(SHIMV2) \
+		$(SHIMV2_DIR)/$(notdir $(GENERATED_CONFIG)) \
 		$(TARGET) \
 		.git-commit .git-commit.tmp
 

--- a/cli/containerd-shim-kata-v2/main.go
+++ b/cli/containerd-shim-kata-v2/main.go
@@ -6,9 +6,14 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/kata-containers/runtime/containerd-shim-v2"
 )
+
+const shimID = "io.containerd.kata.v2"
 
 func shimConfig(config *shim.Config) {
 	config.NoReaper = true
@@ -16,5 +21,10 @@ func shimConfig(config *shim.Config) {
 }
 
 func main() {
-	shim.Run("io.containerd.kata.v2", containerdshim.New, shimConfig)
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Printf("%s containerd shim: id: %q, version: %s, commit: %v\n", project, shimID, version, commit)
+		os.Exit(0)
+	}
+
+	shim.Run(shimID, containerdshim.New, shimConfig)
 }


### PR DESCRIPTION
All components should support a `--version` option to allow clear identification of the version of the component being used.

Note that the build changes are required to allow the shim binary to access the golang code generated by the build (such as the `version` variable).

This is a backport of https://github.com/kata-containers/kata-containers/pull/308.

Fixes: #2886.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>