### PR TITLE
virtcontainers: Fix the memory leak caused by supportedQemuMachines

### DIFF
--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -93,7 +93,8 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		factory = true
 	}
 
-	var qemuMachines = supportedQemuMachines
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
 	if config.IOMMU {
 		var q35QemuIOMMUOptions = "accel=kvm,kernel_irqchip=split"
 

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -68,12 +68,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuArm64{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -68,12 +68,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuPPC64le{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -61,12 +61,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuS390x{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,


### PR DESCRIPTION
Fixes: #3112

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>

I use kata-runtime event to stat kata container, but  I find the RssAnon of kata-runtime is growing all the time
```
-bash-4.2# kata-runtime events --interval 0.1s 58f11a09c74dce4ac64f32192e36565c5b2da106bc6fedb3647f7f84d2014c41

# another terminal
-bash-4.2# cat /proc/`ps -aux|grep "0.1s"|grep -v grep|awk '{print $2}'`/status|grep RssAnon;date
RssAnon:           52512 kB
Tue Jan  5 17:15:34 CST 2021
-bash-4.2# cat /proc/`ps -aux|grep "0.1s"|grep -v grep|awk '{print $2}'`/status|grep RssAnon;date
RssAnon:           52520 kB
Tue Jan  5 17:15:42 CST 2021
-bash-4.2# cat /proc/`ps -aux|grep "0.1s"|grep -v grep|awk '{print $2}'`/status|grep RssAnon;date
RssAnon:           73776 kB
Tue Jan  5 17:33:32 CST 2021
-bash-4.2# cat /proc/`ps -aux|grep "0.1s"|grep -v grep|awk '{print $2}'`/status|grep RssAnon;date
RssAnon:           73776 kB
Tue Jan  5 17:33:34 CST 2021
-bash-4.2# cat /proc/`ps -aux|grep "0.1s"|grep -v grep|awk '{print $2}'`/status|grep RssAnon;date
RssAnon:           82104 kB
Tue Jan  5 17:45:02 CST 2021
```

So I add pprof to kata-runtime and I find that using supportedQemuMachines directly results in a memory leak,
a simpler way is to add printf like the follown,
```
diff --git a/virtcontainers/qemu_amd64.go b/virtcontainers/qemu_amd64.go
index ac7bc693..2d0ef86f 100644
--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -11,6 +11,7 @@ import (
        "github.com/kata-containers/runtime/virtcontainers/types"
 
        govmmQemu "github.com/intel/govmm/qemu"
+       "fmt"
 )
 
@@ -126,6 +128,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
                },
                vmFactory: factory,
        }
+       fmt.Printf("option len = %d\n", len(q.supportedQemuMachines[0].Options))
 
        q.handleImagePath(config)
```

run kata-runtime event and we can see,
```
-bash-4.2# ./kata-runtime events --interval 0.1s 58f11a09c74dce4ac64f32192e36565c5b2da106bc6fedb3647f7f84d2014c41|grep len
option len = 24
option len = 31
option len = 38
option len = 45
option len = 52
option len = 59
option len = 66
option len = 73
option len = 80
option len = 87
option len = 94
option len = 101
option len = 108
option len = 115
option len = 122
option len = 129
option len = 136
option len = 143
option len = 150
```

this pr don't use supportedQemuMachines directly and copy qemuMachines from supportedQemuMachines.