### PR TITLE
Call s.newStore.Destroy if globalSandboxList.addSandbox failed

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -548,6 +548,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	}
 
 	if err = globalSandboxList.addSandbox(s); err != nil {
+		s.newStore.Destroy(s.id)
 		return nil, err
 	}
 


### PR DESCRIPTION
It does not affect the function,  but I think is better to add s.newStore.Destroy if globalSandboxList.addSandbox failed.

Fixes: #2919
Signed-off-by: Shukui Yang <keloyangsk@gmail.com>