### PR TITLE
logging: Fix Logging level

### DIFF
--- a/pkg/katautils/config.go
+++ b/pkg/katautils/config.go
@@ -1189,7 +1189,10 @@ func LoadConfiguration(configPath string, ignoreLogging, builtIn bool) (resolved
 	}
 
 	config.Debug = tomlConf.Runtime.Debug
-	if !tomlConf.Runtime.Debug {
+	if tomlConf.Runtime.Debug {
+		// logrus "Info" level is used as "Debug"
+		kataUtilsLogger.Logger.Level = logrus.InfoLevel
+	} else {
 		// If debug is not required, switch back to the original
 		// default log priority, otherwise continue in debug mode.
 		kataUtilsLogger.Logger.Level = originalLoggerLevel


### PR DESCRIPTION
When running CRI-O in normal mode and setting enable_debug = true
in configuration.toml, the logging level should be info
(which from KATA's perspective behaves like DEBUG).
However the runtime logging level will be  WARN (which from KATA's
perspective behaves like INFO).

The issue can be traced to commit
    eee4d70 "katutils: logging: default log level to Warn".

Fix it by setting the logging level whether the debugging mode is
enabled or not.

Fixes: #3039

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>