### PR TITLE
runtime: Ignore ENOENT in kill/delete

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/kata-containers/runtime/pkg/katautils"
 	vc "github.com/kata-containers/runtime/virtcontainers"
@@ -73,6 +74,11 @@ func delete(ctx context.Context, containerID string, force bool) error {
 	if err != nil {
 		if force {
 			kataLog.Warnf("Failed to get container, force will not fail: %s", err)
+			return nil
+		}
+		if err.Error() == syscall.ENOENT.Error() {
+			kataLog.WithField("container", containerID).Info("skipping delete as container does not exist")
+			katautils.DelContainerIDMapping(ctx, containerID)
 			return nil
 		}
 		return err

--- a/cli/kill.go
+++ b/cli/kill.go
@@ -108,8 +108,11 @@ func kill(ctx context.Context, containerID, signal string, all bool) error {
 
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	status, sandboxID, err := getExistingContainerInfo(ctx, containerID)
-
 	if err != nil {
+		if err.Error() == syscall.ENOENT.Error() {
+			kataLog.WithField("container", containerID).Info("skipping kill as container does not exist")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
If sandbox/container's dir is not exist, the kill/delete will always fail,and this make kubelet/container delete it repeatedly
but fail always. In some kind of abnormal situation(e.g. kill -9 $pidofqemu),kata-runtime may kill/delete sandbox first, this make container'dir not exist, so kata-runtime should skip this error.

Fixes: #2959.

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>