### PR TITLE
dnm: stable-1.11: versions: update CLH  to 0.8 to fix build

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -71,7 +71,7 @@ assets:
     description: "Component used to create virtual machines"
 
     cloud_hypervisor:
-      description: "Cloud Hypervisor is an open source Virtual Machine Monitor"
+      description: "Cloud Hypervisor is an open source Virtual Machine Monitor."
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
Unfortunately the 0.7 branch for CLH is now missing a reference on a dependency;
let's bump to 0.8.0.

Fixes: #2926

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>