### PR TITLE
build: Remove default hypervisor message from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -767,7 +767,6 @@ else
 endif
 	@printf "\n"
 	@printf "• hypervisors:\n"
-	@printf "\tDefault: $(DEFAULT_HYPERVISOR)\n"
 	@printf "\tKnown: $(sort $(HYPERVISORS))\n"
 	@printf "\tAvailable for this architecture: $(sort $(KNOWN_HYPERVISORS))\n"
 	@printf "\n"


### PR DESCRIPTION
The default hypervisor variable will no longer be printed from
the Makefile.

Fixes: #2785

Signed-off-by: Benjamin Porter <bporter816@gmail.com>