### PR TITLE
[backport | master] sandbox: Disconnect from agent after VM shutdown

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -1603,6 +1603,11 @@ func (s *Sandbox) Stop(force bool) error {
 		return err
 	}
 
+	// Stop communicating with the agent.
+	if err := s.agent.disconnect(); err != nil && !force {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a one-shot pod dies in CRI-O, the shimv2 process isn't killed until the pod is actually deleted, even though the VM is shut down. In this case, the shim appears to busyloop when attempting to talk to the (now dead) agent via VSOCK. To address this, we disconnect from the agent after the VM is shut down.

This is especially catastrophic for one-shot pods that may persist for hours or days, but it also applies to any shimv2 pod where Kata is configured to use VSOCK for communication.

Backport of https://github.com/kata-containers/kata-containers/pull/556 to kata-containers/runtime master branch.

Fixes #2719

Signed-off-by: Evan Foster <efoster@adobe.com>