### PR TITLE
cli: Fix the incorrect default hostname "runc"

### DIFF
--- a/cli/spec.go
+++ b/cli/spec.go
@@ -83,6 +83,8 @@ generate a proper rootless spec file.`,
 
 		spec := specconv.Example()
 
+		spec.Hostname = "kata"
+
 		checkNoFile := func(name string) error {
 			_, err := os.Stat(name)
 			if err == nil {


### PR DESCRIPTION
When use "kata-runtime spec" to generate config.json, 
the default hostname is "runc", which is not correct. 
The proper one should be "kata", instead of "runc".

Fixes: #3157

Signed-off-by: Liang Zhou <zhoul110@chinatelecom.cn>