### PR TITLE
gitignore: Ignore cli/containerd-shim-kata-v2/config-generated.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /cli/config/configuration-qemu-virtiofs.toml
 /cli/config/configuration-clh.toml
 /cli/config-generated.go
+/cli/containerd-shim-kata-v2/config-generated.go
 /cli/coverage.html
 /containerd-shim-kata-v2
 /data/kata-collect-data.sh


### PR DESCRIPTION
This link is generated during build, but not ignored by .gitignore.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>