### PR TITLE
virtiofsd: fix typo in test code

### DIFF
--- a/virtcontainers/virtiofsd_test.go
+++ b/virtcontainers/virtiofsd_test.go
@@ -35,7 +35,7 @@ func TestVirtiofsdStart(t *testing.T) {
 
 	socketDir, err := ioutil.TempDir("", "")
 	assert.NoError(err)
-	defer os.RemoveAll(sourcePath)
+	defer os.RemoveAll(socketDir)
 
 	socketPath := socketDir + "socket.s"
 


### PR DESCRIPTION
Fix typo in virtiofsd_test.go

Fixes: #2948

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>