### PR TITLE
cpuset: don't set cpuset.mems in the guest

### DIFF
--- a/virtcontainers/container.go
+++ b/virtcontainers/container.go
@@ -1275,6 +1275,14 @@ func (c *Container) update(resources specs.LinuxResources) error {
 		}
 	}
 
+	// There currently isn't a notion of cpusets.cpus or mems being tracked
+	// inside of the guest. Make sure we clear these before asking agent to update
+	// the container's cgroups.
+	if resources.CPU != nil {
+		resources.CPU.Mems = ""
+		resources.CPU.Cpus = ""
+	}
+
 	return c.sandbox.agent.updateContainer(c.sandbox, *c, resources)
 }
 


### PR DESCRIPTION
Kata doesn't map any numa topologies in the guest. Let's make sure we
clear the Cpuset fields before passing container updates to the
guest. Without this, we could encounter a runtime failure:

```
process_linux.go:297: applying cgroup configuration for process caused
"failed to write 0,1 to cpuset.mems: writea 0,1 to cpuset.mems: write
0,1 to cpuset.mems: write /sys/fs/cgroup/cpuset .... /cpuset.mems:
numerical result out of range"": unknown
```

Note, in the future we may want to have a vCPU to guest CPU mapping and
still include the cpuset.Cpus. Until we have this support, clear this as
well.

Fixes: #2176
Depends-on: github.com/kata-containers/tests#2846
