### PR TITLE
[stable-1.12] virtcontainers: Don't set Ctty

### DIFF
--- a/virtcontainers/shim.go
+++ b/virtcontainers/shim.go
@@ -208,9 +208,6 @@ func startShim(args []string, params ShimParams) (int, error) {
 		cmd.Stderr = f
 		// Create Session
 		cmd.SysProcAttr.Setsid = true
-		// Set Controlling terminal to Ctty
-		cmd.SysProcAttr.Setctty = true
-		cmd.SysProcAttr.Ctty = int(f.Fd())
 	}
 	defer func() {
 		if f != nil {


### PR DESCRIPTION
The https://go-review.googlesource.com/c/go/+/231638/ commit on Golang
introduced a failure on Kata Containers when the runtime is built with
golang 15.2+.

Fixes: #2982

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit c56af73d3d142125e0712028be0b9e179e0ff957)