### PR TITLE
[backport] snap: add GH actions jobs to release the snap package

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,0 +1,37 @@
+name: Release Kata 1.x in snapcraft store
+on:
+  push:
+    tags:
+      - '1.*'
+jobs:
+  release-snap:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
+
+      - name: Build snap
+        run: |
+          sudo apt-get install -y git git-extras
+          kata_url="https://github.com/kata-containers/runtime"
+          latest_version=$(git ls-remote --tags ${kata_url} | egrep -o "refs.*" | egrep -v "\-alpha|\-rc|{}" | egrep -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" | sort -V -r | head -1)
+          current_version="$(echo ${GITHUB_REF} | cut -d/ -f3)"
+          # Check if the current tag is the latest tag
+          if echo -e "$latest_version\n$current_version" | sort -C -V; then
+            # Current version is the latest version, build it
+            snapcraft -d snap --destructive-mode
+          fi
+
+      - name: Upload snap
+        run: |
+          snap_version="$(echo ${GITHUB_REF} | cut -d/ -f3)"
+          snap_file="kata-containers_${snap_version}_amd64.snap"
+          # Upload the snap if it exists
+          if [ -f ${snap_file} ]; then
+            snapcraft upload --release=stable ${snap_file}
+          fi


### PR DESCRIPTION
Use Github actions to build and release the snap package automatically
when a new tag is pushed.

fixes #3098

Signed-off-by: Julio Montes <julio.montes@intel.com>