### PR TITLE
shim-v2: utilize buildmode=pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,7 @@ $(TARGET_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
 
 $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && ln -fs $(GENERATED_CONFIG))
-	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDTAGS) -i -o $@ .)
+	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -i -o $@ .)
 
 .PHONY: \
 	check \


### PR DESCRIPTION
The build is inconsistent between 2.0 and 1.x. Despite it bloating the
shim's RSS, we should make sure we utilize the buildmode=pie flag.

This increases the shim's RSS from ~ 23612 KB to 30476 KB. :(

Fixes: #3074

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>