### PR TITLE
arm64: correct bridge type for QEMUVIRT machine

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -1977,7 +1977,7 @@ func genericBridges(number uint32, machineType string) []types.Bridge {
 	case QemuPC:
 		bt = types.PCI
 	case QemuVirt:
-		bt = types.PCIE
+		bt = types.PCI
 	case QemuPseries:
 		bt = types.PCI
 	case QemuCCWVirtio:

--- a/virtcontainers/qemu_arm64_test.go
+++ b/virtcontainers/qemu_arm64_test.go
@@ -75,7 +75,7 @@ func TestQemuArm64AppendBridges(t *testing.T) {
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.BridgeDevice{
-			Type:    govmmQemu.PCIEBridge,
+			Type:    govmmQemu.PCIBridge,
 			Bus:     defaultBridgeBus,
 			ID:      bridges[0].ID,
 			Chassis: 1,


### PR DESCRIPTION
The device pcie-pci-bridge in qemu will create a pci bus not pcie one.
It should be corrected for QEMUVIRT.
After correct this, vfio pci device can be hotplugged on arm64.

Fixes: #3016
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@bergwolf @jodh-intel @devimc 