### PR TITLE
version: add new docker version entry for agent test on arm

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -215,6 +215,10 @@ externals:
     version: "v18.06-ce"
     meta:
       swarm-version: "1.12.1"
+    architecture:
+      aarch64:
+        agent:
+          version: "v19.03-ce"
 
   kubernetes:
     description: "Kubernetes project container manager"


### PR DESCRIPTION
make proto in agent test on arm64 will fail when using docker 18.06
and using docker 19.03 can avoid that failure. So a new entry of
docker version for agent on arm64 is added.

Signed-off-by: Jianyong wu <jianyong.wu@arm.com>
Fixes: #3056

@jodh-intel @devimc 