### PR TITLE
versions: Upgrade to cloud-hypervisor release v0.14.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v0.14.0"
+      version: "v0.14.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Cloud-hypervisor now has a stable release v0.14.1 in addition to the
v0.14.0 release last week. Let's keep updated with it, given it contains
several bug fixes.

Details: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v0.14.1

Fixes: #3151

Signed-off-by: Bo Chen <chen.bo@intel.com>