### PR TITLE
clh: let clh config build for arm64

### DIFF
--- a/arch/arm64-options.mk
+++ b/arch/arm64-options.mk
@@ -16,3 +16,6 @@ QEMUCMD := qemu-system-aarch64
 FCCMD := firecracker
 # Firecracker's jailer binary name
 FCJAILERCMD := jailer
+
+# cloud-hypervisor binary name
+CLHCMD := cloud-hypervisor


### PR DESCRIPTION
As cloud-hypervisor has been supported on arm64, let its configuration
build.

Fixes: #3027
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@lifupan  @jodh-intel 