### PR TITLE
Update version number of the agent for 1.13.0-alpha0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -170,7 +170,7 @@ components:
       Container management service running in the guest virtual machines
       root context.
     url: "https://github.com/kata-containers/agent"
-    commit: "6f6e9ecd8aded0783c31968b304a9d6589114363"
+    commit: "0b75b2d82d41609fd30dadd11f93c7fe41258893"
 
 externals:
   description: "Third-party projects used by the system"


### PR DESCRIPTION
Having the wrong agent version there causes the following error:
https://github.com/kata-containers/osbuilder/pull/520#issuecomment-832874777

    ERROR: rootfs build failed
    INFO: ERROR: test failed
    INFO: rootfs:
    total 8
    drwxr-xr-x 17 root root 4096 May  5 17:22 clearlinux_rootfs
    drwxr-xr-x 21 root root 4096 May  5 17:22 ubuntu_rootfs
    INFO: images:
    total 0
    INFO: running: /home/runner/work/osbuilder/osbuilder/../tests/cmd/kata-manager/kata-manager.sh configure-image
    file not found: /home/runner/work/osbuilder/osbuilder/../tests/cmd/kata-manager/kata-manager.sh at /usr/bin/chronic line 66.

Fixes: #3170

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>