### PR TITLE
[backport] runtime: clh: disable virtiofs DAX when FS cache size is 0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v0.11.0"
+      version: "270631922deee9bdea13635a104e111768446c7b"
 
     firecracker:
       description: "Firecracker micro-VMM"

--- a/virtcontainers/clh.go
+++ b/virtcontainers/clh.go
@@ -1209,22 +1209,23 @@ func (clh *cloudHypervisor) addVolume(volume types.Volume) error {
 		return err
 	}
 
-	if clh.config.VirtioFSCache == virtioFsCacheAlways {
-		clh.vmconfig.Fs = []chclient.FsConfig{
-			{
-				Tag:       volume.MountTag,
-				CacheSize: int64(clh.config.VirtioFSCacheSize << 20),
-				Socket:    vfsdSockPath,
-			},
-		}
-	} else {
-		clh.vmconfig.Fs = []chclient.FsConfig{
-			{
-				Tag:    volume.MountTag,
-				Socket: vfsdSockPath,
-			},
-		}
+	// disable DAX if VirtioFSCacheSize is 0
+	dax := clh.config.VirtioFSCacheSize != 0
 
+	// numQueues and queueSize are required, let's use the
+	// default values defined by cloud-hypervisor
+	numQueues := int32(1)
+	queueSize := int32(1024)
+
+	clh.vmconfig.Fs = []chclient.FsConfig{
+		{
+			Tag:       volume.MountTag,
+			Socket:    vfsdSockPath,
+			Dax:       dax,
+			CacheSize: int64(clh.config.VirtioFSCacheSize << 20),
+			NumQueues: numQueues,
+			QueueSize: queueSize,
+		},
 	}
 
 	clh.Logger().Debug("Adding share volume to hypervisor: ", volume.MountTag)

--- a/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -1078,6 +1078,10 @@ components:
         id:
           type: string
       required:
+      - cache_size
+      - dax
+      - num_queues
+      - queue_size
       - socket
       - tag
       type: object

--- a/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
+++ b/virtcontainers/pkg/cloud-hypervisor/client/docs/FsConfig.md
@@ -6,10 +6,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Tag** | **string** |  | 
 **Socket** | **string** |  | 
-**NumQueues** | **int32** |  | [optional] [default to 1]
-**QueueSize** | **int32** |  | [optional] [default to 1024]
-**Dax** | **bool** |  | [optional] [default to true]
-**CacheSize** | **int64** |  | [optional] 
+**NumQueues** | **int32** |  | [default to 1]
+**QueueSize** | **int32** |  | [default to 1024]
+**Dax** | **bool** |  | [default to true]
+**CacheSize** | **int64** |  | 
 **Id** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
+++ b/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
@@ -12,9 +12,9 @@ package openapi
 type FsConfig struct {
 	Tag string `json:"tag"`
 	Socket string `json:"socket"`
-	NumQueues int32 `json:"num_queues,omitempty"`
-	QueueSize int32 `json:"queue_size,omitempty"`
-	Dax bool `json:"dax,omitempty"`
-	CacheSize int64 `json:"cache_size,omitempty"`
+	NumQueues int32 `json:"num_queues"`
+	QueueSize int32 `json:"queue_size"`
+	Dax bool `json:"dax"`
+	CacheSize int64 `json:"cache_size"`
 	Id string `json:"id,omitempty"`
 }

--- a/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -654,8 +654,12 @@ components:
 
     FsConfig:
       required:
-      - tag
+      - cache_size
+      - dax
+      - num_queues
+      - queue_size
       - socket
+      - tag
       type: object
       properties:
         tag:


### PR DESCRIPTION
Guest consumes 120Mb more of memory when DAX is enabled and the default
FS cache size (8G) is used. Disable dax when it is not required
reducing guest's memory footprint.

Without this patch:

```
7fdea4000000-7fdee4000000 rw-s 18850589 /memfd:ch_ram (deleted)
Size:            1048576 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:              187876 kB
```

With this patch:

```
7fa970000000-7fa9b0000000 rw-s 612001  /memfd:ch_ram (deleted)
Size:            1048576 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:               57308 kB
Pss:               56722 kB
```

fixes #3072

Signed-off-by: Julio Montes <julio.montes@intel.com>