### PR TITLE
docs: update documentation to reflect qemu.log behavior

### DIFF
--- a/cli/config/configuration-qemu-virtiofs.toml.in
+++ b/cli/config/configuration-qemu-virtiofs.toml.in
@@ -243,6 +243,8 @@ valid_file_mem_backends = @DEFVALIDFILEMEMBACKENDS@
 # This option changes the default hypervisor and kernel parameters
 # to enable debug output where available. This extra output is added
 # to the proxy logs, but only when proxy debug is also enabled.
+# Note: Debug output will only be put into qemu.log in the event
+# of a virtual hardware issue, otherwise it will be empty
 #
 # Default false
 #enable_debug = true

--- a/cli/config/configuration-qemu.toml.in
+++ b/cli/config/configuration-qemu.toml.in
@@ -250,6 +250,8 @@ valid_file_mem_backends = @DEFVALIDFILEMEMBACKENDS@
 # This option changes the default hypervisor and kernel parameters
 # to enable debug output where available. This extra output is added
 # to the proxy logs, but only when proxy debug is also enabled.
+# Note: Debug output will only be put into qemu.log in the event
+# of a virtual hardware issue, otherwise it will be empty.
 #
 # Default false
 #enable_debug = true


### PR DESCRIPTION
The documentation now has notes describing the behavior of qemu.log.

Fixes: #2650 

Signed-off-by: Marcus Mao <marcus_mao@yahoo.com>