### PR TITLE
cli: Fix the incorrect info of command "kata-runtime exec"

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -46,7 +46,7 @@ EXAMPLE:
    If the container is configured to run the linux ps command the following
    will output a list of processes running in the container:
 
-       # ` + name + ` <container-id> ps`,
+       # ` + name + ` exec <container-id> ps`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "console",


### PR DESCRIPTION
When user runs "kata-runtime exec test something" and then the help information prompted,
the "EXAMPLE" field of the help information missed "exec", see:
`# kata-runtime <container-id> ps`

Obviously it missed the word "exec" following the "kata-runtime".

Fixes: #3154

Signed-Off-By: Liang Zhou <zhoul110@chinatelecom.cn>
