### PR TITLE
version: upgrade qemu version to v5.1.0 for arm64

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -100,10 +100,10 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
       architecture:
         aarch64:
-          version: "stable-2.11"
+          version: "5.1.0"
           branch: "master"
-          tag: "v3.1.0-rc2"
-          commit: "47c1cc30e440860aa695358f7c2dd0b9d7b53d16"
+          tag: "v5.1.0"
+          commit: "d0ed6a69d399ae193959225cdeaa9382746c91cc"
 
     qemu-experimental:
       description: "QEMU with virtiofs support"


### PR DESCRIPTION
Now, the qemu version used in arm is so old. As some new features have merged
in current qemu, so it's time to upgrade it.

Fixes: #2989
Signed-off-by: Edmond AK Dantes <edmond.dantes.ak47@outlook.com>

@jon @liwei 