### PR TITLE
scripts: Don't use hard-coded crio config

### DIFF
--- a/data/kata-collect-data.sh.in
+++ b/data/kata-collect-data.sh.in
@@ -346,7 +346,7 @@ show_container_mgr_details()
 		subheading "crio"
 		run_cmd_and_show_quoted_output "" "crio --version"
 		run_cmd_and_show_quoted_output "" "systemctl show crio"
-		run_cmd_and_show_quoted_output "" "cat /etc/crio/crio.conf"
+		run_cmd_and_show_quoted_output "" "crio config"
 	fi
 
 


### PR DESCRIPTION
In show_container_mgr_details(), it used "cat /etc/crio/crio.conf"
instead of "crio config".

Fixes: #2964
Signed-off-by: Qian Cai <cai@redhat.com>