### PR TITLE
Backports to stable 1.12

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -1116,6 +1116,10 @@ func (k *kataAgent) constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
 	grpcSpec.Linux.Resources.BlockIO = nil
 	grpcSpec.Linux.Resources.HugepageLimits = nil
 	grpcSpec.Linux.Resources.Network = nil
+	if grpcSpec.Linux.Resources.CPU != nil {
+		grpcSpec.Linux.Resources.CPU.Cpus = ""
+		grpcSpec.Linux.Resources.CPU.Mems = ""
+	}
 
 	// There are three main reasons to do not apply systemd cgroups in the VM
 	// - Initrd image doesn't have systemd.

--- a/virtcontainers/qemu_amd64.go
+++ b/virtcontainers/qemu_amd64.go
@@ -93,7 +93,8 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		factory = true
 	}
 
-	var qemuMachines = supportedQemuMachines
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
 	if config.IOMMU {
 		var q35QemuIOMMUOptions = "accel=kvm,kernel_irqchip=split"
 

--- a/virtcontainers/qemu_arm64.go
+++ b/virtcontainers/qemu_arm64.go
@@ -68,12 +68,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuArm64{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/virtcontainers/qemu_ppc64le.go
+++ b/virtcontainers/qemu_ppc64le.go
@@ -68,12 +68,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuPPC64le{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/virtcontainers/qemu_s390x.go
+++ b/virtcontainers/qemu_s390x.go
@@ -61,12 +61,15 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		machineType = defaultQemuMachineType
 	}
 
+	qemuMachines := make([]govmmQemu.Machine, len(supportedQemuMachines))
+	copy(qemuMachines, supportedQemuMachines)
+
 	q := &qemuS390x{
 		qemuArchBase{
 			machineType:           machineType,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
+			supportedQemuMachines: qemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,


### PR DESCRIPTION
c5447462 cpuset: when creating container, don't pass cpuset details
607e96dd virtcontainers: Fix the memory leak caused by supportedQemuMachines