### PR TITLE
clh: Disable the 'seccomp' option temporarily

### DIFF
--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -955,6 +955,12 @@ func (clh *cloudHypervisor) LaunchClh() (string, int, error) {
 		args = append(args, "-vv")
 	}
 
+	// Disable the 'seccomp' option in clh for now.
+	// In this way, we can separate the periodic failures caused
+	// by incomplete `seccomp` filters from other failures.
+	// We will bring it back after completing the `seccomp` filter.
+	args = append(args, "--seccomp", "false")
+
 	clh.Logger().WithField("path", clhPath).Info()
 	clh.Logger().WithField("args", strings.Join(args, " ")).Info()
 


### PR DESCRIPTION
We kept observing instabilities from CLH CI jobs periodically. To
separate the random failures caused by `seccomp` from other failures,
this patch disables the 'seccomp' option from clh in kata for now. We
will bring this option back after completing the 'seccomp' filter lists
based on Kata's CI workload.

Fixes: #2899

Signed-off-by: Bo Chen <chen.bo@intel.com>