### PR TITLE
runtime: Fix /var/lib/vc/sbs/${sid} dir residual

### DIFF
--- a/virtcontainers/sandbox.go
+++ b/virtcontainers/sandbox.go
@@ -725,14 +725,14 @@ func fetchSandbox(ctx context.Context, sandboxID string) (sandbox *Sandbox, err 
 
 	var config SandboxConfig
 
-	// Try to load sandbox config from old store at first.
-	c, ctx, err := loadSandboxConfigFromOldStore(ctx, sandboxID)
+	// Try to load sandbox config from new store at first.
+	c, err := loadSandboxConfig(sandboxID)
 	if err != nil {
-		virtLog.Warningf("failed to get sandbox config from old store: %v", err)
-		// If we failed to load sandbox config from old store, try again with new store.
-		c, err = loadSandboxConfig(sandboxID)
+		virtLog.Warningf("failed to get sandbox config from new store: %v", err)
+		// If we failed to load sandbox config from new store, try again with old store.
+		c, ctx, err = loadSandboxConfigFromOldStore(ctx, sandboxID)
 		if err != nil {
-			virtLog.Warningf("failed to get sandbox config from new store: %v", err)
+			virtLog.Warningf("failed to get sandbox config from old store: %v", err)
 			return nil, err
 		}
 	}
@@ -834,7 +834,11 @@ func (s *Sandbox) Delete() error {
 	}
 
 	s.agent.cleanup(s)
-
+	if useOldStore(s.ctx) && s.store != nil {
+		if err := s.store.Delete(); err != nil {
+			s.Logger().WithError(err).Error("store delete failed")
+		}
+	}
 	return s.newStore.Destroy(s.id)
 }
 

--- a/virtcontainers/sandbox_test.go
+++ b/virtcontainers/sandbox_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	exp "github.com/kata-containers/runtime/virtcontainers/experimental"
 	"github.com/kata-containers/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/runtime/virtcontainers/store"
 	"github.com/kata-containers/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -1735,4 +1737,41 @@ func TestGetSandboxCpuSet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSandboxStoreClean(t *testing.T) {
+	ctx := context.Background()
+	contID := "SandboxStore"
+	contConfig := newTestContainerConfigNoop(contID)
+	hConfig := newHypervisorConfig(nil, nil)
+	assert := assert.New(t)
+
+	// create a sandbox
+	p, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NoopAgentType, NetworkConfig{}, []ContainerConfig{contConfig}, nil)
+	assert.NoError(err)
+	defer cleanUp()
+
+	l := len(p.GetAllContainers())
+	assert.Equal(l, 1)
+
+	// persist to disk
+	err = p.storeSandbox()
+	assert.NoError(err)
+
+	loadSandboxConfigFromOldStore(ctx, p.ID())
+
+	runtimeSidPath := store.SandboxConfigurationRoot(p.ID())
+	runtimeSidPath = strings.TrimPrefix(runtimeSidPath, "file://")
+
+	p.store, err = store.NewVCSandboxStore(ctx, testSandboxID)
+	assert.Nil(err)
+
+	p.ctx = context.WithValue(ctx, oldstoreKey, true)
+	err = p.Delete()
+	assert.NoError(err)
+
+	// expect runtimeSidPath not exist, if exist, it means this case failed.
+	_, err = os.Stat(runtimeSidPath)
+	assert.Error(err)
+	assert.True(os.IsNotExist(err))
 }


### PR DESCRIPTION
backport for https://github.com/kata-containers/runtime/pull/2922
Create and delete a kata container everytime, the directory of
/var/lib/vc/sbs/ will have a new directory which's name is the
${sandbox-id}, e.g.
d3e0482b22b9e25cd3268608b12ab8c1eb666960c4fa9a6a72a3e4d0b1606551

Fixes: #2921

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>