### PR TITLE
factory: Use lazy unmount

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -22,6 +22,7 @@ import (
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	exp "github.com/kata-containers/runtime/virtcontainers/experimental"
 	vf "github.com/kata-containers/runtime/virtcontainers/factory"
+	tl "github.com/kata-containers/runtime/virtcontainers/factory/template"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/rootless"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -243,6 +244,9 @@ func setExternalLoggers(ctx context.Context, logger *logrus.Entry) {
 
 	// Set vm factory logger.
 	vf.SetLogger(ctx, logger)
+
+	// Set vm factory template logger.
+	tl.SetLogger(ctx, logger)
 
 	// Set the OCI package logger.
 	oci.SetLogger(ctx, logger)

--- a/virtcontainers/factory/template/template.go
+++ b/virtcontainers/factory/template/template.go
@@ -16,6 +16,7 @@ import (
 	pb "github.com/kata-containers/runtime/protocols/cache"
 	vc "github.com/kata-containers/runtime/virtcontainers"
 	"github.com/kata-containers/runtime/virtcontainers/factory/base"
+	"github.com/sirupsen/logrus"
 )
 
 type template struct {
@@ -24,6 +25,7 @@ type template struct {
 }
 
 var templateWaitForAgent = 2 * time.Second
+var templateLog = logrus.WithField("source", "virtcontainers/factory/template")
 
 // Fetch finds and returns a pre-built template factory.
 // TODO: save template metadata and fetch from storage.
@@ -86,8 +88,13 @@ func (t *template) GetVMStatus() []*pb.GrpcVMStatus {
 }
 
 func (t *template) close() {
-	syscall.Unmount(t.statePath, 0)
-	os.RemoveAll(t.statePath)
+	if err := syscall.Unmount(t.statePath, syscall.MNT_DETACH); err != nil {
+		t.Logger().WithError(err).Errorf("failed to unmount %s", t.statePath)
+	}
+
+	if err := os.RemoveAll(t.statePath); err != nil {
+		t.Logger().WithError(err).Errorf("failed to remove %s", t.statePath)
+	}
 }
 
 func (t *template) prepareTemplateFiles() error {
@@ -170,4 +177,20 @@ func (t *template) checkTemplateVM() error {
 
 	_, err = os.Stat(t.statePath + "/state")
 	return err
+}
+
+// Logger returns a logrus logger appropriate for logging template messages
+func (t *template) Logger() *logrus.Entry {
+	return templateLog.WithFields(logrus.Fields{
+		"subsystem": "template",
+	})
+}
+
+// SetLogger sets the logger for the factory template.
+func SetLogger(ctx context.Context, logger logrus.FieldLogger) {
+	fields := logrus.Fields{
+		"source": "virtcontainers",
+	}
+
+	templateLog = logger.WithFields(fields)
 }

--- a/virtcontainers/factory/template/template_test.go
+++ b/virtcontainers/factory/template/template_test.go
@@ -112,7 +112,14 @@ func TestTemplateFactory(t *testing.T) {
 	err = vm.Stop()
 	assert.Nil(err)
 
-	// CloseFactory
+	// make tt.statePath is busy
+	os.Chdir(tt.statePath)
+
+	// CloseFactory, there is no need to call tt.CloseFactory(ctx)
 	f.CloseFactory(ctx)
-	tt.CloseFactory(ctx)
+
+	// expect tt.statePath not exist, if exist, it means this case failed.
+	_, err = os.Stat(tt.statePath)
+	assert.Error(err)
+	assert.True(os.IsNotExist(err))
 }


### PR DESCRIPTION
backport for https://github.com/kata-containers/runtime/pull/2923

we can have the following case,
1. start kata container with factory feature, this need kata-runtime
   config to enable factory and use initrd as base image.
2. start a kata container.
3. cd /root; cd /run/vc/vm/template dir, this will make
   /run/vc/vm/template to be in used.
4. destroy vm template with kata-runtime factory destroy , and check
		the template mountpoint.
we can see  the template mountpoints will add everytime we repeat the above steps .

[root@centos1 template]# mount |grep template
[root@centos1 template]# docker run -ti --rm  --runtime untrusted-runtime --net none busybox echo

[root@centos1 template]# cd /root; cd /run/vc/vm/template/
[root@centos1 template]# /kata/bin/kata-runtime factory destroy
vm factory destroyed
[root@centos1 template]# mount |grep template
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)
[root@centos1 template]# docker run -ti --rm  --runtime untrusted-runtime --net none busybox echo

[root@centos1 template]# cd /root; cd /run/vc/vm/template/
[root@centos1 template]# /kata/bin/kata-runtime factory destroy
vm factory destroyed
[root@centos1 template]# mount |grep template
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)

Fixes: #2918

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>