### PR TITLE
versions: Bump the newest-version of OpenShift

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -239,7 +239,7 @@ externals:
     meta:
       description: |
         'newest-version' is the latest version known to work.
-      newest-version: "4.5"
+      newest-version: "4.6"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
Updated the newest-version of openshift to 4.6.

Fixes: github.com/kata-containers/tests#3062

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>