### PR TITLE
virtiofs: Enable xattr by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ DEFVIRTIOFSCACHE ?= auto
 #
 # see `virtiofsd -h` for possible options.
 # Make sure you quote args.
-DEFVIRTIOFSEXTRAARGS ?= []
+DEFVIRTIOFSEXTRAARGS ?= [\"-o\", \"xattr\"]
 DEFENABLEIOTHREADS := false
 DEFENABLEMEMPREALLOC := false
 DEFENABLEHUGEPAGES := false


### PR DESCRIPTION
xattr is used by programs like dnf or apt.

Be cause this can be used by containers.
To build and image or by interactive containers
it may be useful to have it by default.

Note that this is not part of the virtiofsd driver
as some users still want to remove this use case.

Fixes: github.com/kata-containers/tests#2008

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>