### PR TITLE
runtime: add podman to data collection script

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -357,6 +357,20 @@ show_container_mgr_details()
 		run_cmd_and_show_quoted_output "" "cat /etc/containerd/config.toml"
 	fi
 
+	if have_cmd "podman"; then
+		subheading "podman"
+		run_cmd_and_show_quoted_output "" "podman --version"
+		run_cmd_and_show_quoted_output "" "podman system info"
+
+		local cmd file
+		for file in {/etc,/usr/share}/containers/*.{conf,json}; do
+			if [ -e "$file" ]; then
+				cmd="cat $file"
+				run_cmd_and_show_quoted_output "" "$cmd"
+			fi
+		done
+
+	fi
 	separator
 }
 


### PR DESCRIPTION
Backported from https://github.com/kata-containers/kata-containers/pull/718

Fixes: #2951
Here anyway we have some older version of the script... should we backport some more commits to make the output as nice as the one in the v2 repo?
