### PR TITLE
DNM: Revert "kernel: move to the latest LTS kernel 5.4.60"

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -155,7 +155,7 @@ assets:
     url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
     uscan-url: >-
       https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-(5\.4\..+)\.tar\.gz
-    version: "v5.4.60"
+    version: "v5.4.32"
 
   kernel-experimental:
     description: "Linux kernel with virtio-fs support"


### PR DESCRIPTION
This reverts commit e529c010e0708954ce9924d5f10aa4d0c47708f6.

As reported in issue https://github.com/kata-containers/tests/issues/2839, we have an regression on our metrics CI, where the current memory footprint is increased. This PR is a quick test to verify whether this increased memory footprint is a result of our recent change to a new kernel version.