### PR TITLE
qemu: fix stopSandbox() to work with newer docker

### DIFF
--- a/virtcontainers/qemu.go
+++ b/virtcontainers/qemu.go
@@ -931,6 +931,22 @@ func (q *qemu) waitSandbox(timeout int) error {
 	return nil
 }
 
+func isConnectionRefusedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if neterr, ok := err.(*net.OpError); ok {
+		if syserr, ok := neterr.Err.(*os.SyscallError); ok {
+			if errno, ok := syserr.Err.(syscall.Errno); ok {
+				if errno == unix.ECONNREFUSED {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // stopSandbox will stop the Sandbox's VM.
 func (q *qemu) stopSandbox() error {
 	span, _ := q.trace("stopSandbox")
@@ -962,6 +978,13 @@ func (q *qemu) stopSandbox() error {
 
 	err := q.qmpSetup()
 	if err != nil {
+		// Ignore any "connection refused" error and assume that the Sandbox
+		// is already stopped in that case.
+		if isConnectionRefusedError(err) {
+			q.Logger().WithError(err).Warn(
+				"Failed to connect to qemu. Assuming Sandbox is already gone.")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When connecting to the qemu socket fails with a connection refused error
assume that qemu died and handle that as if the Sandbox was already
stopped. So that deleteSandbox() can still succeed.

This is needed when working with newer docker releases (19.03). As the
containerd included in there does no longer use the "<runtime> kill"
command before deleting the Sandboxes.
(https://github.com/containerd/containerd/commit/b5ccc66c2c814cfc21d58678c854272427814b59#diff-6a93af2fa6a81ffa3592c6ba4c7f628976e9ac0363a9532589b0fc96f3059ad1)

Fixes: #2611, #2314 

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>