### PR TITLE
clh: Set the BDF info of hotplugged blk devices as the drive PCIAddr

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1600,11 +1600,7 @@ func (k *kataAgent) handleDeviceBlockVolume(c *Container, device api.Device) (*g
 		vol.Source = blockDrive.DevNo
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioBlock:
 		vol.Driver = kataBlkDevType
-		if blockDrive.PCIAddr == "" {
-			vol.Source = blockDrive.VirtPath
-		} else {
-			vol.Source = blockDrive.PCIAddr
-		}
+		vol.Source = blockDrive.PCIAddr
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioMmio:
 		vol.Driver = kataMmioBlkDevType
 		vol.Source = blockDrive.VirtPath

--- a/virtcontainers/kata_agent_test.go
+++ b/virtcontainers/kata_agent_test.go
@@ -457,18 +457,6 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 			},
 		},
 		{
-			BlockDeviceDriver: config.VirtioBlock,
-			inputDev: &drivers.BlockDevice{
-				BlockDrive: &config.BlockDrive{
-					VirtPath: testVirtPath,
-				},
-			},
-			resultVol: &pb.Storage{
-				Driver: kataBlkDevType,
-				Source: testVirtPath,
-			},
-		},
-		{
 			BlockDeviceDriver: config.VirtioMmio,
 			inputDev: &drivers.BlockDevice{
 				BlockDrive: &config.BlockDrive{


### PR DESCRIPTION
This patch sets the 'drive.PCIAddr' with the BDF info when hotplugging
block devices, and also sets the 'drive.Virtpath' as 'nil'
explicitly. In this way, the kata-agent will no longer rely on the
predicted  device path in the guest to locate the block device and
volumes, instead it will rely on the PCI BDF of the hotplugged block
device.

Depends-on: github.com/kata-containers/agent#824

Fixes: #2908

Signed-off-by: Bo Chen <chen.bo@intel.com>
 