### PR TITLE
versions: Add newest-version for OpenShift

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -236,6 +236,10 @@ externals:
       .*/v?([\d\.]+)\.tar\.gz
     version: "v3.10.0"
     commit: "dd10d17"
+    meta:
+      description: |
+        'newest-version' is the latest version known to work.
+      newest-version: "4.5"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
This adds the 'newest-version' property which determines the OpenShift
version used to run the e2e tests.

Fixes: github.com/kata-containers/tests#2860

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>