### PR TITLE
versions: Update version of qemu to 5.1.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "5.0.0"
-      tag: "v5.0.0"
+      version: "5.1.0"
+      tag: "v5.1.0"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
This update is being done to address some of the 9p
issues seen with a bug introduced in 5.0:
https://bugs.launchpad.net/qemu/+bug/1877688

Depends-on: github.com/kata-containers/packaging#1197

Fixes #2978

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>